### PR TITLE
Add caching for common style parameter parsing

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -24,7 +24,7 @@ Enjoy!
     var tile_sources = {
         'mapzen': {
             type: 'MVT',
-            url: window.location.protocol + '//vector.mapzen.com/osm/all/{z}/{x}/{y}.mapbox'
+            url: window.location.protocol + '//vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt'
         },
         'mapzen-geojson': {
             type: 'GeoJSONTiles',

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -203,7 +203,6 @@ layers:
             not: { kind: [rail] }
         draw:
             lines:
-                interactive: true
                 style: flat_lines
                 color: white
                 width: 12
@@ -321,10 +320,15 @@ layers:
 
         draw:
             polygons:
-                interactive: true
                 order: 300
                 color: [.65, .65, .65]
 
+        # turn interactive feature selection on for buildings with names
+        interactive:
+            filter: { name: true }
+            draw: { polygons: { interactive: true } }
+
+        # extrude 3d buildings
         extruded:
             filter: { $zoom: { min: 15 } }
             draw:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -322,11 +322,15 @@ layers:
         draw:
             polygons:
                 interactive: true
-                style: buildings
                 order: 300
-                color: '#bbb'
-                # extrude: function() { return $zoom > 14 }
-                extrude: function () { return (($zoom >= 15 && feature.height > 20) || $zoom >= 16) }
+                color: [.65, .65, .65]
+
+        extruded:
+            filter: { $zoom: { min: 15 } }
+            draw:
+                polygons:
+                    style: buildings
+                    extrude: function () { return (($zoom >= 15 && feature.height > 20) || $zoom >= 16) }
 
         high-line:
             filter: { uid: "37054313" }

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -303,7 +303,6 @@ layers:
                 filter: { aeroway: runway }
                 draw:
                     lines:
-                        # color: [[13, [255, 209, 160]], [16, [255, 255, 255]]]
                         color: [[13, '#FFE4B5'], [16, white]]
                         width: [[11, 3px], [12, 5px], [13, 10px], [15, 75]]
                         order: 2
@@ -334,10 +333,11 @@ layers:
             draw:
                 polygons:
                     style: buildings
-                    extrude: function () { return (($zoom >= 15 && feature.height > 20) || $zoom >= 16) }
+                    extrude: function () { return feature.height > 20 || $zoom >= 16; }
 
         high-line:
-            filter: { uid: "37054313" }
+            # filter: { uid: "37054313" }
+            filter: { roof_material: grass }
             draw:
                 polygons:
                     style: flat
@@ -391,10 +391,14 @@ layers:
             icons:
                 size: [[13, 12px], [15, 18px]]
                 interactive: true
-                # sprite: info
 
+        # add generic icon at high zoom
+        generic:
+            filter: { $zoom: { min: 18 } }
+            draw: { icons: { sprite: info } }
+
+        # examples of different icons mapped to feature properties
         icons:
-            # examples of different icons mapped to feature properties
             restaurant:
                 filter: { kind: [restaurant] }
                 draw: { icons: { sprite: restaurant } }
@@ -413,9 +417,6 @@ layers:
             hospital:
                 filter: { kind: [hospital, pharmacy] }
                 draw: { icons: { sprite: hospital } }
-            # parking:
-            #     filter: { kind: [parking] }
-            #     draw: { icons: { sprite: parking } }
             hotel:
                 filter: { kind: [hotel, hostel] }
                 draw: { icons: { sprite: hotel } }

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -50,7 +50,7 @@ Object.assign(Lines, {
     _parseFeature (feature, rule_style, context) {
         var style = this.feature_style;
 
-        style.color = rule_style.color && StyleParser.parseColor(rule_style.color, context);
+        style.color = rule_style.color && StyleParser.cacheColor(rule_style.color, context);
         style.width = rule_style.width && StyleParser.parseDistance(rule_style.width, context);
 
         // Smoothly interpolate line width between zooms: get scale factors to previous and next zooms
@@ -90,19 +90,26 @@ Object.assign(Lines, {
         style.join = rule_style.join;
         style.tile_edges = rule_style.tile_edges;
 
-        style.outline = style.outline || {};
-        if (rule_style.outline) {
-            style.outline.color = StyleParser.parseColor(rule_style.outline.color, context);
-            style.outline.width = StyleParser.parseDistance(rule_style.outline.width, context);
-            style.outline.cap = rule_style.outline.cap || rule_style.cap;
-            style.outline.join = rule_style.outline.join || rule_style.join;
-        }
-        else {
-            style.outline.color = null;
-            style.outline.width = null;
-        }
+        // style.outline = style.outline || {};
+        // if (rule_style.outline) {
+        //     style.outline.color = rule_style.outline.color && StyleParser.cacheColor(rule_style.outline.color, context);
+        //     style.outline.width = rule_style.outline.width && StyleParser.parseDistance(rule_style.outline.width, context);
+        //     style.outline.cap = rule_style.outline.cap || rule_style.cap;
+        //     style.outline.join = rule_style.outline.join || rule_style.join;
+        // }
+        // else {
+        //     style.outline.color = null;
+        //     style.outline.width = null;
+        // }
 
         return style;
+    },
+
+    preprocess (draw) {
+        draw.color = draw.color && { value: draw.color };
+        // if (draw.outline) {
+        //     draw.outline.color = draw.outline.color && { value: draw.outline.color };
+        // }
     },
 
     /**

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -69,6 +69,7 @@ Object.assign(Lines, {
         style.next_width = StyleParser.cacheDistance(rule_style.width, context);
         style.next_width = Utils.scaleInt16(style.next_width / style.width, 256);
         context.zoom--;
+        context.units_per_meter /= 2;
 
         // height defaults to feature height, but extrude style can dynamically adjust height by returning a number or array (instead of a boolean)
         style.z = (rule_style.z && StyleParser.cacheDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -53,7 +53,7 @@ Object.assign(Points, {
 
         let tile = context.tile.key;
 
-        style.color = (rule_style.color && StyleParser.parseColor(rule_style.color, context)) || [1, 1, 1, 1];
+        style.color = (rule_style.color && StyleParser.cacheColor(rule_style.color, context)) || [1, 1, 1, 1];
         style.z = (rule_style.z && StyleParser.parseDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;
 
         style.sprite = rule_style.sprite;
@@ -106,6 +106,10 @@ Object.assign(Points, {
         }
 
         return style;
+    },
+
+    preprocess (draw) {
+        draw.color = draw.color && { value: draw.color };
     },
 
     /**

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -54,7 +54,7 @@ Object.assign(Points, {
         let tile = context.tile.key;
 
         style.color = (rule_style.color && StyleParser.cacheColor(rule_style.color, context)) || [1, 1, 1, 1];
-        style.z = (rule_style.z && StyleParser.parseDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;
+        style.z = (rule_style.z && StyleParser.cacheDistance(rule_style.z, context)) || StyleParser.defaults.z;
 
         style.sprite = rule_style.sprite;
         if (typeof style.sprite === 'function') {
@@ -68,8 +68,8 @@ Object.assign(Points, {
         }
 
         // point style only supports sizes in pixel units, so unit conversion flag is off
-        style.size = rule_style.size || [32, 32];
-        style.size = StyleParser.parseDistance(style.size, context, false);
+        style.size = rule_style.size || { value: [32, 32] };
+        style.size = StyleParser.cacheDistance(style.size, context, false);
 
         // scale size to 16-bit signed int, with a max allowed width + height of 128 pixels
         style.size = [
@@ -110,6 +110,8 @@ Object.assign(Points, {
 
     preprocess (draw) {
         draw.color = draw.color && { value: draw.color };
+        draw.z = draw.z && { value: draw.z };
+        draw.size = draw.size && { value: draw.size };
     },
 
     /**

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -56,7 +56,7 @@ Object.assign(Polygons, {
         var style = this.feature_style;
 
         style.color = rule_style.color && StyleParser.cacheColor(rule_style.color, context);
-        style.width = rule_style.width && StyleParser.parseDistance(rule_style.width, context);
+        // style.width = rule_style.width && StyleParser.parseDistance(rule_style.width, context);
         style.z = (rule_style.z && StyleParser.parseDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;
 
         // height defaults to feature height, but extrude style can dynamically adjust height by returning a number or array (instead of a boolean)
@@ -96,6 +96,7 @@ Object.assign(Polygons, {
 
     preprocess (draw) {
         draw.color = draw.color && { value: draw.color };
+        draw.z = draw.z && { value: draw.z };
     },
 
     /**

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -55,11 +55,9 @@ Object.assign(Polygons, {
     _parseFeature (feature, rule_style, context) {
         var style = this.feature_style;
 
-        style.color = rule_style.color && StyleParser.parseColor(rule_style.color, context);
+        style.color = rule_style.color && StyleParser.cacheColor(rule_style.color, context);
         style.width = rule_style.width && StyleParser.parseDistance(rule_style.width, context);
         style.z = (rule_style.z && StyleParser.parseDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;
-
-        style.size = rule_style.size && StyleParser.parseDistance(rule_style.size, context);
 
         // height defaults to feature height, but extrude style can dynamically adjust height by returning a number or array (instead of a boolean)
         style.height = feature.properties.height || StyleParser.defaults.height;
@@ -79,24 +77,25 @@ Object.assign(Polygons, {
             }
         }
 
-        style.cap = rule_style.cap;
-        style.join = rule_style.join;
-
-        style.outline = style.outline || {};
-        if (rule_style.outline) {
-            style.outline.color = StyleParser.parseColor(rule_style.outline.color, context);
-            style.outline.width = StyleParser.parseDistance(rule_style.outline.width, context);
-            style.outline.tile_edges = rule_style.outline.tile_edges;
-            style.outline.cap = rule_style.outline.cap || rule_style.cap;
-            style.outline.join = rule_style.outline.join || rule_style.join;
-        }
-        else {
-            style.outline.color = null;
-            style.outline.width = null;
-            style.outline.tile_edges = false;
-        }
+        // style.outline = style.outline || {};
+        // if (rule_style.outline) {
+        //     style.outline.color = StyleParser.parseColor(rule_style.outline.color, context);
+        //     style.outline.width = StyleParser.parseDistance(rule_style.outline.width, context);
+        //     style.outline.tile_edges = rule_style.outline.tile_edges;
+        //     style.outline.cap = rule_style.outline.cap || rule_style.cap;
+        //     style.outline.join = rule_style.outline.join || rule_style.join;
+        // }
+        // else {
+        //     style.outline.color = null;
+        //     style.outline.width = null;
+        //     style.outline.tile_edges = false;
+        // }
 
         return style;
+    },
+
+    preprocess (draw) {
+        draw.color = draw.color && { value: draw.color };
     },
 
     /**

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -56,8 +56,7 @@ Object.assign(Polygons, {
         var style = this.feature_style;
 
         style.color = rule_style.color && StyleParser.cacheColor(rule_style.color, context);
-        // style.width = rule_style.width && StyleParser.parseDistance(rule_style.width, context);
-        style.z = (rule_style.z && StyleParser.parseDistance(rule_style.z || 0, context)) || StyleParser.defaults.z;
+        style.z = (rule_style.z && StyleParser.cacheDistance(rule_style.z, context)) || StyleParser.defaults.z;
 
         // height defaults to feature height, but extrude style can dynamically adjust height by returning a number or array (instead of a boolean)
         style.height = feature.properties.height || StyleParser.defaults.height;

--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -187,6 +187,8 @@ export class RuleTree extends Rule {
                         if (!ruleCache[cache_key][draw_key]) {
                             delete ruleCache[cache_key][draw_key];
                         }
+
+                        ruleCache[cache_key][draw_key].key = cache_key + '/' + draw_key;
                     }
 
                     // No rules evaluated

--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -187,8 +187,9 @@ export class RuleTree extends Rule {
                         if (!ruleCache[cache_key][draw_key]) {
                             delete ruleCache[cache_key][draw_key];
                         }
-
-                        ruleCache[cache_key][draw_key].key = cache_key + '/' + draw_key;
+                        else {
+                            ruleCache[cache_key][draw_key].key = cache_key + '/' + draw_key;
+                        }
                     }
 
                     // No rules evaluated

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -128,6 +128,12 @@ export var Style = {
         try {
             var style = this.feature_style;
 
+            // Preprocess first time
+            if (!rule_style.preprocessed) {
+                this.preprocess(rule_style);
+                rule_style.preprocessed = true;
+            }
+
             // Calculate order if it was not cached
             style.order = rule_style.order;
             if (typeof style.order !== 'number') {
@@ -167,6 +173,8 @@ export var Style = {
     _parseFeature (feature, rule_style, context) {
         throw new MethodNotImplemented('_parseFeature');
     },
+
+    preprocess () {},
 
     // Build functions are no-ops until overriden
     buildPolygons () {},

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -199,17 +199,25 @@ StyleParser.parseDistance = function(val, context, convert = true) {
 
 // Takes a color cache object and returns a color value for this zoom
 // (caching the result for future use)
-// { value: original, static: [r,g,b,a], zoom: { z: [r,g,b,a] } }
+// { value: original, static: [r,g,b,a], zoom: { z: [r,g,b,a] }, dynamic: function(){...} }
 StyleParser.cacheColor = function(val, context = {}) {
-    if (val.static) {
+    if (val.dynamic) {
+        return val.dynamic(context);
+    }
+    else if (val.static) {
         return val.static;
     }
     else if (val.zoom && val.zoom[context.zoom]) {
         return val.zoom[context.zoom];
     }
     else {
+        // Dynamic function-based color
+        if (typeof val.value === 'function') {
+            val.dynamic = val.value;
+            return val.dynamic(context);
+        }
         // Single string color
-        if (typeof val.value === 'string') {
+        else if (typeof val.value === 'string') {
             val.static = parseCSSColor.parseCSSColor(val.value);
             if (val.static && val.static.length === 4) {
                 val.static[0] /= 255;

--- a/test/rule_spec.js
+++ b/test/rule_spec.js
@@ -272,17 +272,10 @@ describe('RuleTree.buildDrawGroups(context)', () => {
 
         it('returns a single object', () => {
             let rule = subject.root.buildDrawGroups(context);
-            assert.deepEqual(
-                rule,
-                {
-                    group: {
-                        color: [1, 2, 3],
-                        visible: true,
-                        width: 20,
-                        order: 1
-                    }
-                }
-            );
+            assert.equal(Object.keys(rule).length, 1);
+            assert.deepEqual(rule.group.color, [1, 2, 3]);
+            assert.equal(rule.group.width, 20);
+            assert.equal(rule.group.order, 1);
         });
     });
 
@@ -300,14 +293,10 @@ describe('RuleTree.buildDrawGroups(context)', () => {
 
         it('returns the correct number of matching rules', () => {
             let rule = subject.root.buildDrawGroups(context);
-            assert.deepEqual(rule, {
-                group: {
-                    color: [1, 2, 3],
-                    order: 1,
-                    visible: true,
-                    width: 20
-                }
-            });
+            assert.equal(Object.keys(rule).length, 1);
+            assert.deepEqual(rule.group.color, [1, 2, 3]);
+            assert.equal(rule.group.width, 20);
+            assert.equal(rule.group.order, 1);
         });
     });
 
@@ -373,15 +362,9 @@ describe('RuleTree.buildDrawGroups(context)', () => {
             };
 
             it('returns only the child\'s draw', () => {
-                let results = subject.root.buildDrawGroups(context);
-
-                assert.deepEqual(results, {
-                    group: {
-                        color: [1, 2, 3],
-                        visible: true
-                    }
-                });
-
+                let rule = subject.root.buildDrawGroups(context);
+                assert.equal(Object.keys(rule).length, 1);
+                assert.deepEqual(rule.group.color, [1, 2, 3]);
             });
 
         });


### PR DESCRIPTION
There's no need to re-parse string-based colors, and interpolated values between zooms, for every feature in the scene (!). By caching these values (sometimes a single static value, sometimes one value-per-zoom), we can get up to 50% decrease in tile build time.