### PR TITLE
De-couples tile loading from Leaflet

### DIFF
--- a/demos/styles.yaml
+++ b/demos/styles.yaml
@@ -299,7 +299,7 @@ layers:
                 width: |
                     function () {
                         return (
-                            zoom >= 16 &&
+                            zoom >= 15 &&
                             (feature.kind != 'ocean' && feature.kind != 'riverbank') &&
                             (2.5 * Math.log(zoom))
                         );
@@ -309,31 +309,6 @@ layers:
         geometry:
             source: osm
             filter: roads
-            # filter: |
-            #     function (json) {
-            #         return {
-            #             type: 'FeatureCollection',
-            #             features: (((json['road']||{}).features)||[]).concat(((json['bridge']||{}).features)||[]).filter(function (feature) {
-            #                 if (['motorway', 'motorway_link'].indexOf(feature.properties.class) > 0) {
-            #                     feature.properties.kind = 'highway';
-            #                     feature.properties.sort_key = 10000;
-            #                 }
-            #                 else if (feature.properties.class == 'main') {
-            #                     feature.properties.kind = 'major_road';
-            #                     feature.properties.sort_key = 1000;
-            #                 }
-            #                 else if (['street', 'street_limited'].indexOf(feature.properties.class) > 0) {
-            #                     feature.properties.kind = 'minor_road';
-            #                     feature.properties.sort_key = 100;
-            #                 }
-            #                 else {
-            #                     feature.properties.kind = feature.properties.type;
-            #                     feature.properties.sort_key = 10;
-            #                 }
-            #                 return feature;
-            #             })
-            #         };
-            #     }
 
         style:
             order: function () { return 3.5 + Math.min(Math.max(feature.sort_key * .000025, -1), 1) / 2; }
@@ -357,17 +332,20 @@ layers:
                 width: function () { return 3 * Math.log(zoom); }
                 # width: [[13, 3px], [15, 5px], [16, 20px]]
                 # width: [[10, 2px], [13, 3px], [15, 5px], [16, 8px], [18, 12px]]
-                outline:
-                    color: [0.7, 0.7, 0.7]
-                    width: function () { return (zoom >= 18 && (3/8 * Math.log(zoom))); }
-
-            bridge:
-                filter: { is_bridge: yes }
+            outline:
+                filter: { scene.zoom: { min: 15 } }
                 style:
                     outline:
-                        # don't draw outline caps on bridges because they draw over connecting non-bridge roads
-                        # see FDR Drive: 40.70278074491014,-74.00795169174671,20
-                        cap: butt
+                        color: [0.7, 0.7, 0.7]
+                        width: function () { return (zoom >= 18 && (3/8 * Math.log(zoom))); }
+
+                bridge:
+                    filter: { is_bridge: yes }
+                    style:
+                        outline:
+                            # don't draw outline caps on bridges because they draw over connecting non-bridge roads
+                            # see FDR Drive: 40.70278074491014,-74.00795169174671,20
+                            cap: butt
 
             tunnel:
                 # filter: function() { return feature.is_link == 'yes' || feature.is_tunnel == 'yes'; }
@@ -376,33 +354,41 @@ layers:
                     color: '#333'
                     width: function () { return 2 * Math.log(zoom); }
                     # width: [[13, 0px], [15, 4px], [16, 6px], [18, 10px]]
-                    outline:
-                        color: white
-                        # width: [[15, 2px], [18, 6px]]
-                        # width: 2px
-                        width: function () { return 1 * Math.log(zoom); }
+                outline:
+                    filter: { scene.zoom: { min: 15 } }
+                    style:
+                        outline:
+                            color: white
+                            # width: [[15, 2px], [18, 6px]]
+                            # width: 2px
+                            width: function () { return 1 * Math.log(zoom); }
 
         major_road:
             filter: { kind: major_road }
             style:
                 color: [0.5, 0.5, 0.5]
                 width: function () { return 2.5 * Math.log(zoom); }
-                outline:
-                    color: [0.7, 0.7, 0.7]
-                    width: function () { return (zoom >= 18 && (3/8 * Math.log(zoom))); }
+            outline:
+                filter: { scene.zoom: { min: 15 } }
+                style:
+                    outline:
+                        color: [0.7, 0.7, 0.7]
+                        width: function () { return (zoom >= 18 && (3/8 * Math.log(zoom))); }
 
         minor_road:
-            filter: { kind: minor_road }
+            filter: { kind: minor_road, scene.zoom: { min: 13 } }
             style:
                 color: [0.65, 0.65, 0.65]
                 width: function () { return 2 * Math.log(zoom); }
-                outline:
-                    color: [0.7, 0.7, 0.7]
-                    width: function () { return (zoom >= 18 && (2.5/8 * Math.log(zoom))); }
+            outline:
+                filter: { scene.zoom: { min: 15 } }
+                style:
+                    outline:
+                        color: [0.7, 0.7, 0.7]
+                        width: function () { return (zoom >= 18 && (2.5/8 * Math.log(zoom))); }
 
         path:
-            filter:
-               kind: path
+            filter: { kind: path, scene.zoom: { min: 15 } }
             style:
                 color: [0.8, 0.8, 0.8]
                 # color: yellow
@@ -416,9 +402,12 @@ layers:
             style:
                 color: [0.5, 0.0, 0.0]
                 width: function () { return 2 * Math.log(zoom); }
-                outline:
-                    color: [0.7, 0.7, 0.7]
-                    width: function () { return (zoom >= 18 && (2/8 * Math.log(zoom))); }
+            outline:
+                filter: { scene.zoom: { min: 15 } }
+                style:
+                    outline:
+                        color: [0.7, 0.7, 0.7]
+                        width: function () { return (zoom >= 18 && (2/8 * Math.log(zoom))); }
 
     buildings:
         geometry:
@@ -484,7 +473,7 @@ layers:
         filter: { name: true }
         style:
             name: points
-            size: 10px
+            size: [[12, 6px], [13, 10px]]
 
             # name: icons
             # sprite: tree

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ dist/tangram.min.js: dist/tangram.debug.js
 src/gl/shader_sources.js: $(shell find src/ -name '*.glsl')
 	bash ./build_shaders.sh > src/gl/shader_sources.js
 
-build-testable: lint dist/tangram.debug.js
+build-testable: dist/tangram.debug.js
 	node build.js --debug=true --all './test/*.js' > dist/tangram.test.js
 
 test: build-testable

--- a/src/camera.js
+++ b/src/camera.js
@@ -248,9 +248,9 @@ class IsometricCamera extends Camera {
         // convert meters to viewport
         mat4.scale(this.projectionMatrix, this.projectionMatrix,
             vec3.fromValues(
-                1 / this.scene.meter_zoom.x,
-                1 / this.scene.meter_zoom.y,
-                1 / this.scene.meter_zoom.y
+                2 / this.scene.viewport_meters.x,
+                2 / this.scene.viewport_meters.y,
+                2 / this.scene.viewport_meters.y
             )
         );
     }

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -17,8 +17,7 @@ if (Utils.isMainThread) {
 
         initialize: function (options) {
             // Defaults
-            options.unloadInvisibleTiles = options.unloadInvisibleTiles || false;
-            options.updateWhenIdle = options.updateWhenIdle || false;
+            options.showDebug = (!options.showDebug ? false : true);
 
             L.setOptions(this, options);
             this.createScene();
@@ -51,18 +50,6 @@ if (Utils.isMainThread) {
             }
 
             L.GridLayer.prototype.onAdd.apply(this, arguments);
-
-            this.hooks.tileunload = (event) => {
-                // TODO: not expecting leaflet to fire this event for tiles that simply pan
-                // out of bounds when 'unloadInvisibleTiles' option is set, but it's firing
-                // since upgrading to latest master branch - force-checking for now
-                if (this.options.unloadInvisibleTiles) {
-                    var tile = event.tile;
-                    var key = tile.getAttribute('data-tile-key');
-                    this.scene.removeTile(key);
-                }
-            };
-            this.on('tileunload', this.hooks.tileunload);
 
             this.hooks.resize = () => {
                 this._updating_tangram = true;
@@ -140,7 +127,6 @@ if (Utils.isMainThread) {
         onRemove: function () {
             L.GridLayer.prototype.onRemove.apply(this, arguments);
 
-            this.off('tileunload', this.hooks.tileunload);
             this._map.off('resize', this.hooks.resize);
             this._map.off('move', this.hooks.move);
             this._map.off('zoomstart', this.hooks.zoomstart);
@@ -155,8 +141,29 @@ if (Utils.isMainThread) {
         },
 
         createTile: function (coords) {
+            var key = coords.x + '/' + coords.y + '/' + coords.z;
             var div = document.createElement('div');
-            this.scene.loadTile(coords, { debugElement: div });
+            div.setAttribute('data-tile-key', key);
+            div.style.width = '256px';
+            div.style.height = '256px';
+
+            if (this.options.showDebug) {
+                var debug_overlay = document.createElement('div');
+                debug_overlay.textContent = key;
+                debug_overlay.style.position = 'absolute';
+                debug_overlay.style.left = 0;
+                debug_overlay.style.top = 0;
+                debug_overlay.style.color = 'white';
+                debug_overlay.style.fontSize = '16px';
+                debug_overlay.style.textOutline = '1px #000000';
+                debug_overlay.style.padding = '8px';
+
+                div.appendChild(debug_overlay);
+                div.style.borderStyle = 'solid';
+                div.style.borderColor = 'white';
+                div.style.borderWidth = '1px';
+            }
+
             return div;
         },
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -721,7 +721,7 @@ Scene.prototype.findMaxZoom = function () {
 };
 
 // Load a single tile
-Scene.prototype._loadTile = function (coords, options = {}) {
+Scene.prototype._loadTile = function (coords) {
     // Skip if not at current scene zoom
     if (coords.z !== this.baseZoom(this.zoom)) {
         return;

--- a/src/scene.js
+++ b/src/scene.js
@@ -352,7 +352,7 @@ Scene.prototype.updateBounds = function () {
         }
     };
 
-    // Mark tiles as visible/invisible
+    // Mark tiles as visible
     for (var tile of Utils.values(this.tiles)) {
         tile.update(this);
     }
@@ -765,13 +765,13 @@ Scene.prototype.rebuildGeometry = function () {
         this.syncConfigToWorker();
 
         // Rebuild visible tiles first, from center out
-        var tile, visible = [], invisible = [];
+        let tile, visible = [];
         for (tile of Utils.values(this.tiles)) {
             if (tile.visible === true) {
                 visible.push(tile);
             }
             else {
-                invisible.push(tile);
+                this.removeTile(tile.key);
             }
         }
 
@@ -779,20 +779,7 @@ Scene.prototype.rebuildGeometry = function () {
             return (b.center_dist > a.center_dist ? -1 : (b.center_dist === a.center_dist ? 0 : 1));
         });
 
-        for (tile of visible) {
-            tile.build(this);
-        }
-
-        for (tile of invisible) {
-            // Keep tiles in current zoom but out of visible range, but rebuild as lower priority
-            if (tile.isInZoom(this)) {
-                tile.build(this);
-            }
-            // Drop tiles outside current zoom
-            else {
-                this.removeTile(tile.key);
-            }
-        }
+        visible.forEach(tile => tile.build(this));
 
         this.updateActiveStyles();
         this.resetTime();

--- a/src/scene.js
+++ b/src/scene.js
@@ -102,16 +102,7 @@ Scene.prototype.init = function () {
         this.loadScene().then(() => {
 
             this.createWorkers().then(() => {
-                this.container = this.container || document.body;
-                this.canvas = document.createElement('canvas');
-                this.canvas.style.position = 'absolute';
-                this.canvas.style.top = 0;
-                this.canvas.style.left = 0;
-                this.canvas.style.zIndex = -1;
-                this.container.appendChild(this.canvas);
-
-                this.gl = Context.getContext(this.canvas, { alpha: false /*premultipliedAlpha: false*/ });
-                this.resizeMap(this.container.clientWidth, this.container.clientHeight);
+                this.createCanvas();
                 this.selection = new FeatureSelection(this.gl, this.workers);
 
                 // Loads rendering styles from config, sets GL context and compiles programs
@@ -162,10 +153,22 @@ Scene.prototype.destroy = function () {
     this.tiles = {}; // TODO: probably destroy each tile separately too
 };
 
+Scene.prototype.createCanvas = function () {
+    this.container = this.container || document.body;
+    this.canvas = document.createElement('canvas');
+    this.canvas.style.position = 'absolute';
+    this.canvas.style.top = 0;
+    this.canvas.style.left = 0;
+    this.canvas.style.zIndex = -1;
+    this.container.appendChild(this.canvas);
+
+    this.gl = Context.getContext(this.canvas, { alpha: false /*premultipliedAlpha: false*/ });
+    this.resizeMap(this.container.clientWidth, this.container.clientHeight);
+};
+
 Scene.prototype.createObjectURL = function () {
     return (window.URL && window.URL.createObjectURL) || (window.webkitURL && window.webkitURL.createObjectURL);
 };
-
 
 Scene.loadWorkerUrl = function (scene) {
     var worker_url = scene.worker_url || Utils.findCurrentURL('tangram.debug.js', 'tangram.min.js'),

--- a/src/scene.js
+++ b/src/scene.js
@@ -268,14 +268,19 @@ Scene.prototype.startZoom = function () {
     this.zooming = true;
 };
 
+// Choose the base zoom level to use for a given fractional zoom
+Scene.prototype.baseZoom = function (zoom) {
+    return Math.round(zoom);
+};
+
 Scene.prototype.preserve_tiles_within_zoom = 2;
 Scene.prototype.setZoom = function (zoom) {
     this.zooming = false;
 
     // Schedule tiles for removal on integer zoom level change
-    if (Math.round(zoom) !== Math.round(this.last_zoom)) {
-        var below = Math.round(zoom);
-        var above = Math.round(zoom);
+    if (this.baseZoom(zoom) !== this.baseZoom(this.last_zoom)) {
+        var below = this.baseZoom(zoom);
+        var above = this.baseZoom(zoom);
 
         log.trace(`scene.last_zoom: ${this.last_zoom}`);
         if (Math.abs(zoom - this.last_zoom) <= this.preserve_tiles_within_zoom) {
@@ -357,8 +362,8 @@ Scene.prototype.updateBounds = function () {
 };
 
 Scene.prototype.removeTilesOutsideZoomRange = function (below, above) {
-    below = Math.min(Math.round(below), this.findMaxZoom() || below);
-    above = Math.min(Math.round(above), this.findMaxZoom() || above);
+    below = Math.min(below, this.findMaxZoom() || below);
+    above = Math.min(above, this.findMaxZoom() || above);
 
     var remove_tiles = [];
     for (var t in this.tiles) {

--- a/src/tile.js
+++ b/src/tile.js
@@ -283,7 +283,7 @@ export default class Tile {
     }
 
     update(scene) {
-        this.visible =  (this.coords.z === Math.round(scene.zoom)) ||
+        this.visible =  (this.coords.z === scene.baseZoom(scene.zoom)) ||
                         (this.coords.z === this.max_zoom && scene.zoom >= this.max_zoom);
 
         this.center_dist = Math.abs(scene.center_meters.x - this.min.x) + Math.abs(scene.center_meters.y - this.min.y);
@@ -295,8 +295,8 @@ export default class Tile {
 
         if (z > this.max_zoom) {
             zgap = z - this.max_zoom;
-            x = ~~(x / Math.pow(2, zgap));
-            y = ~~(y / Math.pow(2, zgap));
+            x = Math.floor(x / Math.pow(2, zgap));
+            y = Math.floor(y / Math.pow(2, zgap));
             z -= zgap;
         }
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -29,7 +29,9 @@ export default class Tile {
             order: {
                 min: Infinity,
                 max: -Infinity
-            }
+            },
+            visible: false,
+            center_dist: 0
         });
 
         this.worker = worker;
@@ -37,7 +39,7 @@ export default class Tile {
 
         this.coords = coords;
         this.coords = this.calculateOverZoom();
-        this.key = [this.coords.x, this.coords.y, this.coords.z].join('/');
+        this.key = Tile.key(this.coords);
         this.min = Geo.metersForTile(this.coords);
         this.max = Geo.metersForTile({x: this.coords.x + 1, y: this.coords.y + 1, z: this.coords.z }),
         this.span = { x: (this.max.x - this.min.x), y: (this.max.y - this.min.y) };
@@ -46,7 +48,22 @@ export default class Tile {
         this.meshes = {}; // renderable VBO meshes keyed by style
     }
 
-    static create(spec) { return new Tile(spec); }
+    static create(spec) {
+        return new Tile(spec);
+    }
+
+    static key({x, y, z}) {
+        return [x, y, z].join('/');
+    }
+
+    // Sort a set of tile instances (which already have a distance from center tile computed)
+    static sort(tiles) {
+        return tiles.sort((a, b) => {
+            let ad = a.center_dist;
+            let bd = b.center_dist;
+            return (bd > ad ? -1 : (bd === ad ? 0 : 1));
+        });
+    }
 
     freeResources() {
         if (this != null && this.meshes != null) {
@@ -252,41 +269,16 @@ export default class Tile {
         this.workerMessage('removeTile', this.key);
     }
 
-    showDebug(div) {
-        var debug_overlay = document.createElement('div');
-        debug_overlay.textContent = this.key;
-        debug_overlay.style.position = 'absolute';
-        debug_overlay.style.left = 0;
-        debug_overlay.style.top = 0;
-        debug_overlay.style.color = 'white';
-        debug_overlay.style.fontSize = '16px';
-        debug_overlay.style.textOutline = '1px #000000';
-        div.appendChild(debug_overlay);
-        div.style.borderStyle = 'solid';
-        div.style.borderColor = 'white';
-        div.style.borderWidth = '1px';
-        return debug_overlay;
-    }
-
     printDebug () {
         log.debug(`Tile: debug for ${this.key}: [  ${JSON.stringify(this.debug)} ]`);
     }
 
-    updateDebugElement(div, show) {
-        div.setAttribute('data-tile-key', this.key);
-        div.style.width = '256px';
-        div.style.height = '256px';
-
-        if (show) {
-            this.showDebug(div);
-        }
-    }
-
     update(scene) {
-        this.visible =  (this.coords.z === scene.baseZoom(scene.zoom)) ||
-                        (this.coords.z === this.max_zoom && scene.zoom >= this.max_zoom);
+        this.visible = (this.coords.z === scene.baseZoom(scene.zoom)) ||
+                       (this.coords.z === this.max_zoom && scene.zoom >= this.max_zoom);
 
-        this.center_dist = Math.abs(scene.center_meters.x - this.min.x) + Math.abs(scene.center_meters.y - this.min.y);
+        // TODO: handle tiles of mismatching zoom levels
+        this.center_dist = Math.abs(scene.center_tile.x - this.coords.x) + Math.abs(scene.center_tile.y - this.coords.y);
     }
 
     calculateOverZoom() {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -27,12 +27,16 @@ sinon.stub(Scene, 'loadWorkerUrl').returns(Promise.resolve(
     URL.createObjectURL(new Blob([workerBody], { type: 'application/javascript' }))
 ));
 
+let container = document.createElement('div');
+container.style.width = 250;
+container.style.height = 250;
+
 window.makeScene = function (options) {
     options = options || {};
 
-    options.disableRenderLoop = true;
-    options.workerUrl = '/dist/tangram.debug.js';
-    options.worker_timeout = 1000;
+    options.disableRenderLoop = options.disableRenderLoop || true;
+    options.workerUrl = options.workerUrl || '/dist/tangram.debug.js';
+    options.container = options.container || container;
 
     return new Scene(
         sampleScene.config,

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -11,12 +11,15 @@ let map = L.map(
 map.setView([0, 0], 0); // required to put leaflet in a "ready" state, or it will never call the layer's onAdd() method
 
 let makeOne = () => {
-    return new LeafletLayer({
+    let layer = new LeafletLayer({
         source: sampleScene.tile_source,
         scene: sampleScene.config,
         disableRenderLoop: true,
         workerUrl: 'http://localhost:9876/tangram.debug.js'
     });
+
+    sinon.stub(layer.scene, 'findVisibleTiles').returns([]);
+    return layer;
 };
 
 describe('Leaflet plugin', () => {

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -134,27 +134,4 @@ describe('Leaflet plugin', () => {
         });
     });
 
-    describe('.createTile(coords, done)', () => {
-        let subject;
-        let coords = { x: 9647, y: 12320, z: 15 };
-
-        beforeEach(() => {
-            subject = makeOne();
-            sinon.spy(subject.scene, 'loadTile');
-            subject.createTile(coords);
-        });
-
-        afterEach(() => {
-            subject.remove();
-        });
-
-        it('calls the .scene.loadTile() method', () => {
-            assert.isTrue(subject.scene.loadTile.called);
-        });
-
-    });
-
-    describe('.updateBounds()', () => {});
-    describe('.render()', () => {});
-
 });

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -12,122 +12,20 @@ let midtownTileKey = `${midtownTile.x}/${midtownTile.y}/${midtownTile.z}`;
 
 describe('Scene', function () {
 
+    let subject;
+
+    beforeEach(() => {
+        subject = makeScene({});
+        sinon.stub(subject, 'findVisibleTiles').returns([]);
+        subject.setView(nycLatLng);
+    });
+
+    afterEach(() => {
+        subject.destroy();
+        subject = null;
+    });
+
     describe('.constructor()', () => {
-
-        it.skip('returns a new instance', () => {
-            let scene = new Scene({});
-            assert.instanceOf(scene, Scene);
-            scene.destroy();
-        });
-
-        describe('when given sensible defaults', () => {
-            let scene;
-            afterEach(() => {
-                scene.destroy();
-            });
-
-            it('returns a instance', () => {
-                scene = makeScene({});
-                assert.instanceOf(scene, Scene);
-            });
-        });
-    });
-
-
-
-    describe('.loadQueuedTiles()', () => {
-        let subject;
-
-        beforeEach((done) => {
-            let coords = midtownTile;
-
-            subject = makeScene({});
-
-            sinon.spy(subject, '_loadTile');
-
-            subject.setView(nycLatLng);
-            subject.init().then(() => {
-                subject.loadTile(coords);
-                subject.loadQueuedTiles();
-                done();
-            });
-        });
-
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
-        });
-
-        it('calls _loadTile with the queued tile', () => {
-            sinon.assert.calledWith(subject._loadTile, midtownTile);
-        });
-    });
-
-
-
-    describe('._loadTile(coords, options)', () => {
-        let subject,
-            coord = midtownTile,
-            div = document.createElement('div');
-
-        beforeEach((done) => {
-            subject = makeScene({});
-            subject.setView(nycLatLng);
-            subject.init().then(done);
-        });
-
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
-        });
-
-        describe('when the scene has not loaded the tile', () => {
-
-            it('loads the tile', () => {
-                let tile = subject._loadTile(coord, { debugElement: div });
-                assert.instanceOf(tile, Tile);
-            });
-
-            it('caches the result in the scene object', () => {
-                let tile = subject._loadTile(coord, { debugElement: div });
-                let tiles = subject.tiles;
-                assert.instanceOf(tiles[tile.key], Tile);
-            });
-        });
-
-        describe('when the scene already have the tile', () => {
-            let key = midtownTileKey;
-            let tile;
-
-            beforeEach(() => {
-                subject.tiles[key] = {};
-                sinon.spy(subject, 'cacheTile');
-                tile = subject._loadTile(coord, { debugElement: div });
-            });
-
-            afterEach(() => {
-                subject.cacheTile.restore();
-                subject.tiles[key] = undefined;
-            });
-
-            it('updates the div', () => {
-                assert.equal(div.getAttribute('data-tile-key'), key);
-            });
-        });
-
-    });
-
-    describe('.create(options)', () => {
-        let subject;
-
-        beforeEach(() => {
-            subject = makeScene({});
-        });
-
-        afterEach( () => {
-            subject.destroy();
-            subject = null;
-        });
 
         it('returns a new instance', () => {
             assert.instanceOf(subject, Scene);
@@ -144,19 +42,95 @@ describe('Scene', function () {
 
     });
 
-    describe('.init()', () => {
+    describe('.loadTile(coords)', () => {
 
-        describe('when the scene is not initialized', () => {
-            let subject;
+        let coords = midtownTile;
+
+        beforeEach(() => {
+            sinon.spy(subject, '_loadTile');
+
+            return subject.init().then(() => {
+                subject.loadTile(coords);
+                subject.loadQueuedTiles();
+            });
+        });
+
+        it('calls _loadTile with the queued tile', () => {
+            sinon.assert.calledWith(subject._loadTile, coords);
+        });
+    });
+
+    // describe('.loadTile(tile)', () => {
+    //     let subject;
+    //     let tile = { coords: null };
+
+    //     beforeEach(() => {
+    //         subject.loadTile(tile);
+    //     });
+
+    //     it('appends the queued_tiles array', () => {
+    //         assert.include(subject.queued_tiles[0], tile);
+    //     });
+
+    // });
+
+    describe('._loadTile(coords, options)', () => {
+
+        let coords = midtownTile;
+
+        beforeEach(() => {
+            return subject.init();
+        });
+
+        describe('when the scene has not loaded the tile', () => {
+
+            it('loads the tile', () => {
+                let tile = subject._loadTile(coords);
+                assert.instanceOf(tile, Tile);
+            });
+
+            it('caches the result in the scene object', () => {
+                let tile = subject._loadTile(coords);
+                let tiles = subject.tiles;
+                assert.instanceOf(tiles[tile.key], Tile);
+            });
+        });
+
+        describe('when the scene already has the tile', () => {
+            let key = midtownTileKey;
+            let tile;
 
             beforeEach(() => {
-                subject = makeScene({});
-                return subject.init();
+                subject._loadTile(coords);
+                sinon.spy(subject, 'cacheTile');
+                tile = subject._loadTile(coords);
+                sinon.spy(tile, 'load');
             });
 
             afterEach(() => {
-                subject.destroy();
-                subject = null;
+                subject.cacheTile.restore();
+                tile.load.restore();
+                subject.tiles[key] = undefined;
+            });
+
+            it('does not load the tile', () => {
+                assert.isFalse(tile.load.called);
+            });
+
+            it('does not cache the tile', () => {
+                assert.isFalse(subject.cacheTile.called);
+            });
+
+        });
+
+    });
+
+    describe('.init()', () => {
+
+        describe('when the scene is not initialized', () => {
+
+            beforeEach(() => {
+                return subject.init();
             });
 
             it('correctly sets the value of the tile source', () => {
@@ -170,7 +144,7 @@ describe('Scene', function () {
             });
 
             it('sets the container property', () => {
-                assert.instanceOf(subject.container, HTMLBodyElement);
+                assert.instanceOf(subject.container, HTMLDivElement);
             });
 
             it('sets the canvas property', () => {
@@ -188,19 +162,10 @@ describe('Scene', function () {
         });
 
         describe('when the scene is already initialized', () => {
-            let subject;
-            beforeEach(() => {
-                subject = makeScene({});
-            });
 
-            afterEach(() => {
-                subject.destroy();
-                subject = null;
-            });
-
-            it('handles second init() call', (done) => {
-                subject.init().then(() => {
-                    subject.init().then(done);
+            it('handles second init() call', () => {
+                return subject.init().then(() => {
+                    return subject.init();
                 });
             });
 
@@ -208,27 +173,19 @@ describe('Scene', function () {
     });
 
     describe('.resizeMap()', () => {
-        let subject;
         let height = 100;
         let width = 200;
         let devicePixelRatio = 2;
         let computedHeight = Math.round(height * devicePixelRatio);
         let computedWidth  = Math.round(width * devicePixelRatio);
 
-        beforeEach((done) => {
-            subject = makeScene({});
+        beforeEach(() => {
             subject.device_pixel_ratio = devicePixelRatio;
-            subject.init().then(() => {
+            return subject.init().then(() => {
                 sinon.spy(subject.gl, 'bindFramebuffer');
                 sinon.spy(subject.gl, 'viewport');
                 subject.resizeMap(width, height);
-                done();
             });
-        });
-
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
         });
 
         it('marks the scene as dirty', () => {
@@ -274,21 +231,18 @@ describe('Scene', function () {
     });
 
     describe('.setView(lng, lat)', () => {
-        let subject;
-        let {lng, lat} = nycLatLng;
+        let {lng, lat, zoom} = nycLatLng;
 
         beforeEach(() => {
-            subject = makeScene({});
             subject.setView(nycLatLng);
         });
 
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
+        it('sets the scene center and zoom', () => {
+            assert.deepEqual(subject.center, {lng, lat});
         });
 
-        it('sets the center scene?', () => {
-            assert.deepEqual(subject.center, {lng, lat});
+        it('sets the scene zoom', () => {
+            assert.equal(subject.zoom, zoom);
         });
 
         it('marks the scene as dirty', () => {
@@ -297,16 +251,9 @@ describe('Scene', function () {
     });
 
     describe('.startZoom()', () => {
-        let subject;
 
         beforeEach(() => {
-            subject = makeScene({});
             subject.startZoom();
-        });
-
-        afterEach(() => {
-            subject.destroy();
-            subject = undefined;
         });
 
         it('sets the last zoom property with the value of the current zoom', () => {
@@ -316,21 +263,17 @@ describe('Scene', function () {
         it('marks the scene as zooming', () => {
             assert.isTrue(subject.zooming);
         });
+
     });
 
     // TODO this method does a lot of stuff
     describe('.setZoom(zoom)', () => {
-        let subject;
+
         beforeEach(() => {
-            subject = makeScene({});
             sinon.spy(subject, 'removeTilesOutsideZoomRange');
             subject.setZoom(10);
         });
 
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
-        });
         it('calls the removeTilesOutsideZoomRange method', () =>  {
             assert.isTrue(subject.removeTilesOutsideZoomRange.called);
         });
@@ -338,42 +281,17 @@ describe('Scene', function () {
         it('marks the scene as dirty', () => {
             assert.isTrue(subject.dirty);
         });
-    });
-
-    describe('.loadTile(tile)', () => {
-        let subject;
-        let tile = { coords: null };
-
-        beforeEach(() => {
-            subject = makeScene({});
-            subject.loadTile(tile);
-        });
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
-        });
-
-        it('appends the queued_tiles array', () => {
-            assert.include(subject.queued_tiles[0], tile);
-        });
 
     });
 
     describe('.update()', () => {
-        let subject;
 
-        beforeEach((done) => {
-            subject = makeScene({});
+        beforeEach(() => {
             sinon.spy(subject, 'loadQueuedTiles');
             sinon.spy(subject, 'render');
 
             subject.setView(nycLatLng);
-            subject.init().then(done);
-        });
-
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
+            return subject.init();
         });
 
         it('calls the loadQueuedTiles method', () => {
@@ -416,16 +334,9 @@ describe('Scene', function () {
     });
 
     describe('.updateStyles()', () => {
-        let subject;
 
-        beforeEach((done) => {
-            subject = makeScene({});
-            return subject.init().then(done);
-        });
-
-        afterEach(() => {
-            subject.destroy();
-            subject = undefined;
+        beforeEach(() => {
+            return subject.init();
         });
 
         it('adds a new mode', () => {
@@ -457,100 +368,100 @@ describe('Scene', function () {
         });
     });
 
-    describe.skip('.rebuildGeometry()', () => {
-        let subject;
-        let div = document.createElement('div');
+    // describe.skip('.rebuildGeometry()', () => {
+    //     let subject;
+    //     let div = document.createElement('div');
 
-        beforeEach((done) => {
-            subject = makeScene({});
-            subject.setView(nycLatLng);
-            subject.init().then(() => {
-                subject.loadTile(midtownTile, div);
-                subject.loadQueuedTiles();
+    //     beforeEach((done) => {
+    //         subject = makeScene({});
+    //         subject.setView(nycLatLng);
+    //         subject.init().then(() => {
+    //             subject.loadTile(midtownTile, div);
+    //             subject.loadQueuedTiles();
 
-                var tile = subject.tiles['38603/49255/17'];
-                var check = setInterval(() => {
-                    if (tile.loaded) {
-                        clearInterval(check);
-                        done();
-                    }
-                }, 50);
-            });
-        });
+    //             var tile = subject.tiles['38603/49255/17'];
+    //             var check = setInterval(() => {
+    //                 if (tile.loaded) {
+    //                     clearInterval(check);
+    //                     done();
+    //                 }
+    //             }, 50);
+    //         });
+    //     });
 
-        afterEach(() => {
-            subject.destroy();
-            subject = undefined;
-        });
+    //     afterEach(() => {
+    //         subject.destroy();
+    //         subject = undefined;
+    //     });
 
-        it('calls back', (done) => {
-            subject.rebuildGeometry().then(done);
-        });
+    //     it('calls back', (done) => {
+    //         subject.rebuildGeometry().then(done);
+    //     });
 
-        it('queues the second call & then runs it when the first call is complete', (done) => {
-            subject.rebuildGeometry();
-            subject.rebuildGeometry().then(done);
-        });
+    //     it('queues the second call & then runs it when the first call is complete', (done) => {
+    //         subject.rebuildGeometry();
+    //         subject.rebuildGeometry().then(done);
+    //     });
 
-        it('runs first call, queues second call, then rejects second call when third call is made', (done) => {
-            let rejectedSecond;
-            subject.rebuildGeometry();
-            subject.rebuildGeometry().catch((error) => {
-                rejectedSecond = (error.message === 'Scene.rebuildGeometry: request superceded by a newer call');
-            });
-            subject.rebuildGeometry().then(() => {
-                assert.isTrue(rejectedSecond);
-                done();
-            });
-        });
-    });
+    //     it('runs first call, queues second call, then rejects second call when third call is made', (done) => {
+    //         let rejectedSecond;
+    //         subject.rebuildGeometry();
+    //         subject.rebuildGeometry().catch((error) => {
+    //             rejectedSecond = (error.message === 'Scene.rebuildGeometry: request superceded by a newer call');
+    //         });
+    //         subject.rebuildGeometry().then(() => {
+    //             assert.isTrue(rejectedSecond);
+    //             done();
+    //         });
+    //     });
+    // });
 
-    describe.skip('.createWorkers()', () => {
-        let subject;
-        beforeEach(() => {
-            subject = makeScene({num_workers: 2});
-            sinon.spy(subject, 'makeWorkers');
-        });
+    // describe.skip('.createWorkers()', () => {
+    //     let subject;
+    //     beforeEach(() => {
+    //         subject = makeScene({num_workers: 2});
+    //         sinon.spy(subject, 'makeWorkers');
+    //     });
 
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
-        });
+    //     afterEach(() => {
+    //         subject.destroy();
+    //         subject = null;
+    //     });
 
-        it('calls the makeWorkers method', (done) => {
-            subject.createWorkers().then(() => {
-                sinon.assert.called(subject.makeWorkers);
-                done();
-            });
-        });
+    //     it('calls the makeWorkers method', (done) => {
+    //         subject.createWorkers().then(() => {
+    //             sinon.assert.called(subject.makeWorkers);
+    //             done();
+    //         });
+    //     });
 
-    });
+    // });
 
-    describe.skip('.makeWorkers(url)', () => {
-        let subject,
-            numWorkers = 2,
-            url = '/tangram-worker.debug.js';
+    // describe.skip('.makeWorkers(url)', () => {
+    //     let subject,
+    //         numWorkers = 2,
+    //         url = '/tangram-worker.debug.js';
 
-        beforeEach(() => {
-            subject = makeScene({numWorkers});
-            subject.makeWorkers(url);
-        });
+    //     beforeEach(() => {
+    //         subject = makeScene({numWorkers});
+    //         subject.makeWorkers(url);
+    //     });
 
-        afterEach(() => {
-            subject.destroy();
-            subject = null;
-        });
+    //     afterEach(() => {
+    //         subject.destroy();
+    //         subject = null;
+    //     });
 
-        describe('when given a url', () => {
+    //     describe('when given a url', () => {
 
-            it('creates the correct number of workers', () => {
-                assert.equal(subject.workers.length, 2);
-            });
+    //         it('creates the correct number of workers', () => {
+    //             assert.equal(subject.workers.length, 2);
+    //         });
 
-            it('creates the correct type of workers', () => {
-                assert.instanceOf(subject.workers[0], Worker);
-            });
-        });
-    });
+    //         it('creates the correct type of workers', () => {
+    //             assert.instanceOf(subject.workers[0], Worker);
+    //         });
+    //     });
+    // });
 
 });

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -59,7 +59,7 @@ describe('Scene', function () {
         });
 
         it('calls _loadTile with the queued tile', () => {
-            sinon.assert.calledOnce(subject._loadTile);
+            sinon.assert.calledWith(subject._loadTile, midtownTile);
         });
     });
 

--- a/test/tile_spec.js
+++ b/test/tile_spec.js
@@ -5,16 +5,17 @@ import samples from './fixtures/samples';
 
 let nycLatLng = { lng: -73.97229909896852, lat: 40.76456761707639, zoom: 17 };
 
-describe('Tile', () => {
+describe('Tile', function() {
+
     let subject,
         scene;
 
-    beforeEach((done) => {
+    beforeEach(() => {
         scene = makeScene({});
+        sinon.stub(scene, 'findVisibleTiles').returns([]);
         scene.setView(nycLatLng);
-        scene.init().then(() => {
+        return scene.init().then(() => {
             subject = Tile.create({coords: { x: 38605, y: 49254, z: 17 }, worker: scene.nextWorker()});
-            done();
         });
     });
 


### PR DESCRIPTION
Let Tangram calculate which tiles to load internally, to reduce coupling to Leaflet. 

This was motivated (at the current moment) by a desire to try different fractional zoom logic than what Leaflet does (which is to round to the nearest zoom level). Rounding is a good default, but other alternatives (like taking the zoom floor) should also be explored. 

De-coupling also makes future view features (rotation, tilt, etc.) possible (or at least easier to implement).