### PR TITLE
Label priority

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -461,3 +461,18 @@ layers:
                     typeface: Italic 10pt Lucida Grande
                     fill: darkgreen
                     stroke: { color: white, width: 3 }
+
+    # building_labels:
+    #     data: { source: osm, layer: buildings }
+    #     filter:
+    #         name: true
+    #         any:
+    #             - { $zoom: { min: 17 }, height: { min: 50 } }
+    #             - $zoom: { min: 18 }
+    #     draw:
+    #         text:
+    #             priority: 6
+    #             font:
+    #                 typeface: 8pt Lucida Grande
+    #                 fill: darkred
+    #                 stroke: { color: white, width: 3 }

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -318,34 +318,31 @@ layers:
             filter: { kind: highway, $zoom: { min: 7 } }
             draw:
                 text:
+                    priority: 2
                     font:
                         fill: '#666'
-                        typeface: 100 12px Helvetica
+                        typeface: 12px Helvetica
                         stroke: { color: white, width: 4 }
 
         not_highway:
             filter: { not: { kind: highway }, $zoom: { min: 13 } }
             draw:
                 text:
+                    priority: 5
                     font:
                         fill: '#666'
                         stroke: { color: white, width: 4 }
-                        typeface: 100 12px Helvetica
+                        typeface: 12px Helvetica
 
             major_road:
                 filter: { kind: major_road, $zoom: { min: 14 } }
                 draw:
                     text:
+                        priority: 3
                         font:
-                            typeface: 100 16px Helvetica
+                            typeface: 16px Helvetica
                             stroke: { color: white, width: 4 }
-            minor_road:
-                filter: { kind: minor_road, railway: false, $zoom: { min: 15 } }
-                draw:
-                    text:
-                        font:
-                            typeface: 100 12px Helvetica
-                            stroke: { color: white, width: 4 }
+
             small:
                 filter: { highway: [residential, unclassified], $zoom: { max: 15 } }
                 visible: false
@@ -409,6 +406,7 @@ layers:
                 - function() { return (feature.scalerank * .75) <= ($zoom - 4); }
         draw:
             text:
+                priority: 1
                 font:
                     typeface: italic 11pt Helvetica
                     fill: black
@@ -458,6 +456,7 @@ layers:
                 - { $zoom: { min: 18 } }
         draw:
             text:
+                priority: 4
                 font:
                     typeface: Italic 10pt Lucida Grande
                     fill: darkgreen

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -27,8 +27,6 @@ Object.assign(TextStyle, {
             WorkerBroker.addTarget('TextStyle', this);
         }
 
-        this.max_priority = 0;
-
         // Point style (parent class) requires texturing to be turned on
         // (labels are always drawn with textures)
         this.defines.TANGRAM_POINT_TEXTURE = true;
@@ -42,12 +40,6 @@ Object.assign(TextStyle, {
 
         // default label style
         this.label_style = {
-            priorities: {
-                administrative: 4,
-                major_road: 3,
-                minor_road: 2,
-                restaurant: 1,
-            },
             lines: {
                 exceed: 80,
                 offset: 0
@@ -328,7 +320,7 @@ Object.assign(TextStyle, {
     },
 
     createLabels (tile, texts) {
-        let labels_priorities = [];
+        let labels_priorities = {};
 
         if (!this.features[tile]) {
             return;
@@ -394,7 +386,9 @@ Object.assign(TextStyle, {
         this.bboxes[tile] = [];
         this.feature_labels[tile] = new Map();
 
-        for (let priority = this.max_priority; priority >= 0; priority--) {
+        // Process labels by priority
+        let priorities = Object.keys(labels).sort((a, b) => a - b);
+        for (let priority of priorities) {
             if (!labels[priority]) {
                 continue;
             }
@@ -523,12 +517,7 @@ Object.assign(TextStyle, {
                 this.texts[tile.key][style_key] = {};
             }
 
-            let priority = 0;
-            if (this.label_style.priorities[feature.properties.kind]) {
-                priority = this.label_style.priorities[feature.properties.kind];
-            }
-
-            this.max_priority = Math.max(priority, this.max_priority);
+            let priority = (rule.priority !== undefined) ? parseFloat(rule.priority) : -1 >>> 0;
 
             if (!this.texts[tile.key][style_key][text]) {
                 this.texts[tile.key][style_key][text] = {


### PR DESCRIPTION
Adds the ability to specify label priority in draw rules in the scene file. This is done through the `priority` field. For example, to set different priorities on `places` vs. `landuse_labels` layers:

```
    places:
        data: { source: osm }
        draw:
            text:
                priority: 1
                font:
                    typeface: italic 11pt Helvetica
                    fill: black

    landuse_labels:
        data: { source: osm }
        draw:
            text:
                priority: 2
                font:
                    typeface: Italic 10pt Lucida Grande
                    fill: darkgreen
```

@sensescape @nvkelso @meetar:
Currently, **lower** priority values take precedence over higher ones. So `priority: 1` labels will be drawn before `priority: 2` labels. In English, I usually think of something that is "priority one" as being more important than something that is "priority two". On the other hand, "high priority" could also imply a higher number :) 

However, the current behavior is opposite of how our `order` field works, which is more a painter's style approach, where higher `order` value geometries are drawn on top of those with lower `order` values. We could leave `priority` as is, or make them consistent (for what it's worth, it's easier to insert important labels later on by simply giving them a higher priority value, vs. having to go back and re-number everything, so there are arguments both ways).

Feedback on which makes most sense and/or will be easiest to work with?
