### PR TITLE
Leaflet zoom/scroll wheel adjustment

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -199,7 +199,7 @@ if (Utils.isMainThread) {
                     map.stop(); // stop panning and fly animations if any
 
                     // NOTE: this is the only real modification to default leaflet behavior
-                    delta /= 40;
+                    delta /= 30;
 
                     delta = Math.max(Math.min(delta, 4), -4);
                     delta = map._limitZoom(zoom + delta) - zoom;

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -191,6 +191,16 @@ if (Utils.isMainThread) {
         modifyScrollWheelBehavior: function (map) {
             if (this.scene.continuous_zoom && map.scrollWheelZoom && this.options.modifyScrollWheel !== false) {
                 let layer = this;
+
+                map.scrollWheelZoom._onWheelScroll = function(e) {
+                    // modify to skip debounce, as it seems to cause animation-sync issues in Chrome
+                    // with Tangram continuous rendering
+                    this._delta += L.DomEvent.getWheelDelta(e);
+                    this._lastMousePos = this._map.mouseEventToContainerPoint(e);
+                    this._performZoom();
+                    L.DomEvent.stop(e);
+                };
+
                 map.scrollWheelZoom._performZoom = function () {
                     var map = this._map,
                         delta = this._delta,
@@ -227,6 +237,10 @@ if (Utils.isMainThread) {
 
                     layer.debounceViewReset();
                 };
+
+                // Re-init scroll wheel
+                map.scrollWheelZoom.removeHooks();
+                map.scrollWheelZoom.addHooks();
             }
         },
 

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -29,6 +29,7 @@ if (Utils.isMainThread) {
         initialize: function (options) {
             // Defaults
             options.showDebug = (!options.showDebug ? false : true);
+            options.wheelDebounceTime = options.wheelDebounceTime || 40;
 
             L.setOptions(this, options);
             this.createScene();
@@ -37,6 +38,11 @@ if (Utils.isMainThread) {
 
             // Force leaflet zoom animations off
             this._zoomAnimated = false;
+
+            this.debounceViewReset = Utils.debounce(() => {
+                this._map.fire('zoomend');
+                this._map.fire('moveend');
+            }, this.options.wheelDebounceTime);
         },
 
         createScene: function () {
@@ -184,6 +190,7 @@ if (Utils.isMainThread) {
         // default behavior is presumably improved
         modifyScrollWheelBehavior: function (map) {
             if (this.scene.continuous_zoom && map.scrollWheelZoom && this.options.modifyScrollWheel !== false) {
+                let layer = this;
                 map.scrollWheelZoom._performZoom = function () {
                     var map = this._map,
                         delta = this._delta,
@@ -217,6 +224,8 @@ if (Utils.isMainThread) {
 
                         map._move(newCenter, newZoom);
                     }
+
+                    layer.debounceViewReset();
                 };
             }
         },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -440,12 +440,31 @@ Utils.hashString = function(str) {
         return 0;
     }
     let hash = 0;
-    
+
     for (let i = 0, len = str.length; i < len; i++) {
         let chr = str.charCodeAt(i);
         hash = ((hash << 5) - hash) + chr;
-        hash |= 0; 
+        hash |= 0;
     }
     return hash;
 };
 
+Utils.debounce = function (func, wait, immediate) {
+    let timeout;
+    return function() {
+        let context = this,
+            args = arguments;
+        let later = function() {
+            timeout = null;
+            if (!immediate) {
+                func.apply(context, args);
+            }
+        };
+        let callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) {
+            func.apply(context, args);
+        }
+    };
+};


### PR DESCRIPTION
Further modifications to Leaflet mouse-wheel scrolling and zoom behavior. Fixes an apparent recent regression in Chrome, where some interaction between Tangram, Leaflet, Chrome requestAnimationFrame (and CodeMirror in the case of Tangram Play) was causing a sync lock, making mouse wheel scroll lock up for animated styles (no scroll would occur until the wheel was stopped moving, then it would move either a very small amount, or a big jump). This seemed related to Leaflet's debounce processing the scroll wheel input. This PR disables that. (These modifications can be disabled with the `modifyScrollWheel: false` option if they cause conflicts with other client app expectations or a need for default Leaflet scroll wheel behavior.)