### PR TITLE
Include text of style evalutation error in debug log

### DIFF
--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -136,7 +136,7 @@ Utils.isWorkerThread && Object.assign(self, {
                         tile.loading = false;
                         tile.loaded = false;
                         tile.error = error.toString();
-                        Utils.log('error', `tile load error for ${tile.key}: ${error.stack}`);
+                        Utils.log('error', `tile load error for ${tile.key}: ${tile.error} at: ${error.stack}`);
 
                         resolve({ tile: Tile.slice(tile) });
                     });


### PR DESCRIPTION
This makes it much easier to track down problems with `eval`ed functions from the scene file.