### PR TITLE
Add cardinal direction placements for point labels

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -560,8 +560,10 @@ layers:
                 $zoom: { min: 18 }
             draw:
                 text:
-                    offset: [12px, 0px]
-                    placement: E
+                    anchor: right
+                    # align: left
+                    offset: [13px, 0]
+                    move_into_tile: false
                     priority: 6
                     font:
                         family: Helvetica

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -427,7 +427,7 @@ layers:
         filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
         draw:
             icons:
-                offset: [0px, -13px]
+                # offset: [0px, -13px]
                 size: [[13, 12px], [15, 18px]]
                 interactive: true
 
@@ -560,7 +560,8 @@ layers:
                 $zoom: { min: 18 }
             draw:
                 text:
-                    offset: [0px, 13px]
+                    offset: [12px, 0px]
+                    placement: E
                     priority: 6
                     font:
                         family: Helvetica

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -1,6 +1,7 @@
 import Utils from '../../utils/utils';
 import Geo from '../../geo';
 import {StyleParser} from '../style_parser';
+import LabelPoint from './label_point';
 
 export default class FeatureLabel {
 
@@ -75,6 +76,16 @@ export default class FeatureLabel {
             text_wrap = default_font_style.text_wrap;
         }
         style.text_wrap = text_wrap;
+
+        // default alignment to match anchor
+        if (!rule.align && rule.anchor && rule.anchor !== 'center') {
+            if (LabelPoint.isLeftAnchor(rule.anchor)) {
+                rule.align = 'right';
+            }
+            else if (LabelPoint.isRightAnchor(rule.anchor)) {
+                rule.align = 'left';
+            }
+        }
 
         style.align = rule.align || default_font_style.align;
 

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -49,7 +49,7 @@ export default class FeatureLabel {
         let size_kind = ft_size.replace(/([0-9]*\.)?[0-9]+/g, '');
 
         // TODO: improve pt/em conversion
-        style.px_logical_size = Utils.toPixelSize(ft_size.replace(/([a-z]|%)/g, ''), size_kind);
+        style.px_logical_size = parseInt(Utils.toPixelSize(ft_size.replace(/([a-z]|%)/g, ''), size_kind));
         style.px_size = style.px_logical_size * Utils.device_pixel_ratio;
         style.stroke_width *= Utils.device_pixel_ratio;
         style.size = size.replace(size_regex, style.px_size + "px");

--- a/src/styles/text/label.js
+++ b/src/styles/text/label.js
@@ -51,23 +51,21 @@ export default class Label {
         return true;
     }
 
-    // whether the label should be discarded
-    // 1. try to keep the label in tile if the label (to avoid collision over tile for now)
-    // 2. if 1. -> keep a minimal distance between the label
-    // 3. if 2. -> perfom occlusion
+    // Whether the label should be discarded
+    // Depends on whether label must fit in the tile bounds, and if so, can it be moved to fit there
     discard (aabbs) {
         let discard = false;
 
-        // perform specific styling rule, should we keep the label in tile bounds?
-        if (this.options.keep_in_tile) {
+        // Should the label be culled if it can't fit inside the tile bounds?
+        if (this.options.cull_from_tile) {
             let in_tile = this.inTileBounds();
 
-            if (!in_tile && this.options.move_in_tile) {
-                // can we move?
-                discard = this.moveInTile();
+            // If it doesn't fit, should we try to move it into the tile bounds?
+            if (!in_tile && this.options.move_into_tile) {
+                // Were we able to fit it in the tile?
+                discard = this.moveIntoTile();
             } else if (!in_tile) {
-                // we didn't want to move at all,
-                // just discard since we're out of tile bounds
+                // discard since we're out of tile bounds
                 return true;
             }
         }

--- a/src/styles/text/label_line.js
+++ b/src/styles/text/label_line.js
@@ -94,7 +94,7 @@ export default class LabelLine extends Label {
         return aabb;
     }
 
-    moveInTile () {
+    moveIntoTile () {
         let in_tile = false;
         let fits_to_segment = this.fitToSegment();
 

--- a/src/styles/text/label_options.js
+++ b/src/styles/text/label_options.js
@@ -1,9 +1,9 @@
 export default class LabelOptions {
 
-    constructor ({ units_per_pixel, offset, anchor, line_exceed, move_in_tile, keep_in_tile, buffer } = {}) {
+    constructor ({ units_per_pixel, offset, anchor, line_exceed, move_into_tile, cull_from_tile, buffer } = {}) {
         this.buffer = buffer || [0, 0];
-        this.keep_in_tile = (keep_in_tile != null) ? keep_in_tile : true;
-        this.move_in_tile = (move_in_tile != null) ? move_in_tile : true;
+        this.cull_from_tile = (cull_from_tile != null) ? cull_from_tile : true;
+        this.move_into_tile = (move_into_tile != null) ? move_into_tile : true;
         this.offset = offset || [0, 0];
         this.anchor = anchor;
         this.line_exceed = (line_exceed != null) ? line_exceed : 80;

--- a/src/styles/text/label_options.js
+++ b/src/styles/text/label_options.js
@@ -1,11 +1,11 @@
 export default class LabelOptions {
 
-    constructor ({ units_per_pixel, offset, placement, line_exceed, move_in_tile, keep_in_tile, buffer } = {}) {
+    constructor ({ units_per_pixel, offset, anchor, line_exceed, move_in_tile, keep_in_tile, buffer } = {}) {
         this.buffer = buffer || [0, 0];
         this.keep_in_tile = (keep_in_tile != null) ? keep_in_tile : true;
         this.move_in_tile = (move_in_tile != null) ? move_in_tile : true;
         this.offset = offset || [0, 0];
-        this.placement = placement;
+        this.anchor = anchor;
         this.line_exceed = (line_exceed != null) ? line_exceed : 80;
         this.units_per_pixel = units_per_pixel || 1;
     }

--- a/src/styles/text/label_options.js
+++ b/src/styles/text/label_options.js
@@ -1,12 +1,13 @@
 export default class LabelOptions {
 
-    constructor ({ units_per_pixel, offset, line_exceed, move_in_tile, keep_in_tile, buffer }) {
-        this.buffer = buffer|| [0, 0];
+    constructor ({ units_per_pixel, offset, placement, line_exceed, move_in_tile, keep_in_tile, buffer } = {}) {
+        this.buffer = buffer || [0, 0];
         this.keep_in_tile = (keep_in_tile != null) ? keep_in_tile : true;
         this.move_in_tile = (move_in_tile != null) ? move_in_tile : true;
         this.offset = offset || [0, 0];
+        this.placement = placement;
         this.line_exceed = (line_exceed != null) ? line_exceed : 80;
-        this.units_per_pixel = units_per_pixel;
+        this.units_per_pixel = units_per_pixel || 1;
     }
 
 }

--- a/src/styles/text/label_point.js
+++ b/src/styles/text/label_point.js
@@ -2,11 +2,11 @@ import Label from './label';
 import Geo from '../../geo';
 import OBB from '../../utils/obb';
 
-// Sets of values to match for cardinal placements
-const wests = ['W', 'NW', 'SW'];
-const easts = ['E', 'NE', 'SE'];
-const norths = ['N', 'NW', 'NE'];
-const souths = ['S', 'SW', 'SE'];
+// Sets of values to match for directional and corner anchors
+const lefts = ['left', 'top-left', 'bottom-left'];
+const rights = ['right', 'top-right', 'bottom-right'];
+const tops = ['top', 'top-left', 'top-right'];
+const bottoms = ['bottom', 'bottom-left', 'bottom-right'];
 
 export default class LabelPoint extends Label {
 
@@ -22,26 +22,26 @@ export default class LabelPoint extends Label {
     }
 
     computeOffset () {
-        if (!this.options.placement) {
+        if (!this.options.anchor || this.options.anchor === 'center') {
             return this.options.offset;
         }
 
         let offset = [this.options.offset[0], this.options.offset[1]];
-        let p = this.options.placement;
+        let anchor = this.options.anchor;
 
-        // An optional west/east offset
-        if (wests.indexOf(p) > -1) {
+        // An optional left/right offset
+        if (LabelPoint.isLeftAnchor(anchor)) {
             offset[0] -= this.size.text_size[0] / 2;
         }
-        else if (easts.indexOf(p) > -1) {
+        else if (LabelPoint.isRightAnchor(anchor)) {
             offset[0] += this.size.text_size[0] / 2;
         }
 
-        // An optional north/south offset
-        if (norths.indexOf(p) > -1) {
+        // An optional top/bottom offset
+        if (LabelPoint.isTopAnchor(anchor)) {
             offset[1] -= this.size.text_size[1] / 2;
         }
-        else if (souths.indexOf(p) > -1) {
+        else if (LabelPoint.isBottomAnchor(anchor)) {
             offset[1] += this.size.text_size[1] / 2;
         }
 
@@ -92,6 +92,22 @@ export default class LabelPoint extends Label {
         }
 
         return !this.inTileBounds();
+    }
+
+    static isLeftAnchor (anchor) {
+        return (lefts.indexOf(anchor) > -1);
+    }
+
+    static isRightAnchor (anchor) {
+        return (rights.indexOf(anchor) > -1);
+    }
+
+    static isTopAnchor (anchor) {
+        return (tops.indexOf(anchor) > -1);
+    }
+
+    static isBottomAnchor (anchor) {
+        return (bottoms.indexOf(anchor) > -1);
     }
 
 }

--- a/src/styles/text/label_point.js
+++ b/src/styles/text/label_point.js
@@ -2,6 +2,12 @@ import Label from './label';
 import Geo from '../../geo';
 import OBB from '../../utils/obb';
 
+// Sets of values to match for cardinal placements
+const wests = ['W', 'NW', 'SW'];
+const easts = ['E', 'NE', 'SE'];
+const norths = ['N', 'NW', 'NE'];
+const souths = ['S', 'SW', 'SE'];
+
 export default class LabelPoint extends Label {
 
     constructor (text, position, size, options) {
@@ -21,17 +27,21 @@ export default class LabelPoint extends Label {
         }
 
         let offset = [this.options.offset[0], this.options.offset[1]];
+        let p = this.options.placement;
 
-        if (this.options.placement === 'W') {
+        // An optional west/east offset
+        if (wests.indexOf(p) > -1) {
             offset[0] -= this.size.text_size[0] / 2;
         }
-        else if (this.options.placement === 'E') {
+        else if (easts.indexOf(p) > -1) {
             offset[0] += this.size.text_size[0] / 2;
         }
-        else if (this.options.placement === 'N') {
+
+        // An optional north/south offset
+        if (norths.indexOf(p) > -1) {
             offset[1] -= this.size.text_size[1] / 2;
         }
-        else if (this.options.placement === 'S') {
+        else if (souths.indexOf(p) > -1) {
             offset[1] += this.size.text_size[1] / 2;
         }
 

--- a/src/styles/text/label_point.js
+++ b/src/styles/text/label_point.js
@@ -6,20 +6,42 @@ export default class LabelPoint extends Label {
 
     constructor (text, position, size, options) {
         super(text, size, options);
-
         this.position = position;
         this.update();
     }
 
     update() {
+        this.options.offset = this.computeOffset();
         this.aabb = this.computeAABB();
+    }
+
+    computeOffset () {
+        if (!this.options.placement) {
+            return this.options.offset;
+        }
+
+        let offset = [this.options.offset[0], this.options.offset[1]];
+
+        if (this.options.placement === 'W') {
+            offset[0] -= this.size.text_size[0] / 2;
+        }
+        else if (this.options.placement === 'E') {
+            offset[0] += this.size.text_size[0] / 2;
+        }
+        else if (this.options.placement === 'N') {
+            offset[1] -= this.size.text_size[1] / 2;
+        }
+        else if (this.options.placement === 'S') {
+            offset[1] += this.size.text_size[1] / 2;
+        }
+
+        return offset;
     }
 
     computeAABB () {
         let width = (this.size.text_size[0] + this.options.buffer[0] * 2) * this.options.units_per_pixel;
         let height = (this.size.text_size[1] + this.options.buffer[1] * 2) * this.options.units_per_pixel;
 
-        // apply offset, x positive, y pointing down
         let p = [
             this.position[0] + (this.options.offset[0] * this.options.units_per_pixel),
             this.position[1] - (this.options.offset[1] * this.options.units_per_pixel)

--- a/src/styles/text/label_point.js
+++ b/src/styles/text/label_point.js
@@ -64,7 +64,7 @@ export default class LabelPoint extends Label {
         return aabb;
     }
 
-    moveInTile () {
+    moveIntoTile () {
         let updated = false;
 
         if (this.aabb[0] < 0) {

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -629,6 +629,7 @@ Object.assign(TextStyle, {
                     buffer,
                     anchor,
                     line_exceed,
+                    move_into_tile: rule.move_into_tile,
                     ref: 0
                 };
             }

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -592,6 +592,11 @@ Object.assign(TextStyle, {
             offset[0] = parseFloat(offset[0]);
             offset[1] = parseFloat(offset[1]); // y-point down
 
+            // label placement (point labels only)
+            // label will be adjusted in the given cardinal direction, relatove to its original point
+            // one of: N, S, E, W
+            let placement = rule.placement;
+
             // label buffer in pixel
             let buffer = rule.buffer;
             if (buffer != null) {
@@ -617,6 +622,7 @@ Object.assign(TextStyle, {
                     priority,
                     offset,
                     buffer,
+                    placement,
                     line_exceed,
                     ref: 0
                 };

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -592,10 +592,10 @@ Object.assign(TextStyle, {
             offset[0] = parseFloat(offset[0]);
             offset[1] = parseFloat(offset[1]); // y-point down
 
-            // label placement (point labels only)
-            // label will be adjusted in the given cardinal direction, relatove to its original point
-            // one of: N, S, E, W
-            let placement = rule.placement;
+            // label anchors (point labels only)
+            // label will be adjusted in the given direction, relatove to its original point
+            // one of: left, right, top, bottom, top-left, top-right, bottom-left, bottom-right
+            let anchor = rule.anchor;
 
             // label buffer in pixel
             let buffer = rule.buffer;
@@ -622,7 +622,7 @@ Object.assign(TextStyle, {
                     priority,
                     offset,
                     buffer,
-                    placement,
+                    anchor,
                     line_exceed,
                     ref: 0
                 };

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -212,7 +212,7 @@ Object.assign(TextStyle, {
 
             // In the absence of better Canvas TextMetrics (not supported by browsers yet),
             // 0.75 buffer produces a better approximate vertical centering of text
-            let ty = y + buffer * .75 + (line_num + 1) * px_size;
+            let ty = y + buffer * 0.75 + (line_num + 1) * px_size;
 
             if (stroke) {
                 this.canvas[tile].context.strokeText(str, tx, ty);

--- a/test/labels_spec.js
+++ b/test/labels_spec.js
@@ -41,7 +41,7 @@ describe('Labels', () => {
                 it(`can move back into tile for ${edge} edge`, () => {
                     label.position = p;
                     label.update();
-                    let discarded = label.moveInTile();
+                    let discarded = label.moveIntoTile();
                     assert.isFalse(discarded);
                     assert.isTrue(label.inTileBounds());
                 });


### PR DESCRIPTION
Add a `placement` property for point labels, to place them in a cardinal direction anchored to their point position (default positioning is centered on anchor point).

Example:

```
draw:
   text:
      placement: E
      offset: [12px, 0px]
      font:
         ...
```

Valid `placement` values are: `N`, `S`, `W`, `E`. Note these are actually interpreted as relative up/down/left/right placements relative to the anchor, not actually moving the label in the specified direction on the map. If this is undesirable we can also use an alternative like: `up`, `down`, `left`, `right`.

Also still thinking about support for:

- Dynamically determining `placement` from a feature property and/or JS function
- Supporting multiple placement options, to try in order of priority, e.g. `placement: [E, S]`
