### PR TITLE
Add a `sprite_default` draw parameter to points

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -63,19 +63,30 @@ Object.assign(Points, {
             return null;
         }
 
-        style.sprite = rule_style.sprite;
-        if (typeof style.sprite === 'function') {
-            style.sprite = style.sprite(context);
+        let sprite = style.sprite = rule_style.sprite;
+        if (typeof sprite === 'function') {
+            sprite = sprite(context);
         }
+        style.sprite_default = rule_style.sprite_default; // optional fallback if 'sprite' not found
 
         // if point has texture and sprites, require a valid sprite to draw
         if (this.texture && Texture.textures[this.texture] && Texture.textures[this.texture].sprites) {
-            if (!style.sprite) {
+            if (!sprite && !style.sprite_default) {
                 return;
             }
-            else if (!Texture.textures[this.texture].sprites[style.sprite]) {
-                log.warn(`Style: in style '${this.name}', could not find sprite '${style.sprite}' for texture '${this.texture}'`);
-                return;
+            else if (!Texture.textures[this.texture].sprites[sprite]) {
+                // If sprite not found, check for default sprite
+                if (style.sprite_default) {
+                    sprite = style.sprite_default;
+                    if (!Texture.textures[this.texture].sprites[sprite]) {
+                        log.warn(`Style: in style '${this.name}', could not find default sprite '${sprite}' for texture '${this.texture}'`);
+                        return;
+                    }
+                }
+                else {
+                    log.warn(`Style: in style '${this.name}', could not find sprite '${sprite}' for texture '${this.texture}'`);
+                    return;
+                }
             }
         }
 
@@ -110,8 +121,8 @@ Object.assign(Points, {
         style.centroid = rule_style.centroid;
 
         // Sets texcoord scale if needed (e.g. for sprite sub-area)
-        if (this.texture && style.sprite) {
-            this.texcoord_scale = Texture.getSpriteTexcoords(this.texture, style.sprite);
+        if (this.texture && sprite) {
+            this.texcoord_scale = Texture.getSpriteTexcoords(this.texture, sprite);
         } else {
             this.texcoord_scale = null;
         }


### PR DESCRIPTION
It turns out a common use case for sprites is to dynamically match the sprite name to a feature property. For example, many of our `kind` property values for POIs directly map to names of sprites in our texture. We can write a rule to match these:

```
draw:
   icons:
      sprite: function() { return feature.kind }
```

But! While that can eliminate hundreds or thousands of lines of style rules with this one rule, there are still times when we won't have a sprite for every possible feature `kind` value. This PR addresses that by adding a `sprite_default` property. When set, this property is used as the sprite value in cases where the value of `sprite` isn't found in the texture.

For example, we can make all sprites default to a generic icon, and only apply that rule at higher zooms, like this:

```
# add generic icon at high zoom, if direct match fails
generic-icons:
   filter: { $zoom: { min: 18 } }
   draw:
      icons:
         sprite_default: generic
```

These changes are particularly to support POI rendering, as seen in: https://github.com/tangrams/poi-labels-demo. That repo will be updated to use this feature.
