### PR TITLE
Properly compile styles in order of dependency

### DIFF
--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -15,6 +15,7 @@ export let TextStyle = Object.create(Sprites);
 Object.assign(TextStyle, {
     name: 'text',
     super: Sprites,
+    extends: 'sprites',
     built_in: true,
     selection: false,
 

--- a/test/fixtures/sample-remote-style.yaml
+++ b/test/fixtures/sample-remote-style.yaml
@@ -39,7 +39,7 @@ windows:
 
                     return o4.y * d.y + o4.x * (1.0 - d.y);
                 }
-            fragment: |
+            color: |
                 vec3 vPos = v_world_position.xyz / u_frequency;
                 vec3 mask = mix(vec3(0.0), vec3(1.0), step(fract(mod(vPos, .9)), vec3(.4, .4, .6)));
 

--- a/test/fixtures/sample-scene.json
+++ b/test/fixtures/sample-scene.json
@@ -73,7 +73,23 @@
                 }
             }
         },
+        "lights": {
+            "ambient": {
+                "type": "ambient",
+                "ambient": 0.5
+            }
+        },
         "styles": {
+            "rainbow_child": {
+                "extends": "rainbow",
+                "animated": true,
+                "shaders": {
+                    "blocks": {
+                        "color":
+                            "color.rgb = clamp(hsv2rgb(c) * 2., 0., 1.);"
+                    }
+                }
+            },
             "rainbow": {
                 "extends": "polygons",
                 "animated": true,
@@ -85,7 +101,7 @@
                                 vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www); \n\
                                 return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y); \n\
                             }",
-                        "fragment":
+                        "color":
                             "vec3 c = vec3(v_world_position.z * .003 + u_time / 10., 1.0, 1.0); \n\
                             color.rgb = hsv2rgb(c);"
                     }
@@ -98,7 +114,7 @@
                         "scale": [1, 2, 3]
                     },
                     "blocks": {
-                        "vertex":
+                        "position":
                             "position.xyz *= scale;"
                     }
                 }


### PR DESCRIPTION
We want to properly support situations where multiple parent-child styles a re defined in the scene def, and then get built in proper order according to their dependencies. i.e. even when a child style appears *before* its parent:

```
styles:
   child:
      extends: parent
      ...

   parent:
      extends: polygons
      ...
```