### PR TITLE
Inlay blending mode

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -662,6 +662,11 @@ export default class Scene {
         this.setRenderState({ depth_test: true, depth_write: false, alpha_blend: (allow_alpha_blend && 'multiply') });
         count += this.renderStyles(styles, program_key);
 
+        // Inlay styles: depth test on, depth write off, blending on
+        styles = Object.keys(this.styles).filter(s => this.styles[s].blend === 'inlay');
+        this.setRenderState({ depth_test: true, depth_write: false, alpha_blend: allow_alpha_blend });
+        count += this.renderStyles(styles, program_key);
+
         // Overlay styles: depth test off, depth write off, blending on
         styles = Object.keys(this.styles).filter(s => this.styles[s].blend === 'overlay');
         this.setRenderState({ depth_test: false, depth_write: false, alpha_blend: allow_alpha_blend });


### PR DESCRIPTION
In some cases, it may be desirable to let labels, icons, or other items drawn with full alpha blending be occluded by other objects, such as buildings.

This branch adds a blending mode for that, called `inlay` (as opposed to `overlay`). The inlay blend has depth test on, but depth write off. This means that the inlay geometry is appropriately depth-positioned with regard to any previously drawn geometry, but will not guarantee correct depth between other geometry drawn with the inlay mode (e.g., multiple inlay geometries will overlay each other).

### Labels with `blend: overlay`

![tangram-1435027367572 1](https://cloud.githubusercontent.com/assets/16733/8394295/a7d1389c-1cfe-11e5-99a0-d8b50929f722.png)

### Labels with `blend: inlay`

![tangram-1435027416750 1](https://cloud.githubusercontent.com/assets/16733/8394296/aa8011f8-1cfe-11e5-89c1-f5ca4914b757.png)