### PR TITLE
Add bower.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Tangram is a library for rendering 2D & 3D maps with WebGL. It is tuned for Open
 1. Clone or download this repository:
   - clone in a terminal window with `git clone https://github.com/tangrams/tangram.git`
   - or download a zip directly: https://github.com/tangrams/tangram/archive/master.zip
+  - or use [Bower](http://bower.io/): `bower install tangram`
 2. Start a webserver in the repository's directory:
   - in a terminal window, enter: `python -m SimpleHTTPServer 8000`
   - if that doesn't work, try: `python -m http.server`

--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "demos",
     "src",
     "build*.*",
-    "karma*.*"
+    "karma*.*",
+    "index.html"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,8 @@
     "src",
     "build*.*",
     "karma*.*",
-    "index.html"
+    "index.html",
+    "watch.sh",
+    "makefile"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "tangram",
+  "description": "WebGL for OpenStreetMap",
+  "version": "0.0.1",
+  "homepage": "http://mapzen.com/tangram",
+  "keywords": [
+    "maps",
+    "graphics",
+    "rendering",
+    "visualization",
+    "WebGL",
+    "OpenStreetMap"
+  ],
+  "authors": [{
+    "name": "Brett Camper",
+    "email": "bcamper@alum.mit.edu"
+  }],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tangrams/tangram.git"
+  },
+  "main": "dist/tangram.min.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "demos",
+    "src",
+    "build*.*",
+    "karma*.*"
+  ]
+}


### PR DESCRIPTION
[Bower](http://bower.io/) is pretty much the best option for front-end dependency/library, albeit far from perfect.

This adds a `bower.json` which works a lot like `package.json`.  It's a bit annoying to have manage both, but it's worth the ability to do: `bower install tangram`.

I already registered the `tangram` name in bower since this is not an authenticated action.