### PR TITLE
Restore support for old `outline` style parameter (for lines)

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -308,7 +308,7 @@ Enjoy!
             },
             'halftone': {
                 setup: function (style) {
-                    scene.config.background.color = 'black';
+                    scene.config.scene.background.color = 'black';
 
                     var layers = scene.config.layers;
                     layers.earth.draw.polygons.style = 'halftone_polygons';

--- a/src/scene.js
+++ b/src/scene.js
@@ -16,6 +16,17 @@ import Tile from './tile';
 import DataSource from './data_source';
 import FeatureSelection from './selection';
 
+import {Polygons} from './styles/polygons/polygons';
+import {Lines} from './styles/lines/lines';
+import {Points} from './styles/points/points';
+import {TextStyle} from './styles/text/text';
+
+// Add built-in rendering styles
+StyleManager.register(Polygons);
+StyleManager.register(Lines);
+StyleManager.register(Points);
+StyleManager.register(TextStyle);
+
 import log from 'loglevel';
 import glMatrix from 'gl-matrix';
 let mat4 = glMatrix.mat4;

--- a/src/scene.js
+++ b/src/scene.js
@@ -1177,13 +1177,22 @@ export default class Scene {
                     // TODO: warn on non-object draw group
                     if (typeof group === 'object' && group.visible !== false) {
                         let style_name = group.style || name;
-                        let style = this.styles[style_name];
-                        if (style) {
-                            this.active_styles[style_name] = true;
-                            if (style.animated) {
-                                animated = true;
-                            }
+                        let styles = [style_name];
+
+                        // optional additional outline style
+                        if (group.outline && group.outline.style) {
+                            styles.push(group.outline.style);
                         }
+
+                        styles = styles.filter(x => this.styles[x]).forEach(style_name => {
+                            let style = this.styles[style_name];
+                            if (style) {
+                                this.active_styles[style_name] = true;
+                                if (style.animated) {
+                                    animated = true;
+                                }
+                            }
+                        });
                     }
                 }
             }

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -69,7 +69,7 @@ Object.assign(Points, {
 
         // point style only supports sizes in pixel units, so unit conversion flag is off
         style.size = rule_style.size || { value: [32, 32] };
-        style.size = StyleParser.cacheDistance(style.size, context, false);
+        style.size = StyleParser.cacheDistance(style.size, context, 'pixels');
 
         // scale size to 16-bit signed int, with a max allowed width + height of 128 pixels
         style.size = [

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -24,7 +24,7 @@ attribute float a_layer;
 // Optional dynamic line extrusion
 #ifdef TANGRAM_EXTRUDE_LINES
     attribute vec3 a_extrude;
-    attribute vec2 a_scale;
+    attribute float a_scale;
 #endif
 
 varying vec4 v_position;
@@ -83,12 +83,7 @@ void main() {
         width *= pow(2., zscale);
 
         // Smoothly interpolate line width between zooms
-        if (zscale >= 0.) {
-            width = mix(width, width * a_scale.x * 256., zscale);
-        }
-        else {
-            width = mix(width, width * a_scale.y * 256., -zscale);
-        }
+        width = mix(width, width * a_scale * 256., -zscale);
 
         // Modify line width before extrusion
         #pragma tangram: width

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -108,27 +108,27 @@ export var Style = {
             this.tile_data[tile].vertex_data = this.vertex_layout.createVertexData();
         }
 
-        this.buildGeometry(feature.geometry, style, this.tile_data[tile].vertex_data);
+        this.buildGeometry(feature.geometry, style, this.tile_data[tile].vertex_data, {context});
     },
 
-    buildGeometry (geometry, style, vertex_data) {
+    buildGeometry (geometry, style, vertex_data, options) {
         if (geometry.type === 'Polygon') {
-            this.buildPolygons([geometry.coordinates], style, vertex_data);
+            this.buildPolygons([geometry.coordinates], style, vertex_data, options);
         }
         else if (geometry.type === 'MultiPolygon') {
-            this.buildPolygons(geometry.coordinates, style, vertex_data);
+            this.buildPolygons(geometry.coordinates, style, vertex_data, options);
         }
         else if (geometry.type === 'LineString') {
-            this.buildLines([geometry.coordinates], style, vertex_data);
+            this.buildLines([geometry.coordinates], style, vertex_data, options);
         }
         else if (geometry.type === 'MultiLineString') {
-            this.buildLines(geometry.coordinates, style, vertex_data);
+            this.buildLines(geometry.coordinates, style, vertex_data, options);
         }
         else if (geometry.type === 'Point') {
-            this.buildPoints([geometry.coordinates], style, vertex_data);
+            this.buildPoints([geometry.coordinates], style, vertex_data, options);
         }
         else if (geometry.type === 'MultiPoint') {
-            this.buildPoints(geometry.coordinates, style, vertex_data);
+            this.buildPoints(geometry.coordinates, style, vertex_data, options);
         }
     },
 

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -91,6 +91,11 @@ export var Style = {
         return Promise.resolve(tile_data);
     },
 
+    // Has mesh data for a given tile?
+    hasDataForTile (tile) {
+        return this.tile_data[tile] != null;
+    },
+
     addFeature (feature, rule, tile, context) {
         if (!this.tile_data[tile]) {
             this.startData(tile);

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -333,3 +333,14 @@ StyleManager.compile = function (keys) {
 
     log.debug(`StyleManager.compile(): compiled all styles`);
 };
+
+// Get all styles with mesh data for a given tile
+StyleManager.stylesForTile = function (tile) {
+    let styles = [];
+    for (let s in Styles) {
+        if (Styles[s].hasDataForTile(tile)) {
+            styles.push(s);
+        }
+    }
+    return styles;
+};

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -3,18 +3,15 @@
 import Utils from '../utils/utils';
 import ShaderProgram from '../gl/shader_program';
 import shaderSources from '../gl/shader_sources'; // built-in shaders
-
 import {Style} from './style';
-import {Polygons} from './polygons/polygons';
-import {Lines} from './lines/lines';
-import {Points} from './points/points';
-import {TextStyle} from './text/text';
 
 import log from 'loglevel';
 
 export var StyleManager = {};
 export var Styles = {};
 export var BaseStyles = {};
+
+StyleManager.styles = Styles;
 
 // Set the base object used to instantiate styles
 StyleManager.baseStyle = Style;
@@ -336,9 +333,3 @@ StyleManager.compile = function (keys) {
 
     log.debug(`StyleManager.compile(): compiled all styles`);
 };
-
-// Add built-in rendering styles
-StyleManager.register(Polygons);
-StyleManager.register(Lines);
-StyleManager.register(Points);
-StyleManager.register(TextStyle);

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -306,8 +306,8 @@ Object.assign(TextStyle, {
     },
 
     // Override
-    startData () {
-        let tile_data = this.super.startData.apply(this);
+    startData (tile) {
+        let tile_data = this.super.startData.apply(this, arguments);
         tile_data.queue = [];
         return tile_data;
     },
@@ -414,11 +414,12 @@ Object.assign(TextStyle, {
     },
 
     // Override
-    endData (tile_data) {
+    endData (tile) {
         // Count collected text
-        let tile, count;
+        let count;
+        let tile_data = this.tile_data[tile];
+
         if (tile_data.queue.length > 0) {
-            tile = tile_data.queue[0][2].tile.key;
             count = Object.keys(this.texts[tile]||{}).length;
             log.trace(`# texts for tile ${tile}: ${count}`);
         }
@@ -453,13 +454,13 @@ Object.assign(TextStyle, {
                 tile_data.queue = [];
                 this.freeTile(tile);
 
-                return this.super.endData.call(this, tile_data);
+                return this.super.endData.apply(this, arguments);
             });
         });
     },
 
     // Override to queue features instead of processing immediately
-    addFeature (feature, rule, context, tile_data) {
+    addFeature (feature, rule, tile, context) {
         // Collect text
         let text;
         let source = rule.text_source || 'name';
@@ -473,7 +474,6 @@ Object.assign(TextStyle, {
         if (text) {
             feature.text = text;
 
-            let tile = context.tile.key;
             if (!this.texts[tile]) {
                 this.texts[tile] = {};
             }
@@ -512,7 +512,10 @@ Object.assign(TextStyle, {
             this.features[tile][style_key][text] = this.features[tile][style_key][text] || [];
             this.features[tile][style_key][text].push(feature);
 
-            tile_data.queue.push([feature, rule, context, tile_data]);
+            if (!this.tile_data[tile]) {
+                this.startData(tile);
+            }
+            this.tile_data[tile].queue.push([feature, rule, tile, context]);
         }
     },
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -135,7 +135,7 @@ export default class Tile {
     static buildGeometry (tile, layers, rules, styles) {
         tile.debug.rendering = +new Date();
 
-        let tile_data = {};
+        let tile_styles = {}; // track styles used in tile
 
         for (let source_name in tile.sources) {
             let source = tile.sources[source_name];
@@ -190,13 +190,13 @@ export default class Tile {
                             continue;
                         }
 
-                        if (!tile_data[style_name]) {
-                            tile_data[style_name] = style.startData();
-                        }
-
                         context.properties = group.properties; // add rule-specific properties to context
 
-                        style.addFeature(feature, group, context, tile_data[style_name]);
+                        style.addFeature(feature, group, tile.key, context);
+
+                        if (!tile_styles[style_name]) {
+                            tile_styles[style_name] = true;
+                        }
 
                         context.properties = null; // clear group-specific properties
                     }
@@ -212,9 +212,9 @@ export default class Tile {
         // Finalize array buffer for each render style
         tile.mesh_data = {};
         let queue = [];
-        for (let style_name in tile_data) {
+        for (let style_name in tile_styles) {
             let style = styles[style_name];
-            queue.push(style.endData(tile_data[style_name]).then((style_data) => {
+            queue.push(style.endData(tile.key).then((style_data) => {
                 if (style_data) {
                     tile.mesh_data[style_name] = {
                         vertex_data: style_data.vertex_data,

--- a/src/tile.js
+++ b/src/tile.js
@@ -1,6 +1,7 @@
 /*global Tile */
 import Geo from './geo';
 import {StyleParser} from './styles/style_parser';
+import {StyleManager} from './styles/style_manager';
 import WorkerBroker from './utils/worker_broker';
 import Texture from './gl/texture';
 
@@ -135,8 +136,6 @@ export default class Tile {
     static buildGeometry (tile, layers, rules, styles) {
         tile.debug.rendering = +new Date();
 
-        let tile_styles = {}; // track styles used in tile
-
         for (let source_name in tile.sources) {
             let source = tile.sources[source_name];
             source.debug.rendering = +new Date();
@@ -194,10 +193,6 @@ export default class Tile {
 
                         style.addFeature(feature, group, tile.key, context);
 
-                        if (!tile_styles[style_name]) {
-                            tile_styles[style_name] = true;
-                        }
-
                         context.properties = null; // clear group-specific properties
                     }
 
@@ -210,9 +205,10 @@ export default class Tile {
         }
 
         // Finalize array buffer for each render style
+        let tile_styles = StyleManager.stylesForTile(tile.key);
         tile.mesh_data = {};
         let queue = [];
-        for (let style_name in tile_styles) {
+        for (let style_name of tile_styles) {
             let style = styles[style_name];
             queue.push(style.endData(tile.key).then((style_data) => {
                 if (style_data) {


### PR DESCRIPTION
After switching to a system where all outlines were drawn as additional draw groups alongside the object they were outlining, we realized that the old system, where we had an explicit `outline` syntax, was really useful. In particular, it's useful for things like drawing a consistent outline width (e.g. 2px outline) on a line that is scaling between zoom levels. This PR:

- Refactors tile mesh construction so that styles can delegate to other styles (e.g. a line style can build its inner line, then calculate the appropriate outline width and call the same or another line style to build the outline geometry).
- Adds support for the `outline` parameter in the line base style.
- Simplifies the dynamic line scaling: now that base tile zoom is determined by `floor` instead of `round`, we only need to scale *up* towards the next zoom level, not both up *and* down towards the previous zoom level.
