### PR TITLE
Move style textures to the scene level

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -490,9 +490,9 @@
                     scene.config.layers.pois.style.sprite = 'tree';
                     scene.config.layers.pois.style.size = [[13, '16px'], [14, '24px'], [15, '32px']];
 
-                    this.state.bouncy = this.uniforms().bouncy;
-                    this.folder.add(this.state, 'bouncy').onChange(function(value) {
-                        this.uniforms().bouncy = value;
+                    this.state.rotate = this.uniforms().rotate;
+                    this.folder.add(this.state, 'rotate').onChange(function(value) {
+                        this.uniforms().rotate = value;
                         scene.requestRedraw();
                     }.bind(this));
                 }

--- a/demos/styles.yaml
+++ b/demos/styles.yaml
@@ -73,6 +73,19 @@ lights:
     #     radius: 1000.0
     #     cutoff: 0.0
 
+# textures:
+#     pois:
+#         url: demos/images/poi_icons_32.png
+#         filtering: mipmap
+#         sprites:
+#             # each sprite is defined as: [x origin, y origin, width, height]
+#             plane: [0, 0, 32, 32]
+#             tree: [0, 185, 32, 32]
+#             sunburst: [0, 629, 32, 32]
+#             restaurant: [0, 777, 32, 32]
+#             cafe: [0, 814, 32, 32]
+#             museum: [0, 518, 32, 32]
+
 styles:
 
     # polygons:
@@ -186,9 +199,11 @@ styles:
                 color: color.rgb += vec3(gl_FragCoord.x / u_resolution.x, 0.0, gl_FragCoord.y / u_resolution.y);
 
     icons:
-        # extends: polygons
         extends: sprites
-        # animated: true
+        animated: true
+        # blend: multiply
+        # texture: pois
+        # texture: demos/images/sunset.jpg
         texture:
             url: demos/images/poi_icons_32.png
             filtering: mipmap
@@ -200,25 +215,24 @@ styles:
                 restaurant: [0, 777, 32, 32]
                 cafe: [0, 814, 32, 32]
                 museum: [0, 518, 32, 32]
-        # shaders:
-        #     transforms:
-        #         vertex: |
-        #             //shape.xy *= abs(sin(u_time * shape.x + shape.y) * cos(u_time + shape.y * 1.5));
-        #             shape.z *= u_time;
-        #             position.y += sin(position.y + u_time*3.) * 10.;
-        #         fragment:
-        #             // color.rgb = vec3(v_texcoord.xy, 0.);
-        # shaders:
-        #     uniforms:
-        #         bouncy: true
-        #     transforms:
-        #         vertex: |
-        #             // Bouncy icons
-        #             if (bouncy) {
-        #                 position.y += sin(v_world_position.y + u_time*3.) * 10.;
-        #             }
-        #         fragment: |
-        #             //color.rgb /= lighting; // reverse lighting hack (replace w/shader lighting block/defines)
+
+        shaders:
+            uniforms:
+                rotate: false
+            transforms:
+                position: |
+                    //shape.xy *= abs(sin(u_time * shape.x + shape.y) * cos(u_time + shape.y * 1.5));
+                    //shape.z *= u_time;
+                    //position.y += sin(position.y + u_time*3.) * 10.;
+                    if (rotate == true) {
+                        //shape.z += mod(position.y, 6.28) + u_time;
+                        shape.z += u_time;
+                    }
+                color: |
+                    //color.rgb = vec3(v_texcoord.xy, 0.);
+                    //if (color.a < .5) {
+                    //    color.rgb = vec3(1);
+                    //}
 
     # text:
     #     selection: true
@@ -585,6 +599,7 @@ layers:
         filter: { name: true, $zoom: { min: 14 } }
         style:
             name: text
+            # visible: false
             order: 5
             interactive: true
             # font:
@@ -623,19 +638,19 @@ layers:
             # name: points
             # size: [[12, 6px], [13, 10px]]
 
+            name: text
             font:
                 size: 12px
                 typeface: Helvetica
                 fill: [.9, .9, .1]
                 stroke: black
 
-            name: text
-
             # name: icons
             # sprite: tree
             # size: [32px, 32px]
             # size: [[13, 16px], [14, 24px], [15, 32px]]
             # size: function() { return (parseInt(feature.id, 16) % 100); }
+            color: white
 
             angle: 0
             # angle: function() { return (parseInt(feature.id, 16) % 360); }
@@ -680,6 +695,7 @@ layers:
 
         style:
             name: text
+            visible: false
             font:
                 size: 12px
                 typeface: Courier

--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -253,10 +253,10 @@ Texture.getSpriteTexcoords = function (texname, sprite) {
 Texture.createFromObject = function (gl, textures) {
     let loading = [];
     if (textures) {
-        for (let name in textures) {
-            let config = textures[name];
-            if (!Texture.textures[name]) {
-                let texture = new Texture(gl, name, config);
+        for (let texname in textures) {
+            let config = textures[texname];
+            if (!Texture.textures[texname]) {
+                let texture = new Texture(gl, texname, config);
                 if (config.url) {
                     loading.push(texture.load(config.url, config));
                 }

--- a/src/scene.js
+++ b/src/scene.js
@@ -1109,6 +1109,26 @@ Scene.prototype.preProcessSceneConfig = function () {
     return StyleManager.preload(this.config.styles);
 };
 
+// Load all textures in the scene definition
+Scene.prototype.loadTextures = function () {
+    this.normalizeTextures();
+    return Texture.createFromObject(this.gl, this.config.textures);
+};
+
+// Handle single or multi-texture syntax, for stylesheet convenience
+Scene.prototype.normalizeTextures = function () {
+    for (let [style_name, style] of Utils.entries(this.config.styles)) {
+        // If style has a single 'texture' object, move it to the global scene texture set
+        // and give it a default name
+        if (style.texture && typeof style.texture === 'object') {
+            let texture_name = '__' + style_name;
+            this.config.textures = this.config.textures || {};
+            this.config.textures[texture_name] = style.texture;
+            style.texture = texture_name; // point stlye to location of texture
+        }
+    }
+};
+
 // Called (currently manually) after styles are updated in stylesheet
 Scene.prototype.updateStyles = function (gl) {
     if (!this.initialized && !this.initializing) {
@@ -1214,6 +1234,7 @@ Scene.prototype.updateConfig = function () {
     this.createLights();
     this.loadDataSources();
     this.setSourceMax();
+    this.loadTextures();
 
     // TODO: detect changes to styles? already (currently) need to recompile anyway when camera or lights change
     this.updateStyles(this.gl);

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -199,15 +199,12 @@ if (Utils.isWorkerThread) {
     // Texture info needs to be synced from main thread
     SceneWorker.syncTextures = function () {
         // We're only syncing the textures that have sprites defined, since these are (currently) the only ones we
-        // need info about for geometry construction (we need width/height, which we only know after the texture loads)
-        // This is an async process, so it returns a promise
-        var textures = [];
-        for (var style of Utils.values(SceneWorker.styles)) {
-            if (style.textures) {
-                for (var t in style.textures) {
-                    if (style.textures[t].sprites) {
-                        textures.push(style.textureName(t));
-                    }
+        // need info about for geometry construction (e.g. width/height, which we only know after the texture loads)
+        let textures = [];
+        if (SceneWorker.config.textures) {
+            for (let [texname, texture] of Utils.entries(SceneWorker.config.textures)) {
+                if (texture.sprites) {
+                    textures.push(texname);
                 }
             }
         }

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -55,8 +55,6 @@ Object.assign(Polygons, {
         style.width = rule_style.width && StyleParser.parseDistance(rule_style.width, context);
         style.z = (rule_style.z && StyleParser.parseDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;
 
-        style.texture = rule_style.texture;
-        style.sprite = rule_style.sprite;
         style.size = rule_style.size && StyleParser.parseDistance(rule_style.size, context);
 
         // height defaults to feature height, but extrude style can dynamically adjust height by returning a number or array (instead of a boolean)
@@ -92,11 +90,6 @@ Object.assign(Polygons, {
             style.outline.color = null;
             style.outline.width = null;
             style.outline.tile_edges = false;
-        }
-
-        // Sets texcoord scale if needed (e.g. for sprite sub-area)
-        if (this.texcoords) {
-            this.setTexcoordScale(style);
         }
 
         return style;

--- a/src/styles/sprites/sprites_fragment.glsl
+++ b/src/styles/sprites/sprites_fragment.glsl
@@ -6,25 +6,17 @@ uniform float u_map_zoom;
 uniform vec2 u_map_center;
 uniform vec2 u_tile_origin;
 
-varying vec2 v_texcoord;
+uniform sampler2D u_texture;
 
-// built-in uniforms for texture maps
-#if defined(NUM_TEXTURES)
-    uniform sampler2D u_textures[NUM_TEXTURES];
-#else
-    uniform sampler2D u_textures[1];
-#endif
+varying vec2 v_texcoord;
 
 #pragma tangram: globals
 
 void main (void) {
-    vec4 color = texture2D(u_textures[0], v_texcoord);
+    vec4 color = texture2D(u_texture, v_texcoord);
 
     #pragma tangram: color
     #pragma tangram: filter
-
-    // TODO: legacy, replace in existing styles
-    // #pragma tangram: fragment
 
     gl_FragColor = color;
 }

--- a/src/styles/sprites/sprites_vertex.glsl
+++ b/src/styles/sprites/sprites_vertex.glsl
@@ -62,7 +62,7 @@ void main() {
     position.xy += rotate2D(shape.xy * 128. * zscale, radians(shape.z * 360.)) * 2. * position.w / u_resolution;
 
     // Re-orders depth so that higher numbered layers are "force"-drawn over lower ones
-    // reorderLayers(a_layer + u_order_min, u_order_range, position);
+    reorderLayers(a_layer + u_order_min, u_order_range, position);
 
     gl_Position = position;
 }

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -71,22 +71,7 @@ StyleManager.preload = function (styles) {
     }
 
     // First load remote styles, then load shader blocks from remote URLs
-    // TODO: also preload textures
-    StyleManager.normalizeTextures(styles);
     return StyleManager.loadRemoteStyles(styles).then(StyleManager.loadRemoteShaderTransforms);
-};
-
-// Handle single or multi-texture syntax, for stylesheet convenience
-StyleManager.normalizeTextures = function (styles) {
-    for (var style of Utils.values(styles)) {
-        style.textures = style.textures || {};
-
-        // Support simpler single texture syntax
-        if (style.texture) {
-            style.textures.default = style.texture; // alias single texture to 'default'
-        }
-    }
-    return styles;
 };
 
 // Load style definitions from external URLs


### PR DESCRIPTION
This removes some style-oriented texture support that I was never entirely comfortable with up to the scene level. This should be more compatible with @patriciogonzalezvivo's forthcoming material textures (https://github.com/tangrams/tangram/pull/112), and follows a suggestion from @meetar to provide a centralized way to define textures in the scene config file.

For cases where the standard material texture isn't enough (e.g. styles like sprites, that aren't doing normal texture mapping + lighting), there are now 3 ways a texture can be added to a style:

## URL in Style
the simplest way to add a new texture is to simply refer to it by URL. For an example `icons` style, this can be done like this:

```
styles:
    icons:
        texture: path/to/image.png
    ...
```

This will automatically load `path/to/image.png`, with default texture settings, and make it available as a shader uniform named `u_texture`.

## Object in Style
If more texture configuration is needed (for instance, specifying sprite UVs or overriding the default texture filtering mode), an object can be provided directly in the style definition instead:

```
styles:
    icons:
        texture:
            url: path/to/image.png
            filtering: mipmap
            sprites:
                # each sprite is defined as: [x origin, y origin, width, height]
                bunny: [0, 0, 32, 32]
                fox: [0, 32, 32, 32]
```

## Centralized at Scene Level
If the same textures will be referenced in multiple places across the scene definition, it's also possible to define textures centrally, at the same top-level as `styles`, `sources`, etc. In the scene config, then later referenced by name by a style:

```
# define textures centrally
textures:
    icon_texture:
        url: path/to/image.png
        filtering: mipmap
        sprites:
            # each sprite is defined as: [x origin, y origin, width, height]
            bunny: [0, 0, 32, 32]
            fox: [0, 32, 32, 32]

# reference the texture by name in a style
styles:
    icons:
        texture: icon_texture
        ...
```


