### PR TITLE
IW: Fix the protocol for the tangram sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,11 +60,15 @@ body {
 
 var tile_source = 'mapzen'; // default source, can be overriden by URL
 
+function appendProtocol(url) {
+   return window.location.protocol + url;
+}
+
 var tile_sources = {
     'mapzen': {
         source: {
             type: 'GeoJSONTileSource',
-            url: 'http://vector.mapzen.com/osm/all/{z}/{x}/{y}.json'
+            url:  appendProtocol('//vector.mapzen.com/osm/all/{z}/{x}/{y}.json')
         },
         layers: 'demos/gl_layers.js',
         styles: 'demos/gl_styles.yaml'
@@ -72,7 +76,7 @@ var tile_sources = {
     'mapzen-dev': {
         source: {
             type: 'GeoJSONTileSource',
-            url: 'http://vector.dev.mapzen.com/osm/all/{z}/{x}/{y}.json'
+            url: appendProtocol('//vector.dev.mapzen.com/osm/all/{z}/{x}/{y}.json')
         },
         layers: 'demos/gl_layers.js',
         styles: 'demos/gl_styles.yaml'
@@ -80,7 +84,7 @@ var tile_sources = {
     'mapzen-local': {
         source: {
             type: 'GeoJSONTileSource',
-            url: 'http://localhost:8080/all/{z}/{x}/{y}.json'
+            url: 'http//localhost:8080/all/{z}/{x}/{y}.json'
         },
         layers: 'demos/gl_layers.js',
         styles: 'demos/gl_styles.yaml'
@@ -88,7 +92,7 @@ var tile_sources = {
     'mapzen-mvt': {
         source: {
             type: 'MapboxTileSource',
-            url: 'http://vector.mapzen.com/osm/all/{z}/{x}/{y}.mapbox'
+            url: appendProtocol('//vector.mapzen.com/osm/all/{z}/{x}/{y}.mapbox')
         },
         layers: 'demos/gl_layers.js',
         styles: 'demos/gl_styles.yaml'
@@ -96,7 +100,7 @@ var tile_sources = {
     'mapzen-topojson': {
         source: {
             type: 'TopoJSONTileSource',
-            url: 'http://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson'
+            url: appendProtocol('//vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson')
         },
         layers: 'demos/gl_layers.js',
         styles: 'demos/gl_styles.yaml'


### PR DESCRIPTION
Currently we always assume a http protocol for our source urls. This
commit adds a function that detects the protocol that the page is
current using and uses that to build the urls.

I left alone the urls were it did not seem necessary to modify (ie
localhost).
