### PR TITLE
Adding basic mechanism for altering tile data.

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -12,7 +12,11 @@
                 // You can edit the tile data here before it gets projected
                 // and rendered
                 return data;
-            }
+            },
+            scripts: [
+                // importScripts doesn't like the agnostic //example.com proto
+                'http://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js'
+            ]
         },
         'mapzen-dev': {
             type: 'GeoJSONTileSource',

--- a/demos/main.js
+++ b/demos/main.js
@@ -7,7 +7,12 @@
     var tile_sources = {
         mapzen: {
             type: 'GeoJSONTileSource',
-            url: window.location.protocol + '//vector.mapzen.com/osm/all/{z}/{x}/{y}.json'
+            url: window.location.protocol + '//vector.mapzen.com/osm/all/{z}/{x}/{y}.json',
+            alter_data: function(data) {
+                // You can edit the tile data here before it gets projected
+                // and rendered
+                return data;
+            }
         },
         'mapzen-dev': {
             type: 'GeoJSONTileSource',

--- a/src/data_source.js
+++ b/src/data_source.js
@@ -11,6 +11,15 @@ export default class DataSource {
         this.id = source.id;
         this.name = source.name;
         this.url = source.url;
+
+        // Get alter data.  Comes in as string, even if using actual
+        // function
+        if (typeof source.alter_data === 'string' && source.alter_data.indexOf('function') !== -1) {
+            source.alter_data = Utils.stringsToFunctions({ a: source.alter_data });
+            source.alter_data = source.alter_data.a;
+        }
+        this.alter_data = source.alter_data;
+
         // overzoom will apply for zooms higher than this
         this.max_zoom = source.max_zoom || Geo.max_zoom;
     }
@@ -201,6 +210,12 @@ export class GeoJSONTileSource extends NetworkTileSource {
     parseSourceData (tile, source, response) {
         let data = JSON.parse(response);
 
+        // Edit response if provided
+        if (typeof this.alter_data === 'function') {
+            this.alter_data.bind(this);
+            data = this.alter_data(data);
+        }
+
         // Single layer or multi-layers?
         if (data.type === 'Feature' || data.type === 'FeatureCollection') {
             source.layers = { _default: data };
@@ -363,4 +378,3 @@ export class MapboxFormatTileSource extends NetworkTileSource {
     }
 
 }
-


### PR DESCRIPTION
This is mostly a proof of concept.  Feel free to close after checking it out.

This just adds the ability to add an `alter_data` function to a data source that will be run before the data gets projected and rendered.

It's currently only for GeoJSON Tile layers since its not necessarily the best way to do this.