### PR TITLE
Update font properties to match ES

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -348,7 +348,8 @@ layers:
                     priority: 2
                     font:
                         fill: '#666'
-                        typeface: 12px Helvetica
+                        family: Helvetica
+                        size: 12px
                         stroke: { color: white, width: 4 }
 
         not_highway:
@@ -359,7 +360,8 @@ layers:
                     font:
                         fill: '#666'
                         stroke: { color: white, width: 4 }
-                        typeface: 12px Helvetica
+                        family: Helvetica
+                        size: 12px
 
             major_road:
                 filter: { kind: major_road, $zoom: { min: 14 } }
@@ -367,7 +369,8 @@ layers:
                     text:
                         priority: 3
                         font:
-                            typeface: 16px Helvetica
+                            family: Helvetica
+                            size: 16px
                             stroke: { color: white, width: 4 }
 
             small:
@@ -436,7 +439,9 @@ layers:
             text:
                 priority: 1
                 font:
-                    typeface: italic 11pt Helvetica
+                    family: Helvetica
+                    size: 11pt
+                    style: italic
                     fill: black
                     stroke: { color: white, width: 3 }
         continents:
@@ -456,14 +461,19 @@ layers:
             draw:
                 text:
                     font:
-                        typeface: italic 14pt Baskerville
+                        family: Baskerville
+                        size: 14pt
+                        style: italic
+
         cities:
             # this filter shows lower scaleranks at higher zooms, starting at z4
             filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }
             draw:
                 text:
                     font:
-                        typeface: italic 12pt Helvetica
+                        family: Helvetica
+                        size: 12pt
+                        style: italic
                         fill: black
                         stroke: { color: white, width: 3 }
         minor-places:
@@ -490,7 +500,9 @@ layers:
                 text:
                     priority: 4
                     font:
-                        typeface: Italic 10pt Lucida Grande
+                        family: Lucida Grande
+                        size: 10pt
+                        style: italic
                         fill: darkgreen
                         stroke: { color: white, width: 3 }
 
@@ -505,7 +517,8 @@ layers:
                     offset: [0px, 13px]
                     priority: 6
                     font:
-                        typeface: 12px Helvetica
+                        family: Helvetica
+                        size: 12px
                         fill: black
 
     # building_labels:
@@ -519,7 +532,8 @@ layers:
     #         text:
     #             priority: 6
     #             font:
-    #                 typeface: 8pt Lucida Grande
+    #                 family: Lucida Grande
+    #                 size: 8pt
     #                 fill: darkred
     #                 stroke: { color: white, width: 3 }
 
@@ -535,7 +549,8 @@ layers:
     #             text_source: schoolDistrict
     #             font:
     #                 fill: white
-    #                 typeface: 16px Futura
+    #                 family: Futura
+    #                 size: 16px
     #                 stroke: { color: black, width: 4 }
 
     # counties:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -476,8 +476,9 @@ layers:
                         style: italic
                         fill: black
                         stroke: { color: white, width: 3 }
+
         minor-places:
-            filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 13 } }
+            filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 14 } }
             visible: false
 
     point_labels:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -449,13 +449,13 @@ layers:
             draw:
                 text:
                     font:
-                        capitalized: true
+                        transform: uppercase
         countries:
             filter: { kind: country }
             draw:
                 text:
                     font:
-                        capitalized: true
+                        transform: uppercase
         oceans:
             filter: { kind: ocean }
             draw:

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -33,12 +33,13 @@ export default class FeatureLabel {
         // - size: in pt, px, or em
         // - style: normal, italic, oblique
         // - weight: normal, bold, etc.
+        // - transform: capitalize, uppercase, lowercase
         style.style = rule.font.style || default_font_style.style;
         style.weight = rule.font.weight || default_font_style.weight;
         style.family = rule.font.family || default_font_style.family;
-        // style.capitalized = rule.font.capitalized || default_font_style.capitalized; // TODO new syntax
+        style.transform = rule.font.transform;
 
-        let size = rule.font.size || rule.font.typeface || default_font_style.size;
+        let size = rule.font.size || rule.font.typeface || default_font_style.size; // TODO: 'typeface' legacy syntax, deprecate
         let size_regex = /([0-9]*\.)?[0-9]+(px|pt|em|%)/g;
         let ft_size = (size.match(size_regex) || [])[0];
         let size_kind = ft_size.replace(/([0-9]*\.)?[0-9]+/g, '');
@@ -49,7 +50,7 @@ export default class FeatureLabel {
         style.stroke_width *= Utils.device_pixel_ratio;
         style.size = size.replace(size_regex, style.px_size + "px");
 
-        if (rule.font.typeface) { // legacy syntax
+        if (rule.font.typeface) { // 'typeface' legacy syntax, deprecate
             style.font_css = rule.font.typeface.replace(size_regex, style.px_size + "px");
         }
         else {
@@ -59,14 +60,32 @@ export default class FeatureLabel {
         return style;
     }
 
-    // Build CSS-style font string
+    // Build CSS-style font string (to set Canvas draw state)
     fontCSS ({ style, weight, size, family }) {
         return [style, weight, size, family]
             .filter(x => x) // remove null props
-            . join(' ');
+            .join(' ');
     }
 
-    constructStyleKey ({ style, weight, family, size, fill, stroke, stroke_width, typeface }) {
-        return [style, weight, family, size, fill, stroke, stroke_width, typeface].join('/'); // typeface for legacy
+    // A key for grouping all labels of the same text style (e.g. same Canvas state, to minimize state changes)
+    constructStyleKey ({ style, weight, family, size, fill, stroke, stroke_width, transform, typeface }) {
+        return [style, weight, family, size, fill, stroke, stroke_width, transform, typeface].join('/'); // typeface for legacy
     }
+
+    // Called before rasterization
+    static applyTextTransform (text, transform) {
+        if (transform === 'capitalize') {
+            return text.replace(/\w\S*/g, function (txt) {
+                return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+            });
+        }
+        else if (transform === 'uppercase') {
+            return text.toUpperCase();
+        }
+        else if (transform === 'lowercase') {
+            return text.toLowerCase();
+        }
+        return text;
+    }
+
 }

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -3,11 +3,11 @@ import {StyleParser} from '../style_parser';
 
 export default class FeatureLabel {
 
-    constructor (feature, rule, context, text, tile, font_style) {
+    constructor (feature, rule, context, text, tile, default_font_style) {
         this.text = text;
         this.feature = feature;
         this.tile_key = tile.key;
-        this.style = this.constructFontStyle(rule, context, font_style);
+        this.style = this.constructFontStyle(rule, context, default_font_style);
         this.style_key = this.constructStyleKey(this.style);
     }
 
@@ -16,21 +16,21 @@ export default class FeatureLabel {
         return Utils.hashString(str);
     }
 
-    constructFontStyle (rule, context, font_style) {
+    constructFontStyle (rule, context, default_font_style) {
         let style = {};
 
         // Use fill if specified, or default
-        style.fill = (rule.font.fill && Utils.toCanvasColor(StyleParser.parseColor(rule.font.fill, context))) || font_style.fill;
+        style.fill = (rule.font.fill && Utils.toCanvasColor(StyleParser.parseColor(rule.font.fill, context))) || default_font_style.fill;
 
         // Use stroke if specified
         if (rule.font.stroke && rule.font.stroke.color) {
             style.stroke = Utils.toCanvasColor(StyleParser.parseColor(rule.font.stroke.color));
-            style.stroke_width = rule.font.stroke.width || font_style.stroke.width;
+            style.stroke_width = rule.font.stroke.width || default_font_style.stroke.width;
         }
 
         // Use default typeface
-        style.font = rule.font.typeface || font_style.typeface;
-        style.capitalized = rule.font.capitalized || font_style.capitalized;
+        style.font = rule.font.typeface || default_font_style.typeface;
+        style.capitalized = rule.font.capitalized || default_font_style.capitalized;
 
         let size_regex = /([0-9]*\.)?[0-9]+(px|pt|em|%)/g;
         let ft_size = style.font.match(size_regex)[0];

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -104,8 +104,8 @@ Object.assign(TextStyle, {
     },
 
     // Width and height of text based on current font style
-    textSize (text, tile, capitalized) {
-        let str = capitalized ? text.toUpperCase() : text;
+    textSize (text, tile, transform) {
+        let str = FeatureLabel.applyTextTransform(text, transform);
         let ctx = this.canvas[tile].context;
         let px_size = this.px_size;
         let px_logical_size = this.px_logical_size;
@@ -126,8 +126,8 @@ Object.assign(TextStyle, {
     },
 
     // Draw text at specified location, adjusting for buffer and baseline
-    drawText (text, [x, y], tile, stroke, capitalized) {
-        let str = capitalized ? text.toUpperCase() : text;
+    drawText (text, [x, y], tile, stroke, transform) {
+        let str = FeatureLabel.applyTextTransform(text, transform);
         let buffer = this.text_buffer * Utils.device_pixel_ratio;
         if (stroke) {
             this.canvas[tile].context.strokeText(str, x + buffer, y + buffer + this.px_size);
@@ -176,7 +176,7 @@ Object.assign(TextStyle, {
                 let text_style = text_infos[text].text_style;
                 // update text sizes
                 this.setFont(tile, text_style); // TODO: only set once above
-                text_infos[text].size = this.textSize(text, tile, text_style.capitalized);
+                text_infos[text].size = this.textSize(text, tile, text_style.transform);
             }
         }
 
@@ -191,7 +191,7 @@ Object.assign(TextStyle, {
                 let info = text_infos[text];
 
                 this.setFont(tile, info.text_style); // TODO: only set once above
-                this.drawText(text, info.position, tile, info.text_style.stroke, info.text_style.capitalized);
+                this.drawText(text, info.position, tile, info.text_style.stroke, info.text_style.transform);
 
                 info.texcoords = Builders.getTexcoordsForSprite(
                     info.position,

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -39,10 +39,12 @@ Object.assign(TextStyle, {
         this.defines.TANGRAM_UNMULTIPLY_ALPHA = true;
 
         // default font style
-        this.font_style = {
-            typeface: 'Helvetica 12px',
-            fill: 'white',
-            capitalized: false
+        this.default_font_style = {
+            style: 'normal',
+            weight: null,
+            size: '12px',
+            family: 'Helvetica',
+            fill: 'white'
         };
 
         this.reset();
@@ -82,13 +84,13 @@ Object.assign(TextStyle, {
     },
 
     // Set font style params for canvas drawing
-    setFont (tile, { font, fill, stroke, stroke_width, px_size, px_logical_size }) {
+    setFont (tile, { font_css, fill, stroke, stroke_width, px_size, px_logical_size }) {
         this.px_size = parseInt(px_size);
         this.px_logical_size = parseInt(px_logical_size);
         this.text_buffer = 8; // pixel padding around text
         let ctx = this.canvas[tile].context;
 
-        ctx.font = font;
+        ctx.font = font_css;
         if (stroke) {
             ctx.strokeStyle = stroke;
             ctx.lineWidth = stroke_width;
@@ -173,7 +175,7 @@ Object.assign(TextStyle, {
             for (let text in text_infos) {
                 let text_style = text_infos[text].text_style;
                 // update text sizes
-                this.setFont(tile, text_style);
+                this.setFont(tile, text_style); // TODO: only set once above
                 text_infos[text].size = this.textSize(text, tile, text_style.capitalized);
             }
         }
@@ -188,7 +190,7 @@ Object.assign(TextStyle, {
             for (let text in text_infos) {
                 let info = text_infos[text];
 
-                this.setFont(tile, info.text_style);
+                this.setFont(tile, info.text_style); // TODO: only set once above
                 this.drawText(text, info.position, tile, info.text_style.stroke, info.text_style.capitalized);
 
                 info.texcoords = Builders.getTexcoordsForSprite(
@@ -421,7 +423,7 @@ Object.assign(TextStyle, {
             }
 
             // features stored by hash for later use from main thread (tile / text / style)
-            let label_feature = new FeatureLabel(feature, rule, context, text, tile, this.font_style);
+            let label_feature = new FeatureLabel(feature, rule, context, text, tile, this.default_font_style);
             let feature_hash = label_feature.getHash();
 
             if (!label_feature.style) {


### PR DESCRIPTION
Split single `typeface` property into individual properties that match Tangram ES syntax:

- `family`: Helvetica, Futura, eta.
- `size`: in pt, px, or em
- `style`: e.g. italic
- `weight`: e.g. bold
- `transform`: capitalize, uppercase, lowercase

Keeps legacy support for `typeface`, will be deprecated.