### PR TITLE
Build a tile per source per view zoom

### DIFF
--- a/src/data_source.js
+++ b/src/data_source.js
@@ -126,14 +126,13 @@ export class NetworkSource extends DataSource {
             dest.sources = {};
         }
 
-        var source = dest.sources[this.name] = {};
-
-        source.url = url;
-        source.debug = {};
-        source.debug.network = +new Date();
+        let source_data = dest.source_data = {};
+        source_data.url = url;
+        dest.debug = dest.debug || {};
+        dest.debug.network = +new Date();
 
         return new Promise((resolve, reject) => {
-            source.error = null;
+            source_data.error = null;
             // For testing network errors
             // var promise = Utils.io(url, 60 * 100, this.response_type);
             // if (Math.random() < .7) {
@@ -141,17 +140,17 @@ export class NetworkSource extends DataSource {
             // }
             // promise.then((body) => {
             let promise = Utils.io(url, 60 * 1000, this.response_type);
-            source.request = promise.request;
+            source_data.request = promise.request;
 
             promise.then((body) => {
-                source.debug.response_size = body.length || body.byteLength;
-                source.debug.network = +new Date() - source.debug.network;
-                source.debug.parsing = +new Date();
-                this.parseSourceData(dest, source, body);
-                source.debug.parsing = +new Date() - source.debug.parsing;
+                dest.debug.response_size = body.length || body.byteLength;
+                dest.debug.network = +new Date() - dest.debug.network;
+                dest.debug.parsing = +new Date();
+                this.parseSourceData(dest, source_data, body);
+                dest.debug.parsing = +new Date() - dest.debug.parsing;
                 resolve(dest);
             }).catch((error) => {
-                source.error = error.toString();
+                source_data.error = error.toString();
                 resolve(dest); // resolve request but pass along error
             });
         });

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -115,13 +115,10 @@ Utils.isWorkerThread && Object.assign(self, {
                     tile.loaded = false;
                     tile.error = null;
 
-                    self.loadSourcesIntoTile(tile).then(() => {
-                        // Any errors? Warn and continue
-                        let e = Object.keys(tile.sources).
-                            map(s => tile.sources[s].error && `[source '${s}': ${tile.sources[s].error}]`).
-                            filter(x => x);
-                        if (e.length > 0) {
-                            Utils.log('warn', `tile load error(s) for ${tile.key}: ${e.join(', ')}`);
+                    self.loadTileSourceData(tile).then(() => {
+                        // Warn and continue on data source error
+                        if (tile.source_data.error) {
+                            Utils.log('warn', `tile load error(s) for ${tile.key}: ${tile.source_data.error}`);
                         }
 
                         tile.loading = false;
@@ -151,12 +148,9 @@ Utils.isWorkerThread && Object.assign(self, {
         });
     },
 
-    // Load all data sources into a tile
-    loadSourcesIntoTile (tile) {
-        return Promise.all(
-            Object.keys(self.sources.tiles)
-                .map(x => self.sources.tiles[x].load(tile))
-        );
+    // Load this tile's data source
+    loadTileSourceData (tile) {
+        return self.sources.tiles[tile.source].load(tile);
     },
 
     // Remove tile

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -127,7 +127,7 @@ StyleParser.getFeatureParseContext = function (feature, tile) {
     return {
         feature,
         tile,
-        zoom: tile.style_zoom || tile.coords.z,
+        zoom: tile.style_zoom,
         geometry: Geo.geometryType(feature.geometry.type),
         meters_per_pixel: Geo.metersPerPixel(tile.coords.z),
         units_per_meter: Geo.units_per_meter[tile.coords.z]

--- a/test/data_source_spec.js
+++ b/test/data_source_spec.js
@@ -178,7 +178,7 @@ describe('DataSource', () => {
                 });
 
                 it('calls back with the tile object', () => {
-                    assert(Object.keys(mockTile.sources).map(s => mockTile.sources[s].error).filter(x => x).length === 0);
+                    assert(!mockTile.source_data.error);
                     assert.isFulfilled(subject.load(mockTile));
                 });
             });
@@ -197,8 +197,8 @@ describe('DataSource', () => {
                     subject = undefined;
                 });
 
-                it('is resolves the promise but includes an error', () => {
-                    assert(Object.keys(mockTile.sources).map(s => mockTile.sources[s].error).filter(x => x).length > 0);
+                it('resolves the promise but includes an error', () => {
+                    assert(mockTile.source_data.error);
                 });
             });
         });

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -12,7 +12,7 @@ describe('Scene', function () {
 
     beforeEach(() => {
         subject = makeScene({});
-        sinon.stub(subject, 'findVisibleTiles').returns([]);
+        sinon.stub(subject, 'findVisibleTileCoordinates').returns([]);
         subject.setView(nycLatLng);
     });
 

--- a/test/tile_manager_spec.js
+++ b/test/tile_manager_spec.js
@@ -16,7 +16,7 @@ describe('TileManager', function () {
     beforeEach(() => {
         scene = makeScene({});
         TileManager.init(scene);
-        sinon.stub(scene, 'findVisibleTiles').returns([]);
+        sinon.stub(scene, 'findVisibleTileCoordinates').returns([]);
         scene.setView(nycLatLng);
     });
 
@@ -25,25 +25,25 @@ describe('TileManager', function () {
         scene = null;
     });
 
-    describe('.queueTile(coords)', () => {
+    describe('.queueCoordinate(coords)', () => {
 
         let coords = midtownTile;
 
         beforeEach(() => {
-            sinon.spy(TileManager, 'loadTile');
+            sinon.spy(TileManager, 'queueCoordinate');
 
             return scene.init().then(() => {
-                TileManager.queueTile(coords);
-                TileManager.loadQueuedTiles();
+                TileManager.queueCoordinate(coords);
+                TileManager.loadQueuedCoordinates();
             });
         });
 
-        it('calls loadTile with the queued tile', () => {
-            sinon.assert.calledWith(TileManager.loadTile, coords);
+        it('calls queueCoordinate with the queued tile', () => {
+            sinon.assert.calledWith(TileManager.queueCoordinate, coords);
         });
     });
 
-    describe('.loadTile(coords, options)', () => {
+    describe('.loadCoordinate(coords)', () => {
 
         let coords = midtownTile;
 
@@ -53,27 +53,36 @@ describe('TileManager', function () {
 
         describe('when the tile manager has not loaded the tile', () => {
 
-            it('loads the tile', () => {
-                let tile = TileManager.loadTile(coords);
+            let tile, tiles;
+
+            beforeEach(() => {
+                TileManager.loadCoordinate(coords);
+                tiles = TileManager.tiles;
+                tile = tiles[Object.keys(tiles)[0]];
+            });
+
+            it('loads and keeps the tile', () => {
+                TileManager.loadCoordinate(coords);
+                assert.isTrue(Object.keys(tiles).length === 1);
                 assert.instanceOf(tile, Tile);
             });
 
-            it('keeps the tile', () => {
-                let tile = TileManager.loadTile(coords);
-                let tiles = TileManager.tiles;
-                assert.instanceOf(tiles[tile.key], Tile);
-            });
         });
 
         describe('when the tile manager already has the tile', () => {
             let key = midtownTileKey;
-            let tile;
+            let tile, tiles;
 
             beforeEach(() => {
-                TileManager.loadTile(coords);
+                TileManager.loadCoordinate(coords);
+
+                tiles = TileManager.tiles;
+                tile = tiles[Object.keys(tiles)[0]];
+
                 sinon.spy(TileManager, 'keepTile');
-                tile = TileManager.loadTile(coords);
                 sinon.spy(tile, 'build');
+
+                TileManager.loadCoordinate(coords);
             });
 
             afterEach(() => {


### PR DESCRIPTION
Revamps how multiple data sources are handled.

Previously: all sources were combined into a single tile object. This didn't allow sources with differing maximum zooms to mix well (all sources were artificially limited to the lowest source max zoom). It also wasn't possible to apply different styles to a source past its max zoom (since it was only built once at the max zoom and then that tile displayed at higher zooms).

Now: internally, tiles are built per source per view zoom, which means that sources can be mixed more easily, and style rules can be applied past the max zoom (separate tile VBOs are built for the higher zooms). This also opens the door to selectively rebuild tiles by source, which will be useful for more dynamic sources (see the road filtering demo for an example).
