### PR TITLE
Recover from failed scene config loads

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -131,10 +131,8 @@ if (Utils.isMainThread) {
 
             // Use leaflet's existing event system as the callback mechanism
             this.scene.load().then(() => {
-                log.debug('Scene.load() completed');
                 this.fire('init');
             }).catch(error => {
-                log.error(`Scene.load() failed: ${error.message}`, error);
                 this.fire('error', error);
             });
         },

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -130,11 +130,11 @@ if (Utils.isMainThread) {
             });
 
             // Use leaflet's existing event system as the callback mechanism
-            this.scene.init().then(() => {
-                log.debug('Scene.init() succeeded');
+            this.scene.load().then(() => {
+                log.debug('Scene.load() completed');
                 this.fire('init');
             }).catch(error => {
-                log.error(`Scene.init() failed: ${error.message}`, error);
+                log.error(`Scene.load() failed: ${error.message}`, error);
                 this.fire('error', error);
             });
         },

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -1,8 +1,6 @@
 import Utils from './utils/utils';
 import Scene from './scene';
 
-import log from 'loglevel';
-
 // Exports must appear outside a function, but will only be defined in main thread (below)
 export var LeafletLayer;
 export function leafletLayer(options) {

--- a/src/module.js
+++ b/src/module.js
@@ -83,6 +83,6 @@ var originalFactory = log.methodFactory;
 log.methodFactory = function (methodName, logLevel) {
     var rawMethod = originalFactory(methodName, logLevel);
     return function (...message) {
-        rawMethod(`Tangram ${version.string}: `, ...message);
+        rawMethod(`Tangram ${version.string}:`, ...message);
     };
 };

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -14,6 +14,8 @@ export var SceneWorker = self;
 // Worker functionality will only be defined in worker thread
 Utils.isWorkerThread && Object.assign(self, {
 
+    FeatureSelection,
+
     sources: {
         tiles: {},
         objects: {}

--- a/src/selection.js
+++ b/src/selection.js
@@ -40,6 +40,16 @@ export default class FeatureSelection {
         this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
     }
 
+    destroy() {
+        if (this.gl && this.fbo) {
+            this.gl.deleteFramebuffer(this.fbo);
+            this.fbo = null;
+            this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+        }
+
+        // TODO: free texture?
+    }
+
     bind() {
         // Switch to FBO
         this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.fbo);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -31,7 +31,7 @@ function loadWorkerContent(url) {
 
 let workerBody = loadWorkerContent(worker_url);
 
-sinon.stub(Scene.prototype, 'loadWorkerUrl').returns(Promise.resolve(
+sinon.stub(Scene.prototype, 'getWorkerUrl').returns(Promise.resolve(
     URL.createObjectURL(new Blob([workerBody], { type: 'application/javascript' }))
 ));
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -31,9 +31,9 @@ function loadWorkerContent(url) {
 
 let workerBody = loadWorkerContent(worker_url);
 
-sinon.stub(Scene.prototype, 'getWorkerUrl').returns(Promise.resolve(
+sinon.stub(Scene.prototype, 'getWorkerUrl').returns(
     URL.createObjectURL(new Blob([workerBody], { type: 'application/javascript' }))
-));
+);
 
 let container = document.createElement('div');
 container.style.width = '250px';

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -51,7 +51,7 @@ describe('Leaflet plugin', () => {
             sinon.spy(map, 'getContainer');
             sinon.spy(subject.scene, 'load');
 
-            subject.on('load', () => {
+            subject.on('init', () => {
                 done();
             });
 

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -49,9 +49,9 @@ describe('Leaflet plugin', () => {
         beforeEach(function (done) {
             subject = makeOne();
             sinon.spy(map, 'getContainer');
-            sinon.spy(subject.scene, 'init');
+            sinon.spy(subject.scene, 'load');
 
-            subject.on('init', () => {
+            subject.on('load', () => {
                 done();
             });
 
@@ -69,7 +69,7 @@ describe('Leaflet plugin', () => {
         });
 
         it('initializes the scene', () => {
-            sinon.assert.called(subject.scene.init);
+            sinon.assert.called(subject.scene.load);
         });
 
     });

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -38,12 +38,12 @@ describe('Scene', function () {
 
     });
 
-    describe('.init()', () => {
+    describe('.load()', () => {
 
-        describe('when the scene is not initialized', () => {
+        describe('when the scene is not loaded', () => {
 
             beforeEach(() => {
-                return subject.init();
+                return subject.load();
             });
 
             it('correctly sets the value of the data source', () => {
@@ -76,9 +76,9 @@ describe('Scene', function () {
 
         describe('when the scene is already initialized', () => {
 
-            it('handles second init() call', () => {
-                return subject.init().then(() => {
-                    return subject.init();
+            it('handles second load() call', () => {
+                return subject.load().then(() => {
+                    return subject.load();
                 });
             });
 
@@ -94,7 +94,7 @@ describe('Scene', function () {
 
         beforeEach(() => {
             subject.device_pixel_ratio = devicePixelRatio;
-            return subject.init().then(() => {
+            return subject.load().then(() => {
                 sinon.spy(subject.gl, 'bindFramebuffer');
                 sinon.spy(subject.gl, 'viewport');
                 Utils.device_pixel_ratio = devicePixelRatio;
@@ -203,7 +203,7 @@ describe('Scene', function () {
             sinon.spy(subject, 'render');
 
             subject.setView(nycLatLng);
-            return subject.init();
+            return subject.load();
         });
 
         describe('when the scene is not dirty', () => {
@@ -243,7 +243,7 @@ describe('Scene', function () {
     describe('.updateStyles()', () => {
 
         beforeEach(() => {
-            return subject.init();
+            return subject.load();
         });
 
         describe('when a new style is added', () => {

--- a/test/tile_manager_spec.js
+++ b/test/tile_manager_spec.js
@@ -32,7 +32,7 @@ describe('TileManager', function () {
         beforeEach(() => {
             sinon.spy(TileManager, 'queueCoordinate');
 
-            return scene.init().then(() => {
+            return scene.load().then(() => {
                 TileManager.queueCoordinate(coords);
                 TileManager.loadQueuedCoordinates();
             });
@@ -48,7 +48,7 @@ describe('TileManager', function () {
         let coords = midtownTile;
 
         beforeEach(() => {
-            return scene.init();
+            return scene.load();
         });
 
         describe('when the tile manager has not loaded the tile', () => {

--- a/test/tile_spec.js
+++ b/test/tile_spec.js
@@ -16,7 +16,7 @@ describe('Tile', function() {
         TileManager.init(scene);
         sinon.stub(scene, 'findVisibleTileCoordinates').returns([]);
         scene.setView(nycLatLng);
-        return scene.init().then(() => {
+        return scene.load().then(() => {
             subject = Tile.create({coords, style_zoom: coords.z, source: scene.sources.osm, worker: scene.nextWorker()});
         });
     });


### PR DESCRIPTION
Previously, if the scene failed to load a config file, it would end up in an un-initialized state that it was usually not able to recover from.

Now, it is reliable to call `Scene.load(config)` multiple times, including when previous calls failed. In addition, if a config fails to load, but there is a previously valid config available, the scene will revert to the previous valid configuration (think of cases like an interactive editor where several config states may be loaded in succession, some valid and some not).