### PR TITLE
Dynamic label priority

### DIFF
--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -437,7 +437,19 @@ Object.assign(TextStyle, {
             }
 
             // label priority (lower is higher)
-            let priority = (rule.priority !== undefined) ? parseFloat(rule.priority) : -1 >>> 0;
+            let priority = rule.priority;
+            if (priority !== undefined) {
+                // if priority is a number, use it as-is, otherwise, check type
+                if (typeof priority === 'string') {
+                    priority = feature.properties[priority]; // get priority from feature property
+                }
+                else if (typeof priority === 'function') {
+                    priority = priority(context);
+                }
+            }
+            else {
+                priority = -1 >>> 0; // default to max priority value if none set
+            }
 
             // label offset in pixel (applied in screen space)
             let offset = rule.offset || [0, 0];

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -440,10 +440,11 @@ Object.assign(TextStyle, {
             let priority = rule.priority;
             if (priority !== undefined) {
                 // if priority is a number, use it as-is, otherwise, check type
-                if (typeof priority === 'string') {
-                    priority = feature.properties[priority]; // get priority from feature property
-                }
-                else if (typeof priority === 'function') {
+                // if (typeof priority === 'string') {
+                //     priority = feature.properties[priority]; // get priority from feature property
+                // }
+                // else if (typeof priority === 'function') {
+                if (typeof priority === 'function') {
                     priority = priority(context);
                 }
             }


### PR DESCRIPTION
Adds the ability for the label `priority` parameter to be dynamic, either:

- Tied to a feature property, by setting `priority` to a string value with the property name, e.g.
  - `priority: label_priority`
- Computed from a JS function, e.g.
  - `priority: function() { return Math.floor(feature.area / 1000); }`

Requested by @nvkelso for upcoming tile data for label priorities.