### PR TITLE
Include the TopoJSON decoder directly in the library

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,6 +13,7 @@ dist/tangram.debug.js: .npm src/gl/shader_sources.js $(shell ./build_deps.sh)
 
 dist/tangram.min.js: dist/tangram.debug.js
 	$(UGLIFY) dist/tangram.debug.js -c warnings=false -m -o dist/tangram.min.js
+	gzip dist/tangram.min.js -c | wc -c | awk '{ printf "%.0fk minified+gzipped\n", $$1 / 1024 }'
 
 # Process shaders into strings and export as a module
 src/gl/shader_sources.js: $(shell find src/ -name '*.glsl')

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "strip-comments": "^0.3.2",
     "pbf": "1.3.2",
     "vector-tile": "1.1.2",
+    "topojson": "^1.6.19",
     "babel": "4.7.8"
   },
   "devDependencies": {
@@ -43,7 +44,6 @@
     "mocha": "~1.21.4",
     "sinon": "~1.10.3",
     "chai": "~1.9.2",
-    "topojson": "~1.6.18",
     "lodash": "~2.4.1",
     "yargs": "~1.3.2",
     "glob": "~4.0.6",

--- a/src/data_source.js
+++ b/src/data_source.js
@@ -7,6 +7,10 @@ import Utils from './utils/utils';
 // For TopoJSON tiles
 import topojson from 'topojson';
 
+// For MVT tiles
+import Pbf from 'pbf';
+import {VectorTile, VectorTileFeature} from 'vector-tile';
+
 export default class DataSource {
 
     constructor (source) {
@@ -258,18 +262,14 @@ export class MVTSource extends NetworkTileSource {
     constructor (source) {
         super(source);
         this.response_type = "arraybuffer"; // binary data
-        this.Protobuf = require('pbf');
-        this.VectorTile = require('vector-tile').VectorTile; // Mapbox vector tile lib
-        this.VectorTileFeature = require('vector-tile').VectorTileFeature;
-
         this.pad_scale = source.pad_scale || 0.001; // scale tile up by this factor (0.1%) to cover seams
     }
 
     parseSourceData (tile, source, response) {
         // Convert Mapbox vector tile to GeoJSON
         var data = new Uint8Array(response);
-        var buffer = new this.Protobuf(data);
-        source.data = new this.VectorTile(buffer);
+        var buffer = new Pbf(data);
+        source.data = new VectorTile(buffer);
         source.layers = this.toGeoJSON(source.data);
         delete source.data; // comment out to save raw data for debugging
 
@@ -324,11 +324,11 @@ export class MVTSource extends NetworkTileSource {
                 }
                 geometry.coordinates = coordinates;
 
-                if (this.VectorTileFeature.types[feature.type] === 'Point') {
+                if (VectorTileFeature.types[feature.type] === 'Point') {
                     geometry.type = 'Point';
                     geometry.coordinates = geometry.coordinates[0][0];
                 }
-                else if (this.VectorTileFeature.types[feature.type] === 'LineString') {
+                else if (VectorTileFeature.types[feature.type] === 'LineString') {
                     if (coordinates.length === 1) {
                         geometry.type = 'LineString';
                         geometry.coordinates = geometry.coordinates[0];
@@ -337,7 +337,7 @@ export class MVTSource extends NetworkTileSource {
                         geometry.type = 'MultiLineString';
                     }
                 }
-                else if (this.VectorTileFeature.types[feature.type] === 'Polygon') {
+                else if (VectorTileFeature.types[feature.type] === 'Polygon') {
                     geometry.type = 'Polygon';
                 }
 

--- a/src/data_source.js
+++ b/src/data_source.js
@@ -3,7 +3,9 @@
 import Geo from './geo';
 import {MethodNotImplemented} from './utils/errors';
 import Utils from './utils/utils';
-import log from 'loglevel';
+
+// For TopoJSON tiles
+import topojson from 'topojson';
 
 export default class DataSource {
 
@@ -216,23 +218,6 @@ DataSource.register(GeoJSONTileSource);
 
 /*** Mapzen/OSM.US-style TopoJSON vector tiles ***/
 export class TopoJSONTileSource extends NetworkTileSource {
-
-    constructor (source) {
-        super(source);
-
-        // Loads TopoJSON library from official D3 source on demand
-        // Not including in base library to avoid the extra weight
-        // Only loaded in worker since that is where data is processed
-        if (Utils.isWorkerThread && typeof topojson === 'undefined') {
-            try {
-                importScripts('http://d3js.org/topojson.v1.min.js');
-                log.info('TopoJSONTileSource: loaded topojson library');
-            }
-            catch (e) {
-                log.error('TopoJSONTileSource: failed to load TopoJSON library!');
-            }
-        }
-    }
 
     parseSourceData (tile, source, response) {
         if (typeof topojson === 'undefined') {


### PR DESCRIPTION
Previously we were importing the TopoJSON library with `importScripts()` via the officially hosted D3 endpoint (http://d3js.org/topojson.v1.min.js), but it turns out that doesn't support HTTPS. So, we've opted to just include the library directly, at the cost of 6k minified, but no external network dependency.