### PR TITLE
Pack vertex attributes

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -558,7 +558,7 @@ Builders.buildQuadsForPoints = function (
     width, height, angle, scale,
     vertex_data, vertex_template,
     scaling_index,
-    { texcoord_index, texcoord_scale }) {
+    { texcoord_index, texcoord_scale, texcoord_normalize }) {
 
     let w2 = width / 2;
     let h2 = height / 2;
@@ -572,9 +572,11 @@ Builders.buildQuadsForPoints = function (
         [-w2, h2]
     ];
 
-    let [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
     let texcoords;
     if (texcoord_index) {
+        texcoord_normalize = texcoord_normalize || 1;
+
+        let [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
         texcoords = [
             [min_u, min_v],
             [max_u, min_v],
@@ -593,8 +595,8 @@ Builders.buildQuadsForPoints = function (
         for (let pos=0; pos < 6; pos++) {
             // Add texcoords
             if (texcoord_index) {
-                vertex_template[texcoord_index + 0] = texcoords[pos][0];
-                vertex_template[texcoord_index + 1] = texcoords[pos][1];
+                vertex_template[texcoord_index + 0] = texcoords[pos][0] * texcoord_normalize;
+                vertex_template[texcoord_index + 1] = texcoords[pos][1] * texcoord_normalize;
             }
 
             vertex_template[0] = point[0];

--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -169,6 +169,7 @@ Builders.buildPolylines = function (
         texcoord_scale,
         texcoord_normalize,
         scaling_index,
+        scaling_normalize,
         join, cap
     }) {
 
@@ -186,6 +187,7 @@ Builders.buildPolylines = function (
         halfWidth: width/2,
         vertices: [],
         scaling_index,
+        scaling_normalize,
         scalingVecs: scaling_index && [],
         texcoord_index,
         texcoords: texcoord_index && [],
@@ -499,7 +501,7 @@ function addCap (coord, normal, numCorners, isBeginning, constants) {
 }
 
 // Add a vertex based on the index position into the VBO (internal method for polyline builder)
-function addIndex (index, { vertex_data, vertex_template, halfWidth, vertices, scaling_index, scalingVecs, texcoord_index, texcoords, texcoord_normalize }) {
+function addIndex (index, { vertex_data, vertex_template, halfWidth, vertices, scaling_index, scaling_normalize, scalingVecs, texcoord_index, texcoords, texcoord_normalize }) {
     // Prevent access to undefined vertices
     if (index >= vertices.length) {
         return;
@@ -517,9 +519,9 @@ function addIndex (index, { vertex_data, vertex_template, halfWidth, vertices, s
 
     // set Scaling vertex (X, Y normal direction + Z haltwidth as attribute)
     if (scaling_index) {
-        vertex_template[scaling_index + 0] = scalingVecs[index][0];
-        vertex_template[scaling_index + 1] = scalingVecs[index][1];
-        vertex_template[scaling_index + 2] = halfWidth;
+        vertex_template[scaling_index + 0] = scalingVecs[index][0] * scaling_normalize;
+        vertex_template[scaling_index + 1] = scalingVecs[index][1] * scaling_normalize;
+        vertex_template[scaling_index + 2] = halfWidth * scaling_normalize;
     }
 
     //  Add vertex to VBO

--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -166,6 +166,7 @@ Builders.buildPolylines = function (
         tile_edge_tolerance,
         texcoord_index,
         texcoord_scale,
+        texcoord_normalize,
         scaling_index,
         join, cap
     }) {
@@ -174,6 +175,7 @@ Builders.buildPolylines = function (
     var trianglesOnJoin = (join === "bevel") ? 1 : ((join === "round") ? 3 : 0);  // Miter is the implicit default
 
     // Build variables
+    texcoord_normalize = texcoord_normalize || 1;
     var [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
 
     // Values that are constant for each line and are passed to helper functions
@@ -186,6 +188,7 @@ Builders.buildPolylines = function (
         scalingVecs: scaling_index && [],
         texcoord_index,
         texcoords: texcoord_index && [],
+        texcoord_normalize,
         min_u, min_v, max_u, max_v,
         nPairs: 0
     };
@@ -495,7 +498,7 @@ function addCap (coord, normal, numCorners, isBeginning, constants) {
 }
 
 // Add a vertex based on the index position into the VBO (internal method for polyline builder)
-function addIndex (index, { vertex_data, vertex_template, halfWidth, vertices, scaling_index, scalingVecs, texcoord_index, texcoords }) {
+function addIndex (index, { vertex_data, vertex_template, halfWidth, vertices, scaling_index, scalingVecs, texcoord_index, texcoords, texcoord_normalize }) {
     // Prevent access to undefined vertices
     if (index >= vertices.length) {
         return;
@@ -507,8 +510,8 @@ function addIndex (index, { vertex_data, vertex_template, halfWidth, vertices, s
 
     // set UVs
     if (texcoord_index) {
-        vertex_template[texcoord_index + 0] = texcoords[index][0];
-        vertex_template[texcoord_index + 1] = texcoords[index][1];
+        vertex_template[texcoord_index + 0] = texcoords[index][0] * texcoord_normalize;
+        vertex_template[texcoord_index + 1] = texcoords[index][1] * texcoord_normalize;
     }
 
     // set Scaling vertex (X, Y normal direction + Z haltwidth as attribute)

--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -83,6 +83,7 @@ Builders.buildExtrudedPolygons = function (
     z, height, min_height,
     vertex_data, vertex_template,
     normal_index,
+    normal_normalize,
     { texcoord_index, texcoord_scale, texcoord_normalize }) {
 
     // Top
@@ -134,9 +135,9 @@ Builders.buildExtrudedPolygons = function (
                 );
 
                 // Update vertex template with current surface normal
-                vertex_template[normal_index + 0] = normal[0];
-                vertex_template[normal_index + 1] = normal[1];
-                vertex_template[normal_index + 2] = normal[2];
+                vertex_template[normal_index + 0] = normal[0] * normal_normalize;
+                vertex_template[normal_index + 1] = normal[1] * normal_normalize;
+                vertex_template[normal_index + 2] = normal[2] * normal_normalize;
 
                 for (var wv=0; wv < wall_vertices.length; wv++) {
                     vertex_template[0] = wall_vertices[wv][0];

--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -36,9 +36,13 @@ Builders.getTexcoordsForSprite = function (area_origin, area_size, tex_size) {
 Builders.buildPolygons = function (
     polygons,
     vertex_data, vertex_template,
-    { texcoord_index, texcoord_scale }) {
+    { texcoord_index, texcoord_scale, texcoord_normalize }) {
 
-    var [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
+    if (texcoord_index) {
+        texcoord_normalize = texcoord_normalize || 1;
+        var [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
+    }
+
     var num_polygons = polygons.length;
     for (var p=0; p < num_polygons; p++) {
         var polygon = polygons[p];
@@ -64,8 +68,8 @@ Builders.buildPolygons = function (
 
             // Add UVs
             if (texcoord_index) {
-                vertex_template[texcoord_index + 0] = (vertex[0] - min_x) * scale_u + min_u;
-                vertex_template[texcoord_index + 1] = (vertex[1] - min_y) * scale_v + min_v;
+                vertex_template[texcoord_index + 0] = ((vertex[0] - min_x) * scale_u + min_u) * texcoord_normalize;
+                vertex_template[texcoord_index + 1] = ((vertex[1] - min_y) * scale_v + min_v) * texcoord_normalize;
             }
 
             vertex_data.addVertex(vertex_template);
@@ -79,18 +83,19 @@ Builders.buildExtrudedPolygons = function (
     z, height, min_height,
     vertex_data, vertex_template,
     normal_index,
-    { texcoord_index, texcoord_scale }) {
+    { texcoord_index, texcoord_scale, texcoord_normalize }) {
 
     // Top
     var min_z = z + (min_height || 0);
     var max_z = z + height;
     vertex_template[2] = max_z;
-    Builders.buildPolygons(polygons, vertex_data, vertex_template, { texcoord_index });
+    Builders.buildPolygons(polygons, vertex_data, vertex_template, { texcoord_index, texcoord_scale, texcoord_normalize });
 
     // Walls
     // Fit UVs to wall quad
-    var [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
     if (texcoord_index) {
+        texcoord_normalize = texcoord_normalize || 1;
+        var [[min_u, min_v], [max_u, max_v]] = texcoord_scale || [[0, 0], [1, 1]];
         var texcoords = [
             [min_u, max_v],
             [min_u, min_v],
@@ -139,8 +144,8 @@ Builders.buildExtrudedPolygons = function (
                     vertex_template[2] = wall_vertices[wv][2];
 
                     if (texcoord_index) {
-                        vertex_template[texcoord_index + 0] = texcoords[wv][0];
-                        vertex_template[texcoord_index + 1] = texcoords[wv][1];
+                        vertex_template[texcoord_index + 0] = texcoords[wv][0] * texcoord_normalize;
+                        vertex_template[texcoord_index + 1] = texcoords[wv][1] * texcoord_normalize;
                     }
 
                     vertex_data.addVertex(vertex_template);

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -23,8 +23,7 @@ Object.assign(Lines, {
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
             { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
-            { name: 'a_extrude', size: 3, type: gl.FLOAT, normalized: false },
-            { name: 'a_scale', size: 1, type: gl.SHORT, normalized: true },
+            { name: 'a_extrude', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
             { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
@@ -169,7 +168,7 @@ Object.assign(Lines, {
         // extrusion vector
         this.vertex_template[4] = 0;
         this.vertex_template[5] = 0;
-        this.vertex_template[6] = 1;
+        this.vertex_template[6] = 0;
 
         // scaling to previous and next zoom
         this.vertex_template[7] = style.next_width;
@@ -209,9 +208,10 @@ Object.assign(Lines, {
                     cap: style.cap,
                     join: style.join,
                     scaling_index: this.vertex_layout.index.a_extrude,
+                    scaling_normalize: Utils.scaleInt16(1, 256), // scale extrusion normals to signed shorts w/256 unit basis
                     texcoord_index: this.vertex_layout.index.a_texcoord,
                     texcoord_scale: this.texcoord_scale,
-                    texcoord_normalize: 65535,
+                    texcoord_normalize: 65535, // scale UVs to unsigned shorts
                     closed_polygon: options && options.closed_polygon,
                     remove_tile_edges: !style.tile_edges && options && options.remove_tile_edges
                 }

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -15,7 +15,7 @@ Object.assign(Lines, {
     built_in: true,
     vertex_shader_key: 'styles/polygons/polygons_vertex', // re-use polygon shaders
     fragment_shader_key: 'styles/polygons/polygons_fragment',
-    selection: true,
+    selection: true, // turn feature selection on
 
     init() {
         Style.init.apply(this, arguments);
@@ -24,13 +24,17 @@ Object.assign(Lines, {
         var attribs = [
             { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_extrude', size: 4, type: gl.SHORT, normalized: true },
-            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
+            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
 
         // Tell the shader we want a order in vertex attributes, and to extrude lines
         this.defines.TANGRAM_LAYER_ORDER = true;
         this.defines.TANGRAM_EXTRUDE_LINES = true;
+
+        // Optional feature selection
+        if (this.selection) {
+            attribs.push({ name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true });
+        }
 
         // Optional texture UVs
         if (this.texcoords) {
@@ -157,38 +161,42 @@ Object.assign(Lines, {
      * A plain JS array matching the order of the vertex layout.
      */
     makeVertexTemplate(style) {
+        let i = 0;
+
         // position - x & y coords will be filled in per-vertex below
-        this.vertex_template[0] = 0;
-        this.vertex_template[1] = 0;
-        this.vertex_template[2] = style.z || 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = style.z || 0;
 
         // layer order - w coord of 'position' attribute (for packing efficiency)
-        this.vertex_template[3] = style.order;
+        this.vertex_template[i++] = style.order;
 
         // extrusion vector
-        this.vertex_template[4] = 0;
-        this.vertex_template[5] = 0;
-        this.vertex_template[6] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
 
         // scaling to previous and next zoom
-        this.vertex_template[7] = style.next_width;
+        this.vertex_template[i++] = style.next_width;
 
         // color
-        this.vertex_template[8] = style.color[0] * 255;
-        this.vertex_template[9] = style.color[1] * 255;
-        this.vertex_template[10] = style.color[2] * 255;
-        this.vertex_template[11] = style.color[3] * 255;
+        this.vertex_template[i++] = style.color[0] * 255;
+        this.vertex_template[i++] = style.color[1] * 255;
+        this.vertex_template[i++] = style.color[2] * 255;
+        this.vertex_template[i++] = style.color[3] * 255;
 
         // selection color
-        this.vertex_template[12] = style.selection_color[0] * 255;
-        this.vertex_template[13] = style.selection_color[1] * 255;
-        this.vertex_template[14] = style.selection_color[2] * 255;
-        this.vertex_template[15] = style.selection_color[3] * 255;
+        if (this.selection) {
+            this.vertex_template[i++] = style.selection_color[0] * 255;
+            this.vertex_template[i++] = style.selection_color[1] * 255;
+            this.vertex_template[i++] = style.selection_color[2] * 255;
+            this.vertex_template[i++] = style.selection_color[3] * 255;
+        }
 
         // Add texture UVs to template only if needed
         if (this.texcoords) {
-            this.vertex_template[16] = 0;
-            this.vertex_template[17] = 0;
+            this.vertex_template[i++] = 0;
+            this.vertex_template[i++] = 0;
         }
 
         return this.vertex_template;

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -39,7 +39,7 @@ Object.assign(Lines, {
             this.defines.TANGRAM_TEXTURE_COORDS = true;
 
             // Add vertex attribute for UVs only when needed
-            attribs.push({ name: 'a_texcoord', size: 2, type: gl.FLOAT, normalized: false });
+            attribs.push({ name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true });
         }
 
         this.vertex_layout = new VertexLayout(attribs);
@@ -212,6 +212,7 @@ Object.assign(Lines, {
                     scaling_index: this.vertex_layout.index.a_extrude,
                     texcoord_index: this.vertex_layout.index.a_texcoord,
                     texcoord_scale: this.texcoord_scale,
+                    texcoord_normalize: 65535,
                     closed_polygon: options && options.closed_polygon,
                     remove_tile_edges: !style.tile_edges && options && options.remove_tile_edges
                 }

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -22,16 +22,15 @@ Object.assign(Lines, {
 
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
-            { name: 'a_position', size: 3, type: gl.SHORT, normalized: true },
+            { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_extrude', size: 3, type: gl.FLOAT, normalized: false },
             { name: 'a_scale', size: 1, type: gl.SHORT, normalized: true },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_layer', size: 1, type: gl.FLOAT, normalized: false }
+            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
 
-        // Tell the shader we want an order attribute, and to extrude lines
-        this.defines.TANGRAM_ORDER_ATTRIBUTE = true;
+        // Tell the shader we want a order in vertex attributes, and to extrude lines
+        this.defines.TANGRAM_LAYER_ORDER = true;
         this.defines.TANGRAM_EXTRUDE_LINES = true;
 
         // Optional texture UVs
@@ -164,28 +163,28 @@ Object.assign(Lines, {
         this.vertex_template[1] = 0;
         this.vertex_template[2] = style.z || 0;
 
+        // layer order - w coord of 'position' attribute (for packing efficiency)
+        this.vertex_template[3] = style.order;
+
         // extrusion vector
-        this.vertex_template[3] = 0;
         this.vertex_template[4] = 0;
-        this.vertex_template[5] = 1;
+        this.vertex_template[5] = 0;
+        this.vertex_template[6] = 1;
 
         // scaling to previous and next zoom
-        this.vertex_template[6] = style.next_width;
+        this.vertex_template[7] = style.next_width;
 
         // color
-        this.vertex_template[7] = style.color[0] * 255;
-        this.vertex_template[8] = style.color[1] * 255;
-        this.vertex_template[9] = style.color[2] * 255;
-        this.vertex_template[10] = style.color[3] * 255;
+        this.vertex_template[8] = style.color[0] * 255;
+        this.vertex_template[9] = style.color[1] * 255;
+        this.vertex_template[10] = style.color[2] * 255;
+        this.vertex_template[11] = style.color[3] * 255;
 
         // selection color
-        this.vertex_template[11] = style.selection_color[0] * 255;
-        this.vertex_template[12] = style.selection_color[1] * 255;
-        this.vertex_template[13] = style.selection_color[2] * 255;
-        this.vertex_template[14] = style.selection_color[3] * 255;
-
-        // layer order
-        this.vertex_template[15] = style.order;
+        this.vertex_template[12] = style.selection_color[0] * 255;
+        this.vertex_template[13] = style.selection_color[1] * 255;
+        this.vertex_template[14] = style.selection_color[2] * 255;
+        this.vertex_template[15] = style.selection_color[3] * 255;
 
         // Add texture UVs to template only if needed
         if (this.texcoords) {

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -22,7 +22,7 @@ Object.assign(Lines, {
 
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
-            { name: 'a_position', size: 3, type: gl.FLOAT, normalized: false },
+            { name: 'a_position', size: 3, type: gl.SHORT, normalized: true },
             { name: 'a_extrude', size: 3, type: gl.FLOAT, normalized: false },
             { name: 'a_scale', size: 1, type: gl.SHORT, normalized: true },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -30,7 +30,7 @@ Object.assign(Points, {
             { name: 'a_shape', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
             { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_texcoord', size: 2, type: gl.FLOAT, normalized: false } // TODO: pack into shorts
+            { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true }
         ];
 
         // If we're not rendering as overlay, we need a layer attribute
@@ -181,7 +181,11 @@ Object.assign(Points, {
             vertex_data,
             vertex_template,
             this.vertex_layout.index.a_shape,
-            { texcoord_index: this.vertex_layout.index.a_texcoord, texcoord_scale: this.texcoord_scale }
+            {
+                texcoord_index: this.vertex_layout.index.a_texcoord,
+                texcoord_scale: this.texcoord_scale,
+                texcoord_normalize: 65535
+            }
         );
     },
 

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -26,7 +26,7 @@ Object.assign(Points, {
         this.fragment_shader_key = 'styles/points/points_fragment';
 
         var attribs = [
-            { name: 'a_position', size: 3, type: gl.SHORT, normalized: true },
+            { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_shape', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
             { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
@@ -35,8 +35,7 @@ Object.assign(Points, {
 
         // If we're not rendering as overlay, we need a layer attribute
         if (this.blend !== 'overlay') {
-            this.defines.TANGRAM_ORDER_ATTRIBUTE = true;
-            attribs.push({ name: 'a_layer', size: 1, type: gl.FLOAT, normalized: false });
+            this.defines.TANGRAM_LAYER_ORDER = true;
         }
 
         this.vertex_layout = new VertexLayout(attribs);
@@ -133,32 +132,35 @@ Object.assign(Points, {
         this.vertex_template[1] = 0;
         this.vertex_template[2] = style.z || 0;
 
+        // layer order (if needed) - w coord of 'position' attribute (for packing efficiency)
+        if (this.defines.TANGRAM_LAYER_ORDER) {
+            this.vertex_template[3] = style.order;
+        }
+        else {
+            this.vertex_template[3] = 0;
+        }
+
         // scaling vector - (x, y) components per pixel, z = angle, w = scaling factor
-        this.vertex_template[3] = 0;
         this.vertex_template[4] = 0;
         this.vertex_template[5] = 0;
         this.vertex_template[6] = 0;
+        this.vertex_template[7] = 0;
 
         // color
-        this.vertex_template[7] = color[0] * 255;
-        this.vertex_template[8] = color[1] * 255;
-        this.vertex_template[9] = color[2] * 255;
-        this.vertex_template[10] = color[3] * 255;
+        this.vertex_template[8] = color[0] * 255;
+        this.vertex_template[9] = color[1] * 255;
+        this.vertex_template[10] = color[2] * 255;
+        this.vertex_template[11] = color[3] * 255;
 
         // selection color
-        this.vertex_template[11] = style.selection_color[0] * 255;
-        this.vertex_template[12] = style.selection_color[1] * 255;
-        this.vertex_template[13] = style.selection_color[2] * 255;
-        this.vertex_template[14] = style.selection_color[3] * 255;
+        this.vertex_template[12] = style.selection_color[0] * 255;
+        this.vertex_template[13] = style.selection_color[1] * 255;
+        this.vertex_template[14] = style.selection_color[2] * 255;
+        this.vertex_template[15] = style.selection_color[3] * 255;
 
         // texture coords
-        this.vertex_template[15] = 0;
         this.vertex_template[16] = 0;
-
-        // Add layer attribute if needed
-        if (this.defines.TANGRAM_ORDER_ATTRIBUTE) {
-            this.vertex_template[17] = style.order;
-        }
+        this.vertex_template[17] = 0;
 
         return this.vertex_template;
     },

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -15,7 +15,7 @@ export var Points = Object.create(Style);
 Object.assign(Points, {
     name: 'points',
     built_in: true,
-    selection: true,
+    selection: true, // turn feature selection on
     blend: 'overlay', // overlays drawn on top of all other styles, with blending
 
     init(options = {}) {
@@ -28,10 +28,14 @@ Object.assign(Points, {
         var attribs = [
             { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_shape', size: 4, type: gl.SHORT, normalized: true },
-            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true }
+            { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true },
+            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
+
+        // Optional feature selection
+        if (this.selection) {
+            attribs.push({ name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true });
+        }
 
         // If we're not rendering as overlay, we need a layer attribute
         if (this.blend !== 'overlay') {
@@ -125,42 +129,40 @@ Object.assign(Points, {
      * A plain JS array matching the order of the vertex layout.
      */
     makeVertexTemplate(style) {
-        var color = style.color || StyleParser.defaults.color;
+        let i = 0;
+        let color = style.color || StyleParser.defaults.color;
 
         // position - x & y coords will be filled in per-vertex below
-        this.vertex_template[0] = 0;
-        this.vertex_template[1] = 0;
-        this.vertex_template[2] = style.z || 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = style.z || 0;
 
-        // layer order (if needed) - w coord of 'position' attribute (for packing efficiency)
-        if (this.defines.TANGRAM_LAYER_ORDER) {
-            this.vertex_template[3] = style.order;
-        }
-        else {
-            this.vertex_template[3] = 0;
-        }
+        // layer order - w coord of 'position' attribute (for packing efficiency)
+        this.vertex_template[i++] = style.order || 0;
 
         // scaling vector - (x, y) components per pixel, z = angle, w = scaling factor
-        this.vertex_template[4] = 0;
-        this.vertex_template[5] = 0;
-        this.vertex_template[6] = 0;
-        this.vertex_template[7] = 0;
-
-        // color
-        this.vertex_template[8] = color[0] * 255;
-        this.vertex_template[9] = color[1] * 255;
-        this.vertex_template[10] = color[2] * 255;
-        this.vertex_template[11] = color[3] * 255;
-
-        // selection color
-        this.vertex_template[12] = style.selection_color[0] * 255;
-        this.vertex_template[13] = style.selection_color[1] * 255;
-        this.vertex_template[14] = style.selection_color[2] * 255;
-        this.vertex_template[15] = style.selection_color[3] * 255;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
 
         // texture coords
-        this.vertex_template[16] = 0;
-        this.vertex_template[17] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+
+        // color
+        this.vertex_template[i++] = color[0] * 255;
+        this.vertex_template[i++] = color[1] * 255;
+        this.vertex_template[i++] = color[2] * 255;
+        this.vertex_template[i++] = color[3] * 255;
+
+        // selection color
+        if (this.selection) {
+            this.vertex_template[i++] = style.selection_color[0] * 255;
+            this.vertex_template[i++] = style.selection_color[1] * 255;
+            this.vertex_template[i++] = style.selection_color[2] * 255;
+            this.vertex_template[i++] = style.selection_color[3] * 255;
+        }
 
         return this.vertex_template;
     },

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -26,7 +26,7 @@ Object.assign(Points, {
         this.fragment_shader_key = 'styles/points/points_fragment';
 
         var attribs = [
-            { name: 'a_position', size: 3, type: gl.FLOAT, normalized: false },
+            { name: 'a_position', size: 3, type: gl.SHORT, normalized: true },
             { name: 'a_shape', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
             { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -41,7 +41,7 @@ void main() {
     vec2 shape_offset = shape.xy * 256. * zscale;
 
     // Position
-    vec4 position = u_modelView * vec4(a_position, 1.);
+    vec4 position = u_modelView * vec4(a_position * 32767., 1.);
 
     // World coordinates for 3d procedural textures
     v_world_position = u_model * vec4(a_position, 1.);

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -7,13 +7,10 @@ uniform float u_meters_per_pixel;
 uniform mat4 u_model;
 uniform mat4 u_modelView;
 
-attribute vec3 a_position;
+attribute vec4 a_position;
 attribute vec4 a_shape;
 attribute vec4 a_color;
 attribute vec2 a_texcoord;
-#ifdef TANGRAM_ORDER_ATTRIBUTE
-    attribute float a_layer;
-#endif
 
 varying vec4 v_color;
 varying vec2 v_texcoord;
@@ -41,10 +38,10 @@ void main() {
     vec2 shape_offset = shape.xy * 256. * zscale;
 
     // Position
-    vec4 position = u_modelView * vec4(a_position * 32767., 1.);
+    vec4 position = u_modelView * vec4(a_position.xyz * 32767., 1.);
 
     // World coordinates for 3d procedural textures
-    v_world_position = u_model * vec4(a_position, 1.);
+    v_world_position = u_model * position;
     v_world_position.xy += shape_offset * u_meters_per_pixel;
     #if defined(TANGRAM_WORLD_POSITION_WRAP)
         v_world_position.xy -= world_position_anchor;
@@ -55,8 +52,8 @@ void main() {
 
     cameraProjection(position);
 
-    #ifdef TANGRAM_ORDER_ATTRIBUTE
-        applyLayerOrder(a_layer, position);
+    #ifdef TANGRAM_LAYER_ORDER
+        applyLayerOrder(a_position.w * 32767., position);
     #endif
 
     position.xy += rotate2D(shape_offset, radians(shape.z * 360.)) * 2. * position.w / u_resolution;

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -24,7 +24,7 @@ Object.assign(Polygons, {
 
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
-            { name: 'a_position', size: 3, type: gl.FLOAT, normalized: false },
+            { name: 'a_position', size: 3, type: gl.SHORT, normalized: true },
             { name: 'a_normal', size: 3, type: gl.FLOAT, normalized: false },
             // { name: 'a_normal', size: 3, type: gl.BYTE, normalized: true }, // attrib isn't a multiple of 4!
             // { name: 'a_color', size: 3, type: gl.FLOAT, normalized: false },

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -25,11 +25,8 @@ Object.assign(Polygons, {
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
             { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
-            { name: 'a_normal', size: 3, type: gl.FLOAT, normalized: false },
-            // { name: 'a_normal', size: 3, type: gl.BYTE, normalized: true }, // attrib isn't a multiple of 4!
-            // { name: 'a_color', size: 3, type: gl.FLOAT, normalized: false },
+            { name: 'a_normal', size: 3, type: gl.BYTE, normalized: true }, // gets padded to 4-bytes
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            // { name: 'a_selection_color', size: 4, type: gl.FLOAT, normalized: false },
             { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
 
@@ -113,7 +110,7 @@ Object.assign(Polygons, {
         // normal
         this.vertex_template[4] = 0;
         this.vertex_template[5] = 0;
-        this.vertex_template[6] = 1;
+        this.vertex_template[6] = 1 * 127;
 
         // color
         this.vertex_template[7] = style.color[0] * 255;
@@ -141,7 +138,7 @@ Object.assign(Polygons, {
         let texcoords = {
             texcoord_index: this.vertex_layout.index.a_texcoord,
             texcoord_scale: this.texcoord_scale,
-            texcoord_normalize: 65535
+            texcoord_normalize: 65535 // scale UVs to unsigned shorts
         };
 
         // Extruded polygons (e.g. 3D buildings)
@@ -151,6 +148,7 @@ Object.assign(Polygons, {
                 style.z, style.height, style.min_height,
                 vertex_data, vertex_template,
                 this.vertex_layout.index.a_normal,
+                127, // scale normals to signed bytes
                 texcoords
             );
         }

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -11,28 +11,28 @@ export var Polygons = Object.create(Style);
 Object.assign(Polygons, {
     name: 'polygons',
     built_in: true,
+    vertex_shader_key: 'styles/polygons/polygons_vertex',
+    fragment_shader_key: 'styles/polygons/polygons_fragment',
+    selection: true, // turn feature selection on
 
     init() {
         Style.init.apply(this, arguments);
-
-        // Base shaders
-        this.vertex_shader_key = 'styles/polygons/polygons_vertex';
-        this.fragment_shader_key = 'styles/polygons/polygons_fragment';
-
-        // Turn feature selection on
-        this.selection = true;
 
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
             { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_normal', size: 3, type: gl.BYTE, normalized: true }, // gets padded to 4-bytes
-            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
+            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
 
         // Tell the shader we have a normal and order attributes
         this.defines.TANGRAM_NORMAL_ATTRIBUTE = true;
         this.defines.TANGRAM_LAYER_ORDER = true;
+
+        // Optional feature selection
+        if (this.selection) {
+            attribs.push({ name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true });
+        }
 
         // Optional texture UVs
         if (this.texcoords) {
@@ -99,35 +99,39 @@ Object.assign(Polygons, {
      * A plain JS array matching the order of the vertex layout.
      */
     makeVertexTemplate(style) {
+        let i = 0;
+
         // position - x & y coords will be filled in per-vertex below
-        this.vertex_template[0] = 0;
-        this.vertex_template[1] = 0;
-        this.vertex_template[2] = style.z || 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = style.z || 0;
 
         // layer order - w coord of 'position' attribute (for packing efficiency)
-        this.vertex_template[3] = style.order;
+        this.vertex_template[i++] = style.order;
 
         // normal
-        this.vertex_template[4] = 0;
-        this.vertex_template[5] = 0;
-        this.vertex_template[6] = 1 * 127;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 0;
+        this.vertex_template[i++] = 1 * 127;
 
         // color
-        this.vertex_template[7] = style.color[0] * 255;
-        this.vertex_template[8] = style.color[1] * 255;
-        this.vertex_template[9] = style.color[2] * 255;
-        this.vertex_template[10] = style.color[3] * 255;
+        this.vertex_template[i++] = style.color[0] * 255;
+        this.vertex_template[i++] = style.color[1] * 255;
+        this.vertex_template[i++] = style.color[2] * 255;
+        this.vertex_template[i++] = style.color[3] * 255;
 
         // selection color
-        this.vertex_template[11] = style.selection_color[0] * 255;
-        this.vertex_template[12] = style.selection_color[1] * 255;
-        this.vertex_template[13] = style.selection_color[2] * 255;
-        this.vertex_template[14] = style.selection_color[3] * 255;
+        if (this.selection) {
+            this.vertex_template[i++] = style.selection_color[0] * 255;
+            this.vertex_template[i++] = style.selection_color[1] * 255;
+            this.vertex_template[i++] = style.selection_color[2] * 255;
+            this.vertex_template[i++] = style.selection_color[3] * 255;
+        }
 
         // Add texture UVs to template only if needed
         if (this.texcoords) {
-            this.vertex_template[15] = 0;
-            this.vertex_template[16] = 0;
+            this.vertex_template[i++] = 0;
+            this.vertex_template[i++] = 0;
         }
 
         return this.vertex_template;

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -24,19 +24,18 @@ Object.assign(Polygons, {
 
         // Basic attributes, others can be added (see texture UVs below)
         var attribs = [
-            { name: 'a_position', size: 3, type: gl.SHORT, normalized: true },
+            { name: 'a_position', size: 4, type: gl.SHORT, normalized: true },
             { name: 'a_normal', size: 3, type: gl.FLOAT, normalized: false },
             // { name: 'a_normal', size: 3, type: gl.BYTE, normalized: true }, // attrib isn't a multiple of 4!
             // { name: 'a_color', size: 3, type: gl.FLOAT, normalized: false },
             { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
             // { name: 'a_selection_color', size: 4, type: gl.FLOAT, normalized: false },
-            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_layer', size: 1, type: gl.FLOAT, normalized: false }
+            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
         ];
 
         // Tell the shader we have a normal and order attributes
         this.defines.TANGRAM_NORMAL_ATTRIBUTE = true;
-        this.defines.TANGRAM_ORDER_ATTRIBUTE = true;
+        this.defines.TANGRAM_LAYER_ORDER = true;
 
         // Optional texture UVs
         if (this.texcoords) {
@@ -108,25 +107,25 @@ Object.assign(Polygons, {
         this.vertex_template[1] = 0;
         this.vertex_template[2] = style.z || 0;
 
+        // layer order - w coord of 'position' attribute (for packing efficiency)
+        this.vertex_template[3] = style.order;
+
         // normal
-        this.vertex_template[3] = 0;
         this.vertex_template[4] = 0;
-        this.vertex_template[5] = 1;
+        this.vertex_template[5] = 0;
+        this.vertex_template[6] = 1;
 
         // color
-        this.vertex_template[6] = style.color[0] * 255;
-        this.vertex_template[7] = style.color[1] * 255;
-        this.vertex_template[8] = style.color[2] * 255;
-        this.vertex_template[9] = style.color[3] * 255;
+        this.vertex_template[7] = style.color[0] * 255;
+        this.vertex_template[8] = style.color[1] * 255;
+        this.vertex_template[9] = style.color[2] * 255;
+        this.vertex_template[10] = style.color[3] * 255;
 
         // selection color
-        this.vertex_template[10] = style.selection_color[0] * 255;
-        this.vertex_template[11] = style.selection_color[1] * 255;
-        this.vertex_template[12] = style.selection_color[2] * 255;
-        this.vertex_template[13] = style.selection_color[3] * 255;
-
-        // layer order
-        this.vertex_template[14] = style.order;
+        this.vertex_template[11] = style.selection_color[0] * 255;
+        this.vertex_template[12] = style.selection_color[1] * 255;
+        this.vertex_template[13] = style.selection_color[2] * 255;
+        this.vertex_template[14] = style.selection_color[3] * 255;
 
         // Add texture UVs to template only if needed
         if (this.texcoords) {

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -43,7 +43,7 @@ Object.assign(Polygons, {
             this.defines.TANGRAM_TEXTURE_COORDS = true;
 
             // Add vertex attribute for UVs only when needed
-            attribs.push({ name: 'a_texcoord', size: 2, type: gl.FLOAT, normalized: false });
+            attribs.push({ name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true });
         }
 
         this.vertex_layout = new VertexLayout(attribs);
@@ -138,7 +138,12 @@ Object.assign(Polygons, {
     },
 
     buildPolygons(polygons, style, vertex_data) {
-        var vertex_template = this.makeVertexTemplate(style);
+        let vertex_template = this.makeVertexTemplate(style);
+        let texcoords = {
+            texcoord_index: this.vertex_layout.index.a_texcoord,
+            texcoord_scale: this.texcoord_scale,
+            texcoord_normalize: 65535
+        };
 
         // Extruded polygons (e.g. 3D buildings)
         if (style.extrude && style.height) {
@@ -147,7 +152,7 @@ Object.assign(Polygons, {
                 style.z, style.height, style.min_height,
                 vertex_data, vertex_template,
                 this.vertex_layout.index.a_normal,
-                { texcoord_index: this.vertex_layout.index.a_texcoord, texcoord_scale: this.texcoord_scale }
+                texcoords
             );
         }
         // Regular polygons
@@ -155,7 +160,7 @@ Object.assign(Polygons, {
             Builders.buildPolygons(
                 polygons,
                 vertex_data, vertex_template,
-                { texcoord_index: this.vertex_layout.index.a_texcoord, texcoord_scale: this.texcoord_scale }
+                texcoords
             );
         }
     }

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -22,8 +22,10 @@ attribute vec4 a_color;
 
 // Optional dynamic line extrusion
 #ifdef TANGRAM_EXTRUDE_LINES
-    attribute vec3 a_extrude;
-    attribute float a_scale;
+    // xy: extrusion direction in xy plane
+    // z:  half-width of line (amount to extrude)
+    // w:  scaling factor for interpolating width between zooms
+    attribute vec4 a_extrude;
 #endif
 
 varying vec4 v_position;
@@ -59,15 +61,16 @@ void main() {
     vec4 position = vec4(a_position.xyz * 32767., 1.);
 
     #ifdef TANGRAM_EXTRUDE_LINES
-        vec2 extrude = a_extrude.xy;
-        float width = a_extrude.z;
+        vec2 extrude = a_extrude.xy * 255.;
+        float width = a_extrude.z * 255.;
+        float scale = a_extrude.w * 255.;
 
         // Keep line width constant in screen-space
         float zscale = u_tile_origin.z - u_map_position.z;
         width *= pow(2., zscale);
 
         // Smoothly interpolate line width between zooms
-        width = mix(width, width * a_scale * 256., -zscale);
+        width = mix(width, width * scale, -zscale);
 
         // Modify line width before extrusion
         #pragma tangram: width

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -9,9 +9,8 @@ uniform mat4 u_model;
 uniform mat4 u_modelView;
 uniform mat3 u_normalMatrix;
 
-attribute vec3 a_position;
+attribute vec4 a_position;
 attribute vec4 a_color;
-attribute float a_layer;
 
 // Optional normal attribute, otherwise default to up
 #ifdef TANGRAM_NORMAL_ATTRIBUTE
@@ -57,7 +56,7 @@ void main() {
     #endif
 
     // Position
-    vec4 position = vec4(a_position * 32767., 1.);
+    vec4 position = vec4(a_position.xyz * 32767., 1.);
 
     #ifdef TANGRAM_EXTRUDE_LINES
         vec2 extrude = a_extrude.xy;
@@ -110,7 +109,7 @@ void main() {
 
     // Camera
     cameraProjection(position);
-    applyLayerOrder(a_layer, position);
+    applyLayerOrder(a_position.w * 32767., position);
 
     gl_Position = position;
 }

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -57,7 +57,7 @@ void main() {
     #endif
 
     // Position
-    vec4 position = vec4(a_position, 1.);
+    vec4 position = vec4(a_position * 32767., 1.);
 
     #ifdef TANGRAM_EXTRUDE_LINES
         vec2 extrude = a_extrude.xy;

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -590,7 +590,8 @@ Object.assign(TextStyle, {
             this.vertex_layout.index.a_shape,
             {
                 texcoord_index: this.vertex_layout.index.a_texcoord,
-                texcoord_scale: texcoord_scale
+                texcoord_scale: texcoord_scale,
+                texcoord_normalize: 65535
             }
         );
     },

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -16,7 +16,7 @@ Object.assign(TextStyle, {
     name: 'text',
     super: Points,
     built_in: true,
-    selection: false,
+    selection: false, // no feature selection for text by default
 
     init() {
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -403,8 +403,11 @@ Utils.recurseValues = function* (obj) {
     }
 };
 
-Utils.scaleInt16 = function (val, max) {
-    return (val / max) * 32768;
+// Scale a *signed* short for use in a GL VBO
+// `unit` is an optional scaling factor to mimic fixed point, since these values will be
+// normalized to 0-1, e.g. divide input by unit on the way in, multiply it back in the shader
+Utils.scaleInt16 = function (val, unit) {
+    return (val / unit) * 32767;
 };
 
 Utils.degToRad = function (degrees) {


### PR DESCRIPTION
Packs some vertex attributes into smaller data types:

- position: floats -> signed shorts
- normal: floats -> signed bytes
- texture UVs: floats -> unsigned shorts
- line extrusion: floats -> signed shorts
- layer order: floats -> signed shorts

This produces about a 44% decrease in memory usage for VBOs in a typical complex scene (midtown Manhattan zoom 15).