### PR TITLE
Add a 'sprite_source' property to tie sprites to a feature property

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -63,11 +63,20 @@ Object.assign(Points, {
             return null;
         }
 
-        let sprite = style.sprite = rule_style.sprite;
+        // specify sprite explicitly
+        let sprite = rule_style.sprite;
         if (typeof sprite === 'function') {
             sprite = sprite(context);
         }
-        style.sprite_default = rule_style.sprite_default; // optional fallback if 'sprite' not found
+
+        // specify sprite by field
+        if (!sprite) {
+            sprite = rule_style.sprite_source;
+            sprite = (typeof sprite === 'string') && feature.properties[sprite];
+        }
+
+        // fallback if 'sprite' not found
+        style.sprite_default = rule_style.sprite_default;
 
         // if point has texture and sprites, require a valid sprite to draw
         if (this.texture && Texture.textures[this.texture] && Texture.textures[this.texture].sprites) {


### PR DESCRIPTION
`sprite_source` is a new draw group property for points that sets the `sprite` value to that of the specified feature property. For example:

`sprite_source: kind`

is syntactic sugar for

`sprite: function() { return feature.kind }`

The reasoning to add a specific property for it is:

- It turns out it's a fairly common way to specify feature/sprite mappings, with a pre-defined sprite sheet texture that lines up with known feature property values.
- It pairs well with the recently added `sprite_default` property. By setting a `sprite_source` and a `sprite_default`, it's easy to setup data-driven sprites with a clear fallback.
- The behavior and name is similar to the existing `text_source` field for the text style.

