### PR TITLE
Track shader block 'scope'

### DIFF
--- a/src/material.js
+++ b/src/material.js
@@ -91,7 +91,7 @@ export default class Material {
             style.texcoords = style.texcoords || (this.normal.mapping === 'uv');
         }
 
-        style.replaceShaderBlock(Material.block, shaderSources['gl/shaders/material']);
+        style.replaceShaderBlock(Material.block, shaderSources['gl/shaders/material'], 'Material');
     }
 
     setupProgram (_program) {

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -270,6 +270,7 @@ export var Style = {
 
         // Get any custom code blocks, uniform dependencies, etc.
         var blocks = (this.shaders && this.shaders.blocks);
+        var block_scopes = (this.shaders && this.shaders.block_scopes);
         var uniforms = (this.shaders && this.shaders.uniforms);
 
         // accept a single extension, or an array of extensions
@@ -289,6 +290,7 @@ export var Style = {
                     defines,
                     uniforms,
                     blocks,
+                    block_scopes,
                     extensions
                 }
             );
@@ -304,6 +306,7 @@ export var Style = {
                         defines: selection_defines,
                         uniforms,
                         blocks,
+                        block_scopes,
                         extensions
                     }
                 );
@@ -324,10 +327,14 @@ export var Style = {
     },
 
     // Add a shader block
-    addShaderBlock (key, ...blocks) {
+    addShaderBlock (key, block, scope = null) {
         this.shaders.blocks = this.shaders.blocks || {};
         this.shaders.blocks[key] = this.shaders.blocks[key] || [];
-        this.shaders.blocks[key].push(...blocks);
+        this.shaders.blocks[key].push(block);
+
+        this.shaders.block_scopes = this.shaders.block_scopes || {};
+        this.shaders.block_scopes[key] = this.shaders.block_scopes[key] || [];
+        this.shaders.block_scopes[key].push(scope);
     },
 
     // Remove all shader blocks for key
@@ -337,9 +344,9 @@ export var Style = {
         }
     },
 
-    replaceShaderBlock (key, ...blocks) {
+    replaceShaderBlock (key, block, scope = null) {
         this.removeShaderBlock(key);
-        this.addShaderBlock(key, ...blocks);
+        this.addShaderBlock(key, block, scope);
     },
 
     /** TODO: could probably combine and generalize this with similar method in ShaderProgram

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -235,17 +235,24 @@ StyleManager.mix = function (style, styles) {
         }, {}) || {}
     );
 
-    merge.map(x => x.blocks).filter(x => x).forEach(blocks => {
+    // Keep track of which style each block originated from
+    let merge_block_scopes = sources.filter(x => x.shaders && x.shaders.blocks).map(x => x.name);
+
+    merge.map(x => x.blocks).filter(x => x).forEach((blocks, num) => {
         shaders.blocks = shaders.blocks || {};
+        shaders.block_scopes = shaders.block_scopes || {};
 
         for (let [t, block] of Utils.entries(blocks)) {
             shaders.blocks[t] = shaders.blocks[t] || [];
+            shaders.block_scopes[t] = shaders.block_scopes[t] || [];
 
             if (Array.isArray(block)) {
                 shaders.blocks[t].push(...block);
+                shaders.block_scopes[t].push(...block.map(() => merge_block_scopes[num]));
             }
             else {
                 shaders.blocks[t].push(block);
+                shaders.block_scopes[t].push(merge_block_scopes[num]);
             }
         }
     });


### PR DESCRIPTION
We recently added shader error events with detailed metadata, allowing Tangram Play to extract information about which styles shader blocks failed to compile, including specific line numbers mapped from GL shader compile errors. However, after using this in the editor, it became clear that the need was more complex than the original implementation. For example, Tangram itself injects `global` shader blocks internally, for common shared functions, throwing off the line numbers for user-defined shader code. Additionally, compile errors in a block that was mixed in from a 'parent' style wouldn't be found when the 'child' style failed to compile, preventing the error from being properly syntax highlighted.

This PR adds lower-level tracking of where each shader block came from. For example, when `styleA` mixes in `styleB`, we now track which blocks came from the 'parent `styleA`, and which were added as part of `styleB`'s own definition. This adds more detailed error metadata, which should allow Tangram Play or other clients to properly trace the error back to its original source.


