### PR TITLE
Switch the watcher to something that can work on OS X

### DIFF
--- a/watch.sh
+++ b/watch.sh
@@ -1,5 +1,1 @@
-
-while true; do
-    inotifywait -r -e modify src/ test/ && \
-	make run-tests
-done
+ls src/*.js src/gl/*.js test/*.js | entr -r make run-tests


### PR DESCRIPTION
To install entr on OS X, type

   brew install entr