### PR TITLE
Adjust for Safari Canvas alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gl-matrix": "2.2.1",
     "js-yaml": "^3.1.0",
     "loglevel": "~1.2.0",
+    "bowser": "1.0.0",
     "strip-comments": "^0.3.2",
     "gl-shader-errors": "^1.0.3",
     "pbf": "1.3.2",

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -34,9 +34,9 @@ Object.assign(TextStyle, {
         // (labels are always drawn with textures)
         this.defines.TANGRAM_POINT_TEXTURE = true;
 
-        // Manually un-multiply alpha, because Canvas text rasterization is pre-multiplied
+        // Manually un-multiply alpha, because some Canvas text rasterization is pre-multiplied
         // See https://github.com/tangrams/tangram/issues/179
-        this.defines.TANGRAM_UNMULTIPLY_ALPHA = true;
+        this.defines.TANGRAM_UNMULTIPLY_ALPHA = Utils.canvasPremultipliedAlpha();
 
         // default font style
         this.default_font_style = {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,6 +3,7 @@
 
 import log from 'loglevel';
 import yaml from 'js-yaml';
+import bowser from 'bowser';
 import Geo from '../geo';
 
 var Utils;
@@ -147,6 +148,11 @@ Utils.loadResource = function (source) {
             resolve(source);
         }
     });
+};
+
+// Wrapper for browser info
+Utils.browser = function () {
+    return bowser;
 };
 
 // Needed for older browsers that still support WebGL (Safari 6 etc.)
@@ -416,6 +422,11 @@ Utils.radToDeg = function (radians) {
 
 Utils.toCanvasColor = function (color) {
     return 'rgb(' +  Math.round(color[0] * 255) + ',' + Math.round(color[1]  * 255) + ',' + Math.round(color[2] * 255) + ')';
+};
+
+// Some Canvas implementations have pre-multiplied alpha that we need to adjust for
+Utils.canvasPremultipliedAlpha = function () {
+    return (Utils.browser().safari ? false : true);
 };
 
 Utils.toPixelSize = function (size, kind) {


### PR DESCRIPTION
Canvas text in Safari appears to NOT be premultiplied, unlike in Chrome and FF.

See https://github.com/tangrams/tangram/issues/179 for background.