### PR TITLE
Un-multiply alpha on text styles

### DIFF
--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -45,6 +45,11 @@ void main (void) {
         }
     #endif
 
+    // Manually un-multiply alpha, for cases where texture has pre-multiplied alpha
+    #ifdef TANGRAM_UNMULTIPLY_ALPHA
+        color.rgb /= max(color.a, 0.001);
+    #endif
+
     #pragma tangram: color
     #pragma tangram: filter
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -31,6 +31,10 @@ Object.assign(TextStyle, {
         // (labels are always drawn with textures)
         this.defines.TANGRAM_POINT_TEXTURE = true;
 
+        // Manually un-multiply alpha, because Canvas text rasterization is pre-multiplied
+        // See https://github.com/tangrams/tangram/issues/179
+        this.defines.TANGRAM_UNMULTIPLY_ALPHA = true;
+
         // default font style
         this.font_style = {
             typeface: 'Helvetica 12px',


### PR DESCRIPTION
Fixes the "dirty" halos on text seen in #179 (see for more detail).

This was an issue with pre-multiplied alpha handling between WebGL and Canvas. It looks like the text rasterized into the canvas uses pre-multiplied alpha, which means that instead of the halo simply alpha-fading to 0 at is edges, it is also "fading" out the halo RGB itself. For example, with a yellow halo, you get a dirty gray at the edge as the RG components interpolate from 1 to 0 (instead of remaining constant while just the alpha interpolates).

Our WebGL blending pipeline is currently setup to expect un-premultiplied alpha. To fix this for now, we are simply dividing the color RGB by its alpha in the shader to "un-multiply" the alpha

In the future, we may consider adding a new blending mode, alongside overlay, that is intended to be used with image sources with pre-multiplied alpha (e.g. something like `overlay-premultiplied`). This route would include:

- Setting the UNPACK_PREMULTIPLY_ALPHA_WEBGL flag to true for text canvas textures.
- Setting the blend equation to gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA); for the text (overlay-premultiplied) mode.
- Adding a blend mode that would group these styles into a distinct render state.

Adding a new blending mode may be a more performant future solution, but the shader approach is a quick fix for now and can be adjusted without otherwise affecting behavior.
