### PR TITLE
Data sources can append custom URL params

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -159,7 +159,7 @@ sources:
     mapzen:
         type: TopoJSON
         url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
-        params:
+        url_params:
             api_key: vector-tiles-HqUVidw
         max_zoom: 16
         # # Data filtering demo with 'scripts' and 'transform' properties:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -158,43 +158,43 @@ styles:
 sources:
     mapzen:
         type: TopoJSON
-        url:  http://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson?api_key=vector-tiles-HqUVidw
+        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        params:
+            api_key: vector-tiles-HqUVidw
         max_zoom: 16
-    #     # Data filtering demo with 'scripts' and 'transform' properties:
-    #     # Tile data is passed through a 'transform' pre-processing function before Tangram geometry is built.
-    #     # 'transform' adds an 'intersects_park' property to each road that intersects a park feature.
-    #     # That feature is then filtered on below in the 'roads' layer.
-    #     # scripts: ['https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js']
-    #     # transform: |
-    #     #     function(data, extra_data) {
-
-    #     #         if (data.roads &&
-    #     #             data.roads.features &&
-    #     #             data.landuse &&
-    #     #             data.landuse.features) {
-
-    #     #             data.roads.features.forEach(function(road) {
-    #     #                 for (var i=0; i < data.landuse.features.length; i++) {
-    #     #                     var land = data.landuse.features[i];
-
-    #     #                     if (land.properties.kind !== 'park') {
-    #     #                         continue;
-    #     #                     }
-
-    #     #                     try {
-    #     #                         if (turf.intersect(road, land)) {
-    #     #                             road.properties.intersects_park = true;
-    #     #                         }
-    #     #                     }
-    #     #                     catch(e){
-    #     #                         //debugger;
-    #     #                     }
-    #     #                 }
-    #     #                 return true;
-    #     #             });
-    #     #         }
-    #     #         return data;
-    #     #     }
+        # # Data filtering demo with 'scripts' and 'transform' properties:
+        # Tile data is passed through a 'transform' pre-processing function before Tangram geometry is built.
+        # 'transform' adds an 'intersects_park' property to each road that intersects a park feature.
+        # That feature is then filtered on below in the 'roads' layer.
+        # scripts: ['https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js']
+        # transform: |
+        #     function(data, extra_data) {
+        #         if (data.roads &&
+        #             data.roads.features &&
+        #             data.landuse &&
+        #             data.landuse.features) {
+        #
+        #             data.roads.features.forEach(function(road) {
+        #                 for (var i=0; i < data.landuse.features.length; i++) {
+        #                     var land = data.landuse.features[i];
+        #                     if (land.properties.kind !== 'park') {
+        #                         continue;
+        #                     }
+        #
+        #                     try {
+        #                         if (turf.intersect(road, land)) {
+        #                             road.properties.intersects_park = true;
+        #                         }
+        #                     }
+        #                     catch(e){
+        #                         //debugger;
+        #                     }
+        #                 }
+        #                 return true;
+        #             });
+        #         }
+        #         return data;
+        #     }
     # schools:
     #     type: GeoJSON
     #     url: data/school-districts-polygon.geojson

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -9,7 +9,6 @@ export default class DataSource {
         this.config = config; // save original config
         this.id = config.id;
         this.name = config.name;
-        this.url = Utils.addParamsToURL(config.url, config.params);
         this.pad_scale = config.pad_scale || 0.0001; // scale tile up by small factor to cover seams
         this.default_winding = null; // winding order will adapt to data source
 
@@ -166,6 +165,7 @@ export class NetworkSource extends DataSource {
 
     constructor (source) {
         super(source);
+        this.url = Utils.addParamsToURL(source.url, source.url_params);
         this.response_type = ""; // use to set explicit XHR type
 
         if (this.url == null) {

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -9,7 +9,7 @@ export default class DataSource {
         this.config = config; // save original config
         this.id = config.id;
         this.name = config.name;
-        this.url = config.url;
+        this.url = Utils.addParamsToURL(config.url, config.params);
         this.pad_scale = config.pad_scale || 0.0001; // scale tile up by small factor to cover seams
         this.default_winding = null; // winding order will adapt to data source
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -76,6 +76,10 @@ Utils.cacheBusterForUrl = function (url) {
 // Add a set of query string params to a URL
 // params: hash of key/value pairs of query string parameters
 Utils.addParamsToURL = function (url, params) {
+    if (!params || Object.keys(params).length === 0) {
+        return url;
+    }
+
     var qs_index = url.indexOf('?');
     var hash_index = url.indexOf('#');
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -73,6 +73,39 @@ Utils.cacheBusterForUrl = function (url) {
     return url;
 };
 
+// Add a set of query string params to a URL
+// params: hash of key/value pairs of query string parameters
+Utils.addParamsToURL = function (url, params) {
+    var qs_index = url.indexOf('?');
+    var hash_index = url.indexOf('#');
+
+    // Save and trim hash
+    var hash = '';
+    if (hash_index > -1) {
+        hash = url.slice(hash_index);
+        url = url.slice(0, hash_index);
+    }
+
+    // Start query string
+    if (qs_index === -1) {
+        qs_index = url.length;
+        url += '?';
+    }
+    qs_index++; // advanced past '?'
+
+    // Build query string params
+    var url_params = '';
+    for (var p in params) {
+        url_params += `${p}=${params[p]}&`;
+    }
+
+    // Insert new query string params and restore hash
+    // NOTE: doesn't replace any values already present on query string, just inserts dupe values
+    url = url.slice(0, qs_index) + url_params + url.slice(qs_index) + hash;
+
+    return url;
+};
+
 // Polyfill (for Safari compatibility)
 Utils._createObjectURL = undefined;
 Utils.createObjectURL = function (url) {

--- a/test/data_source_spec.js
+++ b/test/data_source_spec.js
@@ -51,12 +51,9 @@ describe('DataSource', () => {
         it('sets the max_zoom level', () => {
             assert.equal(subject.max_zoom, max_zoom);
         });
-        it('sets the url', () => {
-            assert.equal(subject.url, url);
-        });
     });
 
-    describe('DataSource.create(type, url_template, options)', () => {
+    describe('DataSource.create(options)', () => {
 
         describe('when I ask for a GeoJSON source with a tile template URL', () => {
             let subject = DataSource.create(_.merge({type: 'GeoJSON'}, options));
@@ -155,6 +152,17 @@ describe('DataSource', () => {
 
             assert.deepEqual(firstFeature.geometry.coordinates, [-0.006075396068253094,-0.006075396068253094]);
         });
+    });
+
+    describe('NetworkSource', () => {
+
+        describe('when creating an instance of a subclass of NetworkSource', () => {
+            let subject = DataSource.create(_.merge({type: 'GeoJSON'}, options));
+            it('sets the url', () => {
+                assert.equal(subject.url, url);
+            });
+        });
+
     });
 
     describe('NetworkTileSource', () => {


### PR DESCRIPTION
This adds the ability for data source definitions to add custom URL parameters to the query string. This has little benefit currently, since you can just write out the whole URL explicitly. But it will allow us to more easily customize parameters like API keys:

- By having the Leaflet plugin set the API key param in the scene file when it's passed through as an option
- Once we incorporate file inclusion, this will allow users to easily import a Mapzen basemap and then set their own API key.

Example:
Instead of the full URL, `http://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson?api_key=vector-tiles-HqUVidw`, you can write:


```
sources:
   osm:
      type: TopoJSON
      url: http://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
      params:
         api_key: vector-tiles-HqUVidw
```

The future inclusion example mentioned above would then look like:

```
include: path/to/mapzen/style.yaml

sources:
    mapzen:
        params:
            api_key: vector-tiles-HqUVidw
```
