### PR TITLE
Don't extrude polygon edges along tile boundaries by default

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -84,7 +84,13 @@ Builders.buildExtrudedPolygons = function (
     vertex_data, vertex_template,
     normal_index,
     normal_normalize,
-    { texcoord_index, texcoord_scale, texcoord_normalize }) {
+    {
+        remove_tile_edges,
+        tile_edge_tolerance,
+        texcoord_index,
+        texcoord_scale,
+        texcoord_normalize
+    }) {
 
     // Top
     var min_z = z + (min_height || 0);
@@ -116,6 +122,10 @@ Builders.buildExtrudedPolygons = function (
             var contour = polygon[q];
 
             for (var w=0; w < contour.length - 1; w++) {
+                if (remove_tile_edges && Builders.isOnTileEdge(contour[w], contour[w+1], { tolerance: tile_edge_tolerance })) {
+                    continue; // don't extrude tile edges
+                }
+
                 // Two triangles for the quad formed by each vertex pair, going from bottom to top height
                 var wall_vertices = [
                     // Triangle

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -96,7 +96,7 @@ Object.assign(Lines, {
 
         style.cap = rule_style.cap;
         style.join = rule_style.join;
-        style.tile_edges = rule_style.tile_edges;
+        style.tile_edges = rule_style.tile_edges; // usually activated for debugging, or rare visualization needs
 
         // Construct an outline style
         style.outline = style.outline || {};

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -5,6 +5,7 @@ import {StyleParser} from '../style_parser';
 import gl from '../../gl/constants'; // web workers don't have access to GL context, so import all GL constants
 import VertexLayout from '../../gl/vertex_layout';
 import Builders from '../builders';
+import Geo from '../../geo';
 
 export var Polygons = Object.create(Style);
 
@@ -72,6 +73,8 @@ Object.assign(Polygons, {
             }
         }
 
+        style.tile_edges = rule_style.tile_edges; // usually activated for debugging, or rare visualization needs
+
         // style.outline = style.outline || {};
         // if (rule_style.outline) {
         //     style.outline.color = StyleParser.parseColor(rule_style.outline.color, context);
@@ -137,12 +140,14 @@ Object.assign(Polygons, {
         return this.vertex_template;
     },
 
-    buildPolygons(polygons, style, vertex_data) {
+    buildPolygons(polygons, style, vertex_data, context) {
         let vertex_template = this.makeVertexTemplate(style);
-        let texcoords = {
+        let options = {
             texcoord_index: this.vertex_layout.index.a_texcoord,
             texcoord_scale: this.texcoord_scale,
-            texcoord_normalize: 65535 // scale UVs to unsigned shorts
+            texcoord_normalize: 65535, // scale UVs to unsigned shorts
+            remove_tile_edges: !style.tile_edges,
+            tile_edge_tolerance: Geo.tile_scale * context.tile.pad_scale * 4
         };
 
         // Extruded polygons (e.g. 3D buildings)
@@ -153,7 +158,7 @@ Object.assign(Polygons, {
                 vertex_data, vertex_template,
                 this.vertex_layout.index.a_normal,
                 127, // scale normals to signed bytes
-                texcoords
+                options
             );
         }
         // Regular polygons
@@ -161,7 +166,7 @@ Object.assign(Polygons, {
             Builders.buildPolygons(
                 polygons,
                 vertex_data, vertex_template,
-                texcoords
+                options
             );
         }
     }


### PR DESCRIPTION
When constructing polylines, we exclude line segments that coincide with tile boundaries by default (they can be enabled if desired with the `tile_edges: true` style parameter, usually for debugging).

We have not been applying the same logic to polygon extrusion, most likely an oversight. We haven't noticed because Mapzen vector tile building polygons are unclipped, and these are the most common extrusion case. A recent issue reported by a user revealed this problem when using non-tiled GeoJSON.

This extends the same behavior (and `tile_edges` flag) to the `polygons` style.