### PR TITLE
Simplify order inheritance

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -167,7 +167,7 @@ layers:
             filter: { kind: [park, graveyard, cemetery, forest, recreation_ground] }
             draw:
                 polygons:
-                    order: 1
+                    order: 2
                     color: '#bddec5'
         blue:
             filter: { kind: [commercial, industrial] }
@@ -282,7 +282,7 @@ layers:
                 lines:
                     color: '#bbb'
                     width: [[15, 0px], [18, 2px]]
-                    order: -2
+                    order: 3 # -2
                 outlines:
                     width: 0
         airports:

--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -16,8 +16,8 @@ function cacheKey (rules) {
 export function mergeTrees(matchingTrees, key, context) {
     var draw = {},
         draws,
-        order = [],
-        order_draws = [],
+        // order = [],
+        // order_draws = [],
         treeDepth = 0,
         i, x, t;
 
@@ -50,12 +50,12 @@ export function mergeTrees(matchingTrees, key, context) {
             }
 
             // Collect unique orders (don't add the order multiple times for the smae draw rule)
-            if (draws[i].order !== undefined) {
-                if (order_draws.indexOf(draws[i]) === -1) {
-                    order.push(draws[i].order);
-                    order_draws.push(draws[i]);
-                }
-            }
+            // if (draws[i].order !== undefined) {
+            //     if (order_draws.indexOf(draws[i]) === -1) {
+            //         order.push(draws[i].order);
+            //         order_draws.push(draws[i]);
+            //     }
+            // }
         }
 
         // Merge remaining draw objects
@@ -68,16 +68,17 @@ export function mergeTrees(matchingTrees, key, context) {
     }
 
     // Sum all orders
-    if (order.length > 0) {
-        // Order can be cached if it is all numeric
-        if (order.length === 1 && typeof order[0] === 'number') {
-            order = order[0];
-        }
-        else if (order.every(v => typeof v === 'number')) {
-            order = calculateOrder(order, context); // TODO: use StyleParser.calculateOrder
-        }
-        draw.order = order;
-    }
+    // Note: temporarily commenting out, will revisit with new scene file syntax
+    // if (order.length > 0) {
+    //     // Order can be cached if it is all numeric
+    //     if (order.length === 1 && typeof order[0] === 'number') {
+    //         order = order[0];
+    //     }
+    //     else if (order.every(v => typeof v === 'number')) {
+    //         order = calculateOrder(order, context); // TODO: use StyleParser.calculateOrder
+    //     }
+    //     draw.order = order;
+    // }
 
     return draw;
 }

--- a/test/rule_spec.js
+++ b/test/rule_spec.js
@@ -73,7 +73,6 @@ describe('.mergeTrees()', () => {
                 parent,
                 {
                     group: {
-                        "order": 1,
                         "b": "z",
                         "color": [7, 8, 9]
                     }
@@ -85,7 +84,7 @@ describe('.mergeTrees()', () => {
             assert.deepEqual(mergeTrees(subject, 'group', {}), {
                 visible: true,
                 width: 10,
-                order: 5,
+                order: 3,
                 a: 'y',
                 b: 'z',
                 color: [7, 8, 9]


### PR DESCRIPTION
Follow standard inheritance for `order` property, so that child rules replace the order of value of parent/ancestor rules (instead of summing together).

We may revisit the order sum behavior in the future, with new syntax. But came to the conclusion that this is a simpler default.