### PR TITLE
Styles can enable GL extensions

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -133,6 +133,25 @@ styles:
         base: points
         texture: pois
 
+    grid:
+        base: polygons
+        lighting: false
+        shaders:
+            extensions: [OES_standard_derivatives]
+            blocks:
+                color: |
+                    // From: http://madebyevan.com/shaders/grid/
+                    // Pick a coordinate to visualize in a grid
+                    vec3 coord = v_world_position.xyz / 10.;
+
+                    // Compute anti-aliased world-space grid lines
+                    vec3 grid = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);
+                    float line = min(min(grid.x, grid.y), grid.z);
+
+                    // Just visualize the grid lines directly
+                    color = vec4(vec3(1.0 - min(line, 1.0)), 1.0);
+
+
 sources:
     # When commented, demo main.js will set source based on URL - uncomment for testing
     # osm:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -137,7 +137,8 @@ styles:
         base: polygons
         lighting: false
         shaders:
-            extensions: [OES_standard_derivatives]
+            extensions: OES_standard_derivatives
+            # extensions: [OES_standard_derivatives, EXT_frag_depth]
             blocks:
                 color: |
                     // From: http://madebyevan.com/shaders/grid/

--- a/src/gl/extensions.js
+++ b/src/gl/extensions.js
@@ -1,0 +1,20 @@
+// WebGL extension wrapper
+// Stores extensions by name and GL context
+
+var Extensions;
+export default Extensions = {};
+
+Extensions.extensions = new Map(); // map of extensions by GL context
+
+Extensions.getExtension = function (gl, name) {
+    let exts = Extensions.extensions.get(gl);
+    if (!exts) {
+        Extensions.extensions.set(gl, {});
+        exts = Extensions.extensions.get(gl);
+    }
+
+    if (!exts[name]) {
+        exts[name] = gl.getExtension(name);
+    }
+    return exts[name];
+};

--- a/src/gl/extensions.js
+++ b/src/gl/extensions.js
@@ -1,20 +1,17 @@
 // WebGL extension wrapper
 // Stores extensions by name and GL context
 
-var Extensions;
-export default Extensions = {};
+let extensions = new Map(); // map of extensions by GL context
 
-Extensions.extensions = new Map(); // map of extensions by GL context
-
-Extensions.getExtension = function (gl, name) {
-    let exts = Extensions.extensions.get(gl);
+export default function getExtension (gl, name) {
+    let exts = extensions.get(gl);
     if (!exts) {
-        Extensions.extensions.set(gl, {});
-        exts = Extensions.extensions.get(gl);
+        extensions.set(gl, new Map());
+        exts = extensions.get(gl);
     }
 
-    if (!exts[name]) {
-        exts[name] = gl.getExtension(name);
+    if (!exts.get(name)) {
+        exts.set(name, gl.getExtension(name));
     }
-    return exts[name];
-};
+    return exts.get(name);
+}

--- a/src/gl/shader_program.js
+++ b/src/gl/shader_program.js
@@ -4,6 +4,7 @@
 
 import GLSL from './glsl';
 import Texture from './texture';
+import Extensions from './extensions';
 
 import log from 'loglevel';
 import strip from 'strip-comments';
@@ -24,6 +25,9 @@ export default class ShaderProgram {
 
         // key/values for blocks that can be injected into shaders at compile-time
         this.blocks = Object.assign({}, options.blocks||{});
+
+        // list of extensions to activate
+        this.extensions = options.extensions || [];
 
         // JS-object uniforms that are expected by this program
         // If they are not found in the existing shader source, their types will be inferred and definitions
@@ -78,6 +82,9 @@ export default class ShaderProgram {
         // Make list of defines to be injected later
         var defines = this.buildDefineList();
 
+        // Check for extension availability
+        this.checkExtensions();
+
         // Inject user-defined blocks (arbitrary code points matching named #pragmas)
         // Replace according to this pattern:
         // #pragma tangram: [key]
@@ -127,23 +134,22 @@ export default class ShaderProgram {
         this.computed_vertex_source = this.computed_vertex_source.replace(regexp, '');
         this.computed_fragment_source = this.computed_fragment_source.replace(regexp, '');
 
-        // Build & inject defines
-        // This is done *after* code injection so that we can add defines for which code points were injected
-        defines['TANGRAM_VERTEX_SHADER'] = true;
-        defines['TANGRAM_FRAGMENT_SHADER'] = false;
-        this.computed_vertex_source = ShaderProgram.buildDefineString(defines) + this.computed_vertex_source;
-
-        defines['TANGRAM_VERTEX_SHADER'] = false;
-        defines['TANGRAM_FRAGMENT_SHADER'] = true;
-        this.computed_fragment_source = ShaderProgram.buildDefineString(defines) + this.computed_fragment_source;
-
         // Detect uniform definitions, inject any missing ones
         this.ensureUniforms(this.dependent_uniforms);
 
-        // Include program info useful for debugging
-        var info = (this.name ? (this.name + ' / id ' + this.id) : ('id ' + this.id));
-        this.computed_vertex_source = '// Program: ' + info + '\n' + this.computed_vertex_source;
-        this.computed_fragment_source = '// Program: ' + info + '\n' + this.computed_fragment_source;
+        // Build & inject extensions & defines
+        // This is done *after* code injection so that we can add defines for which code points were injected
+        let info = (this.name ? (this.name + ' / id ' + this.id) : ('id ' + this.id));
+        let header = `// Program: ${info}\n` +
+            ShaderProgram.buildExtensionString(this.extensions);
+
+        defines['TANGRAM_VERTEX_SHADER'] = true;
+        defines['TANGRAM_FRAGMENT_SHADER'] = false;
+        this.computed_vertex_source = header + ShaderProgram.buildDefineString(defines) + this.computed_vertex_source;
+
+        defines['TANGRAM_VERTEX_SHADER'] = false;
+        defines['TANGRAM_FRAGMENT_SHADER'] = true;
+        this.computed_fragment_source = header + ShaderProgram.buildDefineString(defines) + this.computed_fragment_source;
 
         // Compile & set uniforms to cached values
         try {
@@ -390,6 +396,17 @@ export default class ShaderProgram {
         return attrib;
     }
 
+    // Check availability of extensions
+    checkExtensions() {
+        for (let ext of this.extensions) {
+            if (!Extensions.getExtension(this.gl, ext)) {
+                log.warn(`Could not enable extension '${ext}'`);
+                return false;
+            }
+        }
+        return true;
+    }
+
 }
 
 
@@ -421,6 +438,16 @@ ShaderProgram.buildDefineString = function (defines) {
         }
     }
     return define_str;
+};
+
+// Turn a list of extension names into single string of #extension statements
+ShaderProgram.buildExtensionString = function (extensions) {
+    extensions = extensions || [];
+    let str = "";
+    for (let ext of extensions) {
+        str += `#extension GL_${ext} : enable\n`;
+    }
+    return str;
 };
 
 ShaderProgram.addBlock = function (key, ...blocks) {

--- a/src/module.js
+++ b/src/module.js
@@ -17,7 +17,6 @@ import DataSource from './data_source';
 import TileManager from './tile_manager';
 import GLSL from './gl/glsl';
 import ShaderProgram from './gl/shader_program';
-import Extensions from './gl/extensions';
 import VertexData from './gl/vertex_data';
 import Texture from './gl/texture';
 import Material from './material';
@@ -42,7 +41,6 @@ var debug = {
     TileManager,
     GLSL,
     ShaderProgram,
-    Extensions,
     VertexData,
     Texture,
     Material,

--- a/src/module.js
+++ b/src/module.js
@@ -17,6 +17,7 @@ import DataSource from './data_source';
 import TileManager from './tile_manager';
 import GLSL from './gl/glsl';
 import ShaderProgram from './gl/shader_program';
+import Extensions from './gl/extensions';
 import VertexData from './gl/vertex_data';
 import Texture from './gl/texture';
 import Material from './material';
@@ -41,6 +42,7 @@ var debug = {
     TileManager,
     GLSL,
     ShaderProgram,
+    Extensions,
     VertexData,
     Texture,
     Material,

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -256,6 +256,7 @@ export var Style = {
         // Get any custom code blocks, uniform dependencies, etc.
         var blocks = (this.shaders && this.shaders.blocks);
         var uniforms = (this.shaders && this.shaders.uniforms);
+        var extensions = (this.shaders && this.shaders.extensions);
 
         // Create shaders
         try {
@@ -267,7 +268,8 @@ export var Style = {
                     name: this.name,
                     defines,
                     uniforms,
-                    blocks
+                    blocks,
+                    extensions
                 }
             );
             this.program.compile();
@@ -281,7 +283,8 @@ export var Style = {
                         name: (this.name + ' (selection)'),
                         defines: selection_defines,
                         uniforms,
-                        blocks
+                        blocks,
+                        extensions
                     }
                 );
                 this.selection_program.compile();

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -256,7 +256,12 @@ export var Style = {
         // Get any custom code blocks, uniform dependencies, etc.
         var blocks = (this.shaders && this.shaders.blocks);
         var uniforms = (this.shaders && this.shaders.uniforms);
+
+        // accept a single extension, or an array of extensions
         var extensions = (this.shaders && this.shaders.extensions);
+        if (typeof extensions === 'string') {
+            extensions = [extensions];
+        }
 
         // Create shaders
         try {

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -217,7 +217,17 @@ StyleManager.mix = function (style, styles) {
     shaders.extensions = Object.keys(merge
         .map(x => x.extensions)
         .filter(x => x)
-        .reduce((prev, cur) => { cur.forEach(x => prev[x] = true); return prev; }, {}) || {}
+        .reduce((prev, cur) => {
+            // single extension
+            if (typeof cur === 'string') {
+                prev[cur] = true;
+            }
+            // array of extensions
+            else {
+                cur.forEach(x => prev[x] = true);
+            }
+            return prev;
+        }, {}) || {}
     );
 
     merge.map(x => x.blocks).filter(x => x).forEach(blocks => {

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -213,6 +213,13 @@ StyleManager.mix = function (style, styles) {
     shaders.defines = Object.assign({}, ...merge.map(x => x.defines).filter(x => x));
     shaders.uniforms = Object.assign({}, ...merge.map(x => x.uniforms).filter(x => x));
 
+    // Build a list of unique extensions
+    shaders.extensions = Object.keys(merge
+        .map(x => x.extensions)
+        .filter(x => x)
+        .reduce((prev, cur) => { cur.forEach(x => prev[x] = true); return prev; }, {}) || {}
+    );
+
     merge.map(x => x.blocks).filter(x => x).forEach(blocks => {
         shaders.blocks = shaders.blocks || {};
 


### PR DESCRIPTION
Custom styles can now enable GL extensions, with a new `extensions` property (within `shaders`). For example, a style that uses the `OES_standard_derivatives` extension:

```
    grid:
        base: polygons
        lighting: false
        shaders:
            extensions: OES_standard_derivatives
            blocks:
                color: |
                    // From: http://madebyevan.com/shaders/grid/
                    // Pick a coordinate to visualize in a grid
                    vec3 coord = v_world_position.xyz / 10.;
                    // Compute anti-aliased world-space grid lines
                    vec3 grid = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);
                    float line = min(min(grid.x, grid.y), grid.z);
                    // Just visualize the grid lines directly
                    color = vec4(vec3(1.0 - min(line, 1.0)), 1.0);
```

`extensions` is either a single extension name, or a list of one or more requested extensions, e.g. for multiple extensions:

` extensions: [OES_standard_derivatives, EXT_frag_depth]`

For each available extension, a `#define` with the following form will be set: `TANGRAM_EXTENSION_${name}`, e.g. 

`#define TANGRAM_EXTENSION_OES_standard_derivatives`

(Some extensions already set a `#define`, but by setting our own we also ensure consistency across extensions.)

If any of the extensions are not available on the client a warning will be printed to console. The style will still be compiled. However, by testing for the presence of enabled extensions (via `#define`, `#ifdef`, etc.), the shader can be written to be compatible on machines without the requested extension. If fallback isn't implemented and the style fails to compile, then it will not render (as with any other invalid rendering style).