### PR TITLE
Alpha background

### DIFF
--- a/demos/css/main.css
+++ b/demos/css/main.css
@@ -15,7 +15,7 @@ body {
     width: 200px;
     margin-left: -100px;
     position: absolute;
-    z-index: 10;
+    z-index: 100001;
     text-align: center;
     font-family: Helvetica, sans-serif;
     font-size: 12px;

--- a/demos/main.js
+++ b/demos/main.js
@@ -189,7 +189,7 @@ Enjoy!
     // Update URL hash on move
     map.attributionControl.setPrefix('');
     map.setView(map_start_location.slice(0, 2), map_start_location[2]);
-    map.on('moveend', updateURL);
+    map.on('move', updateURL);
 
     // Take a screenshot and save file
     function screenshot() {
@@ -481,7 +481,7 @@ Enjoy!
         selection_info.style.display = 'block';
 
         // Show selected feature on hover
-        scene.container.addEventListener('mousemove', function (event) {
+        map.getContainer().addEventListener('mousemove', function (event) {
             if (gui['feature info'] == false) {
                 if (selection_info.parentNode != null) {
                     selection_info.parentNode.removeChild(selection_info);
@@ -498,18 +498,17 @@ Enjoy!
                 }
                 var feature = selection.feature;
                 if (feature != null) {
-                    // console.log("selection map: " + JSON.stringify(feature));
-
                     var label = '';
                     if (feature.properties.name != null) {
                         label = feature.properties.name;
                     }
+                    // Object.keys(feature.properties).forEach(p => label += `<b>${p}:</b> ${feature.properties[p]}<br>`);
 
                     if (label != '') {
                         selection_info.style.left = (pixel.x + 5) + 'px';
                         selection_info.style.top = (pixel.y + 15) + 'px';
                         selection_info.innerHTML = '<span class="labelInner">' + label + '</span>';
-                        scene.container.appendChild(selection_info);
+                        map.getContainer().appendChild(selection_info);
                     }
                     else if (selection_info.parentNode != null) {
                         selection_info.parentNode.removeChild(selection_info);
@@ -534,10 +533,10 @@ Enjoy!
     function preUpdate (will_render) {
         // Input
         if (key.isPressed('up')) {
-            map.setZoom(map.getZoom() + zoom_step);
+            map._move(map.getCenter(), map.getZoom() + zoom_step);
         }
         else if (key.isPressed('down')) {
-            map.setZoom(map.getZoom() - zoom_step);
+            map._move(map.getCenter(), map.getZoom() - zoom_step);
         }
 
         // Profiling
@@ -589,10 +588,16 @@ Enjoy!
             window.osm_layer =
                 L.tileLayer(
                     'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    { opacity: 0.5 })
-                .bringToFront()
+                    // 'https://stamen-tiles.a.ssl.fastly.net/terrain-background/{z}/{x}/{y}.jpg',
+                    {
+                        maxZoom: 19//,
+                        // opacity: 0.5
+                    })
                 .addTo(map);
+                // .bringToFront();
         }
+
+        layer.bringToFront();
     });
 
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "gl-matrix": "2.2.1",
     "js-yaml": "^3.1.0",
     "loglevel": "~1.2.0",
-    "bowser": "1.0.0",
     "strip-comments": "^0.3.2",
     "gl-shader-errors": "^1.0.3",
     "pbf": "1.3.2",

--- a/src/gl/render_state.js
+++ b/src/gl/render_state.js
@@ -30,15 +30,13 @@ export default class RenderState {
 
     	// Blending mode
     	RenderState.blending = new RenderState(
-            { blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA },
+            { blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA, src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA },
             (value) => {
     			if (value.blend) {
             		gl.enable(gl.BLEND);
 
                     if (value.src_alpha && value.dst_alpha) {
-                        gl.blendFuncSeparate(
-                            value.src, value.dst,
-                            value.src_alpha || gl.ONE, value.dst_alpha || gl.ONE_MINUS_SRC_ALPHA);
+                        gl.blendFuncSeparate(value.src, value.dst, value.src_alpha, value.dst_alpha);
                     }
                     else {
                         gl.blendFunc(value.src, value.dst);

--- a/src/gl/render_state.js
+++ b/src/gl/render_state.js
@@ -30,11 +30,17 @@ export default class RenderState {
 
     	// Blending mode
     	RenderState.blending = new RenderState(
-    		{ blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA},
-    		(value) => {
+            { blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA, src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA },
+            (value) => {
     			if (value.blend) {
             		gl.enable(gl.BLEND);
-                	gl.blendFunc(value.src, value.dst);
+
+                    if (value.src_alpha && value.dst_alpha) {
+                        gl.blendFuncSeparate(value.src, value.dst, value.src_alpha, value.dst_alpha);
+                    }
+                    else {
+                        gl.blendFunc(value.src, value.dst);
+                    }
     			} else {
     				gl.disable(gl.BLEND);
     			}

--- a/src/gl/render_state.js
+++ b/src/gl/render_state.js
@@ -30,13 +30,15 @@ export default class RenderState {
 
     	// Blending mode
     	RenderState.blending = new RenderState(
-            { blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA, src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA },
+            { blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA },
             (value) => {
     			if (value.blend) {
             		gl.enable(gl.BLEND);
 
                     if (value.src_alpha && value.dst_alpha) {
-                        gl.blendFuncSeparate(value.src, value.dst, value.src_alpha, value.dst_alpha);
+                        gl.blendFuncSeparate(
+                            value.src, value.dst,
+                            value.src_alpha || gl.ONE, value.dst_alpha || gl.ONE_MINUS_SRC_ALPHA);
                     }
                     else {
                         gl.blendFunc(value.src, value.dst);

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -88,7 +88,7 @@ if (Utils.isMainThread) {
 
                 this.scene.setView(view);
                 this.scene.immediateRedraw();
-                this.reverseTransform(map);
+                this.reverseTransform();
                 this._updating_tangram = false;
             };
             map.on('move', this.hooks.move);
@@ -137,7 +137,7 @@ if (Utils.isMainThread) {
 
                 this.updateSize();
                 this.updateView();
-                this.reverseTransform(map);
+                this.reverseTransform();
 
                 this._updating_tangram = false;
 
@@ -281,35 +281,15 @@ if (Utils.isMainThread) {
             this.scene.update();
         },
 
-        // Reverse the CSS transform Leaflet applies to the layer, since Tangram's WebGL canvas
+        // Reverse the CSS positioning Leaflet applies to the layer, since Tangram's WebGL canvas
         // is expected to be 'absolutely' positioned.
-        reverseTransform: function (map) {
-            if (!map || !this.scene.canvas) {
+        reverseTransform: function () {
+            if (!this._map || !this.scene || !this.scene.container) {
                 return;
             }
 
-            var pane = map.getPanes().mapPane;
-            // var transform = pane.style.transform || pane.style['-webkit-transform'];
-            var style = window.getComputedStyle(pane);
-            var transform = style.transform || style['-webkit-transform'];
-
-            // Parse transform like: 'matrix(1, 0, 0, 1, 50, -100)'
-            if (!this.matrixRegex) {
-                let n = '\\s*([-+]?[0-9]*\\.?[0-9]+)(?:deg|rad|grad|px|%)*\\s*'; // match a number and optional units
-                this.matrixRegex = new RegExp(`matrix\\s*\\(${n},${n},${n},${n},${n},${n}\\)`); // match 6 matrix coefficients
-            }
-
-            var match = transform.match(this.matrixRegex);
-            if (match && match.length >= 7) {
-                // Matrix with reverse translation
-                match = match.slice(1, 7); // pull out 6 matching matrix values
-                match[4] *= -1; // reverse x & y translation components
-                match[5] *= -1;
-
-                var matrix = `matrix(${match.join(', ')})`; // reconstruct matrix
-                this.scene.canvas.style.transform = matrix;
-                this.scene.canvas.style['-webkit-transform'] = matrix;
-            }
+            var top_left = this._map.containerPointToLayerPoint([0, 0]);
+            L.DomUtil.setPosition(this.scene.container, top_left);
         }
 
     });

--- a/src/scene.js
+++ b/src/scene.js
@@ -237,15 +237,15 @@ export default class Scene {
         this.canvas.style.position = 'absolute';
         this.canvas.style.top = 0;
         this.canvas.style.left = 0;
+        this.canvas.style.backgroundColor = 'transparent'; // TODO: only if alpha on
 
         // Force tangram canvas underneath all leaflet layers, and set background to transparent
-        this.canvas.style.zIndex = -1;
         this.container.style.cssText += 'background: transparent;';
         this.container.appendChild(this.canvas);
 
         try {
             this.gl = Context.getContext(this.canvas, {
-                alpha: false /*premultipliedAlpha: false*/,
+                alpha: true, premultipliedAlpha: true, // TODO: vary w/scene alpha
                 device_pixel_ratio: Utils.device_pixel_ratio
             });
         }
@@ -832,7 +832,7 @@ export default class Scene {
             }
         }
         else {
-            RenderState.blending.set({ blend: false, src: null, dst: null} );
+            RenderState.blending.set({ blend: false });
         }
     }
 
@@ -1104,7 +1104,7 @@ export default class Scene {
             this.background.color = StyleParser.parseColor(bg.color);
         }
         if (!this.background.color) {
-            this.background.color = [0, 0, 0, 1]; // default background to black
+            this.background.color = [0, 0, 0, 0]; // default background TODO: vary w/scene alpha
         }
     }
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -820,15 +820,27 @@ export default class Scene {
         if (alpha_blend) {
             // Traditional blending
             if (alpha_blend === true) {
-                RenderState.blending.set({ blend: true, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA });
+                RenderState.blending.set({
+                    blend: true,
+                    src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA,
+                    src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA
+                });
             }
             // Additive blending
             else if (alpha_blend === 'add') {
-                RenderState.blending.set({ blend: true, src: gl.ONE, dst: gl.ONE });
+                RenderState.blending.set({
+                    blend: true,
+                    src: gl.ONE, dst: gl.ONE,
+                    src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA
+                });
             }
             // Multiplicative blending
             else if (alpha_blend === 'multiply') {
-                RenderState.blending.set({ blend: true, src: gl.ZERO, dst: gl.SRC_COLOR });
+                RenderState.blending.set({
+                    blend: true,
+                    src: gl.ZERO, dst: gl.SRC_COLOR,
+                    src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA
+                });
             }
         }
         else {

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -229,7 +229,9 @@ StyleParser.colorForString = function(string) {
 StyleParser.cacheColor = function(val, context = {}) {
     if (val.dynamic) {
         let v = val.dynamic(context);
-        v[3] = v[3] || 1; // default alpha
+        if (v[3] == null) {
+            v[3] = 1; // default alpha
+        }
         return v;
     }
     else if (val.static) {
@@ -243,7 +245,9 @@ StyleParser.cacheColor = function(val, context = {}) {
         if (typeof val.value === 'function') {
             val.dynamic = val.value;
             let v = val.dynamic(context);
-            v[3] = v[3] || 1; // default alpha
+            if (v[3] == null) {
+                v[3] = 1; // default alpha
+            }
             return v;
         }
         // Single string color
@@ -272,7 +276,9 @@ StyleParser.cacheColor = function(val, context = {}) {
         // Single array color
         else {
             val.static = val.value;
-            val.static[3] = val.static[3] || 1; // default alpha
+            if (val.static[3] == null) {
+                val.static[3] = 1; // default alpha
+            }
             return val.static;
         }
     }
@@ -319,7 +325,7 @@ StyleParser.parseColor = function(val, context = {}) {
     // Defaults
     if (val) {
         // alpha
-        if (!val[3]) {
+        if (val[3] == null) {
             val[3] = 1;
         }
     }

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -34,9 +34,8 @@ Object.assign(TextStyle, {
         // (labels are always drawn with textures)
         this.defines.TANGRAM_POINT_TEXTURE = true;
 
-        // Manually un-multiply alpha, because some Canvas text rasterization is pre-multiplied
-        // See https://github.com/tangrams/tangram/issues/179
-        this.defines.TANGRAM_UNMULTIPLY_ALPHA = Utils.canvasPremultipliedAlpha();
+        // Manually un-multiply alpha, because Canvas text rasterization is pre-multiplied
+        this.defines.TANGRAM_UNMULTIPLY_ALPHA = true;
 
         // default font style
         this.default_font_style = {

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -163,6 +163,8 @@ Object.assign(TextStyle, {
         // create a canvas
         if(!this.canvas[tile]) {
             let canvas = document.createElement('canvas');
+            canvas.style.backgroundColor = 'transparent'; // render text on transparent background
+
             this.canvas[tile] = {
                 canvas: canvas,
                 context: canvas.getContext('2d')

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,7 +3,6 @@
 
 import log from 'loglevel';
 import yaml from 'js-yaml';
-import bowser from 'bowser';
 import Geo from '../geo';
 
 var Utils;
@@ -148,11 +147,6 @@ Utils.loadResource = function (source) {
             resolve(source);
         }
     });
-};
-
-// Wrapper for browser info
-Utils.browser = function () {
-    return bowser;
 };
 
 // Needed for older browsers that still support WebGL (Safari 6 etc.)
@@ -422,11 +416,6 @@ Utils.radToDeg = function (radians) {
 
 Utils.toCanvasColor = function (color) {
     return 'rgb(' +  Math.round(color[0] * 255) + ',' + Math.round(color[1]  * 255) + ',' + Math.round(color[2] * 255) + ')';
-};
-
-// Some Canvas implementations have pre-multiplied alpha that we need to adjust for
-Utils.canvasPremultipliedAlpha = function () {
-    return (Utils.browser().ios ? false : true);
 };
 
 Utils.toPixelSize = function (size, kind) {

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -47,7 +47,7 @@ describe('Leaflet plugin', () => {
 
         beforeEach(function (done) {
             subject = makeOne();
-            sinon.spy(map, 'getContainer');
+            sinon.spy(subject, 'getContainer');
             sinon.spy(subject.scene, 'load');
 
             subject.on('init', () => {
@@ -60,11 +60,11 @@ describe('Leaflet plugin', () => {
 
         afterEach(() => {
             subject.remove();
-            map.getContainer.restore();
+            subject.getContainer.restore();
         });
 
-        it('calls the map\'s .getContainer() method', () => {
-            sinon.assert.called(map.getContainer);
+        it('calls the layer\'s .getContainer() method', () => {
+            sinon.assert.called(subject.getContainer);
         });
 
         it('initializes the scene', () => {


### PR DESCRIPTION
Adds alpha to the Tangram GL canvas, which allows for Leaflet layers (or other HTML content) to be placed *beneath* the map, in addition to on top of it. The GL canvas is now inserted in the correct location in the Leaflet DOM (previously it was pulled out of the DOM to make positioning simpler, and because without alpha it often got covered by other layers). 

This also necessitates a few changes to client interactivity handling, since we want listeners and pop-ups attached to the map container, not the Tangram scene container. (see https://github.com/tangrams/tangram/compare/alpha-background#diff-a2925ce738063617bef38726407de2d0R484, https://github.com/tangrams/tangram/compare/alpha-background#diff-a2925ce738063617bef38726407de2d0R511); cc @meetar and @nvkelso on this point for adjusting other demos (but will put this Tangram change in a 0.4 release for better compatibility transition).

Color values can now include an alpha component (including for "opaque" geometry that isn't otherwise doing GL blending with other Tangram features). For example:

```
scene:
    background:
        color: [0, 0, 0, .5] # allow background to show through with 50% opacity
```

or 

```
scene:
    background:
        color: transparent
```

or

```
        draw:
            polygons:
                color: [.25, 0, 0, .25] # draw red with 25% opacity in background
```

Here's an example of Tangram buildings and roads rendered over Stamen's terrain raster tiles:

<img width="921" alt="screen shot 2015-10-15 at 10 16 47 pm" src="https://cloud.githubusercontent.com/assets/16733/10551566/4185c064-7413-11e5-9af8-27d242b54011.png">
