### PR TITLE
Make resources in scene file relative

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -27,7 +27,7 @@ scene:
 
 textures:
     pois:
-        url: demos/images/poi_icons_32.png
+        url: images/poi_icons_32.png
         filtering: mipmap
         sprites:
             # each sprite is defined as: [x origin, y origin, width, height]
@@ -55,7 +55,7 @@ styles:
                 EFFECT_NOISE_ANIMATED: true
             blocks:
                 global:
-                    url: demos/shaders/glsl-noise-periodic-3d.glsl
+                    url: shaders/glsl-noise-periodic-3d.glsl
                 color: |
                     color.rgb *=
                         abs(pnoise(
@@ -80,7 +80,7 @@ styles:
                     color.rgb = hsv2rgb(c);
 
     popup:
-        url: demos/styles/popup.yaml
+        url: styles/popup.yaml
 
     elevator:
         base: polygons
@@ -100,17 +100,17 @@ styles:
             ambient: 0
             diffuse: 0
             emission:
-                texture: demos/images/sunset.jpg
+                texture: images/sunset.jpg
                 mapping: spheremap
 
     halftone_polygons:
-        url: demos/styles/halftone.yaml
+        url: styles/halftone.yaml
 
     halftone_lines:
-        url: demos/styles/halftone.yaml
+        url: styles/halftone.yaml
 
     windows:
-        url: demos/styles/windows.yaml
+        url: styles/windows.yaml
 
     flat:
         base: polygons

--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -73,6 +73,10 @@ export default class Texture {
             return;
         }
 
+        if (Texture.base_url) {
+            url = Utils.addBaseURL(url, Texture.base_url);
+        }
+
         this.loading = new Promise((resolve, reject) => {
             this.image = new Image();
             this.image.onload = () => {
@@ -325,5 +329,7 @@ Texture.syncTexturesToWorker = function (names) {
 
 // Global set of textures, by name
 Texture.textures = {};
+
+Texture.base_url = null; // optional base URL to add to textures
 
 subscribeMixin(Texture);

--- a/src/scene.js
+++ b/src/scene.js
@@ -1033,6 +1033,9 @@ export default class Scene {
        @return {Promise}
     */
     loadScene() {
+        this.config_path = Utils.pathForURL(this.config_source);
+        Texture.base_url = this.config_path;
+
         return Utils.loadResource(this.config_source).then((config) => {
             this.config = config;
             return this.preProcessConfig().then(() => { this.trigger('loadScene', this.config); });
@@ -1102,7 +1105,7 @@ export default class Scene {
         this.config.lights = this.config.lights || {}; // ensure lights object
         this.config.styles = this.config.styles || {}; // ensure styles object
 
-        return StyleManager.preload(this.config.styles);
+        return StyleManager.preload(this.config.styles, this.config_path);
     }
 
     // Load all textures in the scene definition

--- a/src/scene.js
+++ b/src/scene.js
@@ -1033,7 +1033,7 @@ export default class Scene {
        @return {Promise}
     */
     loadScene() {
-        this.config_path = Utils.pathForURL(this.config_source);
+        this.config_path = (typeof this.config_source === 'string') && Utils.pathForURL(this.config_source);
         Texture.base_url = this.config_path;
 
         return Utils.loadResource(this.config_source).then((config) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -8,9 +8,10 @@ import Geo from '../geo';
 var Utils;
 export default Utils = {};
 
-// Add the current base URL for schemeless or protocol-less URLs
+// Add a base URL for schemeless or protocol-less URLs
+// Defaults to adding current window protocol and base, or adds a custom base if specified
 // Maybe use https://github.com/medialize/URI.js if more robust functionality is needed
-Utils.addBaseURL = function (url) {
+Utils.addBaseURL = function (url, base) {
     if (!url) {
         return;
     }
@@ -21,9 +22,23 @@ Utils.addBaseURL = function (url) {
     }
     // No http(s) or data, add base
     else if (url.search(/(http|https|data):\/\//) < 0) {
-        url = window.location.origin + window.location.pathname + url;
+        var relative = (url[0] !== '/');
+        var base_info;
+        if (base) {
+            base_info = document.createElement('a'); // use a temporary element to parse URL
+            base_info.href = base;
+        }
+        else {
+            base_info = window.location;
+        }
+
+        url = base_info.origin + (relative ? base_info.pathname : '') + url;
     }
     return url;
+};
+
+Utils.pathForURL = function (url) {
+    return url.substr(0, url.lastIndexOf('/') + 1);
 };
 
 Utils.cacheBusterForUrl = function (url) {


### PR DESCRIPTION
By making resources in the scene file (textures, shader blocks loaded via URL) relative to the scene file itself, we can load entire styles remotely/cross-origin, even when they reference other resources.

For simple local styles, this just means that you should specify any resources as relative to the location of the scene file. For example, in the bundled example, several resources that had a path of `demos/images/...` were changed to `images/...`, since the `scene.yaml` already resides inside the `demos/` directory.