### PR TITLE
Multi-line labels

### DIFF
--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -609,7 +609,7 @@ Object.assign(TextStyle, {
 
             // max line width for word wrap
             let max_line_width = rule.max_line_width; // use explicitly set value
-            if (typeof max_line_width !== 'number' && Geo.geometryType(feature.geometry.type) !== 'line') {
+            if (max_line_width == null && Geo.geometryType(feature.geometry.type) !== 'line') {
                 // point labels (for point and polygon features) have word wrap on w/default max length,
                 // line labels default off
                 max_line_width = 15;

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -609,8 +609,9 @@ Object.assign(TextStyle, {
 
             // max line width for word wrap
             let max_line_width = rule.max_line_width; // use explicitly set value
-            if (typeof max_line_width !== 'number' && Geo.geometryType(feature.geometry.type) === 'point') {
-                // point labels have word wrap on w/default max length, line labels default off
+            if (typeof max_line_width !== 'number' && Geo.geometryType(feature.geometry.type) !== 'line') {
+                // point labels (for point and polygon features) have word wrap on w/default max length,
+                // line labels default off
                 max_line_width = 15;
             }
 


### PR DESCRIPTION
Re-implements multi-line labels (previous implementation had issues and was disabled). Labels with word wrap / line breaks are now drawn directly as multi-line labels in the Canvas texture (e.g. the word wrapping is implemented as part of the Canvas text drawing, vs. as part of the Tangram label/geometry building/rendering process).

The maximum number of characters per line before a line break occurs is configurable via the `max_line_width` parameter (should this be `max_line_characters`?). 

```
draw:
   text:
      max_line_width: 10
      ...
```

Word wrap is **enabled** by default for point labels (labels for point or polygon geometries) with a default `max_line_width` of **15 characters** (is this the best default?), and is **disabled** by default for line labels. Word wrap can be explicitly disabled by setting `max_line_width: false`.

Additionally, line breaks occurring *in the label text itself*, e.g. `\n` characters, will always trigger line breaks / multi-line label rendering. For example, the label text `One\nTwo\nThree` will render as three separate lines, regardless of the `max_line_width` setting. If these breaks are undesirable, they can be filtered out of the input with a `text_source: function() { ... }`.

It is also possible to control the text **alignment** when there are multiple lines of text. Possible alignment values are `center` (default), `left` justified, and `right` justified. Alignment has no effect if the label fits on a single line, as the alignment only affects the the position of the lines *relative to each other*; it does not affect the position of the entire label itself (use `offset` for that, and/or the upcoming `anchor` functionality, see #182).

```
draw:
   text:
      align: right
      ...
```
Examples:

Defaults of `max_line_width: 15` and `align: center`:
<img width="355" alt="center" src="https://cloud.githubusercontent.com/assets/16733/10714114/f9ef479c-7ab2-11e5-8ecb-ab88559ed22b.png">

With `align: right`:
<img width="351" alt="right" src="https://cloud.githubusercontent.com/assets/16733/10714117/0fc05214-7ab3-11e5-897c-03c02e2955fa.png">

With `align: left`:
<img width="358" alt="left" src="https://cloud.githubusercontent.com/assets/16733/10714119/152df9cc-7ab3-11e5-8d19-111bb5d77501.png">

With `max_line_width: 0` (every word renders on its own line, because every word exceeds the max allowed length):
<img width="372" alt="width 0" src="https://cloud.githubusercontent.com/assets/16733/10714120/1b0b75cc-7ab3-11e5-9537-cacaa796bf45.png">

With `max_line_width: false`, e.g. word wrapping disabled:
<img width="285" alt="word wrap off" src="https://cloud.githubusercontent.com/assets/16733/10714137/3528ca3a-7ab4-11e5-9c10-3f9e43ce8236.png">

