### PR TITLE
Optionally enforce polygon winding order

### DIFF
--- a/src/geo.js
+++ b/src/geo.js
@@ -235,3 +235,31 @@ Geo.multiPolygonArea = function (polygons) {
 Geo.ringWinding = function (ring) {
     return Geo.signedPolygonAreaSum(ring) > 0 ? 'CW' : 'CCW';
 };
+
+// Enforce winding order on outer/inner rings
+// winding: 'CW' or 'CCW'
+Geo.enforceWinding = function (geom, winding) {
+    let polys;
+    if (geom.type === 'Polygon') {
+        polys = [geom.coordinates];
+    }
+    else if (geom.type === 'MultiPolygon') {
+        polys = geom.coordinates;
+    }
+    else {
+        return geom;
+    }
+
+    for (let p=0; p < polys.length; p++) {
+        let poly = polys[p];
+
+        // If first ring winding doesn't match, reverse all rings
+        // NOTE: assumes ring winding orders already alternate as expected
+        if (Geo.ringWinding(poly[0]) !== winding) {
+            for (let ring of poly) {
+                ring.reverse();
+            }
+        }
+    }
+    return geom;
+};

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -10,6 +10,7 @@ export default class DataSource {
         this.name = source.name;
         this.url = source.url;
         this.pad_scale = source.pad_scale || 0.0005; // scale tile up by small factor to cover seams
+        this.enforce_winding = source.enforce_winding || false; // whether to enforce winding order
 
         // Optional function to transform source data
         this.transform = source.transform;
@@ -102,6 +103,11 @@ export default class DataSource {
                                 coord[1] = Math.round(coord[1] * (1 + this.pad_scale) - (Geo.tile_scale * this.pad_scale/2));
                             }
                         });
+
+                        // Optionally enforce winding order since not all data sources guarantee it
+                        if (this.enforce_winding) {
+                            Geo.enforceWinding(feature.geometry, 'CCW');
+                        }
                     });
                 }
             }

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -69,6 +69,7 @@ export class GeoJSONSource extends NetworkSource {
         this.tile_indexes = {}; // geojson-vt tile indices, by layer name
         this.max_zoom = Math.max(this.max_zoom || 0, 15); // TODO: max zoom < 15 causes artifacts/no-draw at 20, investigate
         this.pad_scale = 0; // we don't want padding on auto-tiled sources
+        this.enforce_winding = (source.enforce_winding === false) ? false : true; // default on, can be forced off
     }
 
     _load(dest) {


### PR DESCRIPTION
While many GeoJSON/TopoJSON data sources (including Mapzen's tiles) are encoded with typical CCW-ordered outer rings (and CW inner rings), it turns out not all data sources follow this, and GeoJSON does not enforce it. In particular, user-supplied GeoJSON/TopoJSON files may have inverse ring orders depending on how/where they were generated.

To fix this, we can enforce CCW winding order. This PR adds an option to do that per-data-source. By default, **tiled** data sources do **not** enforce winding order (i.e. they are assumed to already be correctly wound); **non-tiled** data sources **do** enforce winding order (i.e. they are assumed to not be safe). (Defaulting off saves a bit of needless computation.)

These defaults can be overridden if desired, for example to reverse these options:

```
sources:
   osm:
        type: GeoJSON
        url:  http://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
        enforce_winding: true # default for tiled sources is false
    schools:
        type: GeoJSON
        url: demos/data/school-districts-polygon.geojson
        enforce_winding: false # default for non-tiled sources is true
```


