### PR TITLE
Tangram can be loaded outside of a bundled JS

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ all: \
 debug: dist/tangram.debug.js
 
 dist/tangram.debug.js: .npm src/gl/shader_sources.js $(shell ./build_deps.sh)
-	node build.js --debug=true --require './src/module.js' --runtime | derequire > dist/tangram.debug.js
+	node build.js --debug=true --require './src/module.js' --runtime | $(DEREQUIRE) > dist/tangram.debug.js
 
 dist/tangram.min.js: dist/tangram.debug.js
 	$(UGLIFY) dist/tangram.debug.js -c warnings=false -m -o dist/tangram.min.js

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@
 UGLIFY = ./node_modules/.bin/uglifyjs
 KARMA = ./node_modules/karma/bin/karma
 JSHINT = ./node_modules/.bin/jshint
+DEREQUIRE = ./node_modules/.bin/derequire
 
 # Build debug and minified libraries
 all: \
@@ -11,7 +12,7 @@ all: \
 debug: dist/tangram.debug.js
 
 dist/tangram.debug.js: .npm src/gl/shader_sources.js $(shell ./build_deps.sh)
-	node build.js --debug=true --require './src/module.js' --runtime > dist/tangram.debug.js
+	node build.js --debug=true --require './src/module.js' --runtime | derequire > dist/tangram.debug.js
 
 dist/tangram.min.js: dist/tangram.debug.js
 	$(UGLIFY) dist/tangram.debug.js -c warnings=false -m -o dist/tangram.min.js

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git://github.com/tangrams/tangram.git"
   },
+  "main": "dist/tangram.min.js",
   "homepage": "https://github.com/tangrams/tangram",
   "keywords": [
     "maps",
@@ -23,11 +24,21 @@
     "email": "tangram@mapzen.com"
   },
   "contributors": [
-    { "name": "Brett Camper" },
-    { "name": "Peter Richardson" },
-    { "name": "Patricio Gonzalez Vivo" },
-    { "name": "Karim Naaji" },
-    { "name": "Ivan Willig" }
+    {
+      "name": "Brett Camper"
+    },
+    {
+      "name": "Peter Richardson"
+    },
+    {
+      "name": "Patricio Gonzalez Vivo"
+    },
+    {
+      "name": "Karim Naaji"
+    },
+    {
+      "name": "Ivan Willig"
+    }
   ],
   "license": "MIT",
   "dependencies": {
@@ -47,23 +58,24 @@
     "babel": "5.8.29"
   },
   "devDependencies": {
-    "uglify-js": "^2.4.14",
-    "browserify": "6.1.0",
-    "jshint": "2.7.0",
-    "mocha": "~1.21.4",
-    "sinon": "~1.10.3",
-    "chai": "~1.9.2",
-    "lodash": "~2.4.1",
-    "yargs": "~1.3.2",
-    "glob": "~4.0.6",
-    "chai-as-promised": "~4.1.1",
-    "karma-mocha": "~0.1.9",
-    "karma": "~0.12.23",
-    "karma-chrome-launcher": "~0.1.4",
-    "karma-sauce-launcher": "tangrams/karma-sauce-launcher#firefox-profiles",
-    "karma-sinon": "~1.0.4",
     "babel-runtime": "5.8.29",
     "babelify": "6.4.0",
-    "karma-mocha-reporter": "^1.0.0"
+    "browserify": "6.1.0",
+    "chai": "~1.9.2",
+    "chai-as-promised": "~4.1.1",
+    "derequire": "^2.0.3",
+    "glob": "~4.0.6",
+    "jshint": "2.7.0",
+    "karma": "~0.12.23",
+    "karma-chrome-launcher": "~0.1.4",
+    "karma-mocha": "~0.1.9",
+    "karma-mocha-reporter": "^1.0.0",
+    "karma-sauce-launcher": "tangrams/karma-sauce-launcher#firefox-profiles",
+    "karma-sinon": "~1.0.4",
+    "lodash": "~2.4.1",
+    "mocha": "~1.21.4",
+    "sinon": "~1.10.3",
+    "uglify-js": "^2.4.14",
+    "yargs": "~1.3.2"
   }
 }

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -5,309 +5,315 @@ import Geo from './geo';
 // Exports must appear outside a function, but will only be defined in main thread (below)
 export var LeafletLayer;
 export function leafletLayer(options) {
-    return new LeafletLayer(options);
+    return extendLeaflet(options);
 }
 
-// Leaflet layer functionality is only defined in main thread
-if (Utils.isMainThread) {
+function extendLeaflet(options) {
 
-    // Determine if we are extending the leaflet 0.7.x TileLayer class, or the newer
-    // leaflet 1.x GridLayer class.
-    let layerBaseClass = L.GridLayer ? L.GridLayer : L.TileLayer;
-    let leafletVersion = layerBaseClass === L.GridLayer ? '1.x' : '0.7.x';
-    let layerClassConfig = {};
+    // Leaflet layer functionality is only defined in main thread
+    if (Utils.isMainThread) {
 
-    // If extending leaflet 0.7.x TileLayer, make add/remove tile no ops
-    if (layerBaseClass === L.TileLayer) {
-        layerClassConfig._addTile = function(){};
-        layerClassConfig._removeTile = function(){};
-    }
+        let L = options.leaflet || window.L;
 
-    // Define custom layer methods
-    Object.assign(layerClassConfig, {
+        // Determine if we are extending the leaflet 0.7.x TileLayer class, or the newer
+        // leaflet 1.x GridLayer class.
+        let layerBaseClass = L.GridLayer ? L.GridLayer : L.TileLayer;
+        let leafletVersion = layerBaseClass === L.GridLayer ? '1.x' : '0.7.x';
+        let layerClassConfig = {};
 
-        initialize: function (options) {
-            // Defaults
-            options.showDebug = (!options.showDebug ? false : true);
-            options.wheelDebounceTime = options.wheelDebounceTime || 40;
-
-            L.setOptions(this, options);
-            this.createScene();
-            this.hooks = {};
-            this._updating_tangram = false;
-
-            // Force leaflet zoom animations off
-            this._zoomAnimated = false;
-
-            this.debounceViewReset = Utils.debounce(() => {
-                this._map.fire('zoomend');
-                this._map.fire('moveend');
-            }, this.options.wheelDebounceTime);
-        },
-
-        createScene: function () {
-            this.scene = Scene.create(
-                this.options.scene,
-                {
-                    numWorkers: this.options.numWorkers,
-                    preUpdate: this.options.preUpdate,
-                    postUpdate: this.options.postUpdate,
-                    continuousZoom: (LeafletLayer.leafletVersion === '1.x'),
-                    highDensityDisplay: this.options.highDensityDisplay,
-                    logLevel: this.options.logLevel,
-                    // advanced option, app will have to manually called scene.update() per frame
-                    disableRenderLoop: this.options.disableRenderLoop,
-                    // advanced option, will require library to be served as same host as page
-                    allowCrossDomainWorkers: this.options.allowCrossDomainWorkers
-                });
-        },
-
-        // Finish initializing scene and setup events when layer is added to map
-        onAdd: function (map) {
-            if (!this.scene) {
-                this.createScene();
-            }
-
-            layerBaseClass.prototype.onAdd.apply(this, arguments);
-
-            this.hooks.resize = () => {
-                this._updating_tangram = true;
-                this.updateSize();
-                this._updating_tangram = false;
-            };
-            map.on('resize', this.hooks.resize);
-
-            this.hooks.move = () => {
-                if (this._updating_tangram) {
-                    return;
-                }
-
-                this._updating_tangram = true;
-                var view = map.getCenter();
-                view.zoom = Math.min(map.getZoom(), map.getMaxZoom() || Geo.max_zoom);
-
-                this.scene.setView(view);
-                this.scene.immediateRedraw();
-                this.reverseTransform();
-                this._updating_tangram = false;
-            };
-            map.on('move', this.hooks.move);
-
-            this.hooks.zoomstart = () => {
-                if (this._updating_tangram) {
-                    return;
-                }
-
-                this._updating_tangram = true;
-                this.scene.startZoom();
-                this._updating_tangram = false;
-            };
-            map.on('zoomstart', this.hooks.zoomstart);
-
-            this.hooks.dragstart = () => {
-                this.scene.panning = true;
-            };
-            map.on('dragstart', this.hooks.dragstart);
-
-            this.hooks.dragend = () => {
-                this.scene.panning = false;
-            };
-            map.on('dragend', this.hooks.dragend);
-
-            // Force leaflet zoom animations off
-            map._zoomAnimated = false;
-
-            // Modify default leaflet scroll wheel behavior
-            this.modifyScrollWheelBehavior(map);
-
-            // Add GL canvas to layer container
-            this.scene.container = this.getContainer();
-
-            // Initial view
-            this.updateView();
-
-            // Subscribe to tangram events
-            this.scene.subscribe({
-                move: this.onTangramViewUpdate.bind(this)
-            });
-
-            // Use leaflet's existing event system as the callback mechanism
-            this.scene.load().then(() => {
-                this._updating_tangram = true;
-
-                this.updateSize();
-                this.updateView();
-                this.reverseTransform();
-
-                this._updating_tangram = false;
-
-                this.fire('init');
-            }).catch(error => {
-                this.fire('error', error);
-            });
-        },
-
-        onRemove: function (map) {
-            layerBaseClass.prototype.onRemove.apply(this, arguments);
-
-            map.off('resize', this.hooks.resize);
-            map.off('move', this.hooks.move);
-            map.off('zoomstart', this.hooks.zoomstart);
-            map.off('dragstart', this.hooks.dragstart);
-            map.off('dragend', this.hooks.dragend);
-            this.hooks = {};
-
-            if (this.scene) {
-                this.scene.destroy();
-                this.scene = null;
-            }
-        },
-
-        createTile: function (coords) {
-            var key = coords.x + '/' + coords.y + '/' + coords.z;
-            var div = document.createElement('div');
-            div.setAttribute('data-tile-key', key);
-            div.style.width = '256px';
-            div.style.height = '256px';
-
-            if (this.options.showDebug) {
-                var debug_overlay = document.createElement('div');
-                debug_overlay.textContent = key;
-                debug_overlay.style.position = 'absolute';
-                debug_overlay.style.left = 0;
-                debug_overlay.style.top = 0;
-                debug_overlay.style.color = 'white';
-                debug_overlay.style.fontSize = '16px';
-                debug_overlay.style.textOutline = '1px #000000';
-                debug_overlay.style.padding = '8px';
-
-                div.appendChild(debug_overlay);
-                div.style.borderStyle = 'solid';
-                div.style.borderColor = 'white';
-                div.style.borderWidth = '1px';
-            }
-
-            return div;
-        },
-
-        // Modify leaflet's default scroll wheel behavior to have a much more sensitve/continuous zoom
-        // Note: this should be deprecated once leaflet continuous zoom is more widely used and the
-        // default behavior is presumably improved
-        modifyScrollWheelBehavior: function (map) {
-            if (this.scene.continuous_zoom && map.scrollWheelZoom && this.options.modifyScrollWheel !== false) {
-                let layer = this;
-                let enabled = map.scrollWheelZoom.enabled();
-                if (enabled) {
-                    map.scrollWheelZoom.disable(); // disable before modifying
-                }
-
-                // modify prototype and current instance, so add/remove hooks work on existing references
-                L.Map.ScrollWheelZoom._onWheelScroll = map.scrollWheelZoom._onWheelScroll = function(e) {
-                    // modify to skip debounce, as it seems to cause animation-sync issues in Chrome
-                    // with Tangram continuous rendering
-                    this._delta += L.DomEvent.getWheelDelta(e);
-                    this._lastMousePos = this._map.mouseEventToContainerPoint(e);
-                    this._performZoom();
-                    L.DomEvent.stop(e);
-                };
-
-                L.Map.ScrollWheelZoom._performZoom = map.scrollWheelZoom._performZoom = function () {
-                    var map = this._map,
-                        delta = this._delta,
-                        zoom = map.getZoom();
-
-                    map.stop(); // stop panning and fly animations if any
-
-                    // NOTE: this is the only real modification to default leaflet behavior
-                    delta /= 40;
-
-                    delta = Math.max(Math.min(delta, 4), -4);
-                    delta = map._limitZoom(zoom + delta) - zoom;
-
-                    this._delta = 0;
-                    this._startTime = null;
-
-                    if (!delta) { return; }
-
-                    if (map.options.scrollWheelZoom === 'center') {
-                        map._move(map.getCenter(), zoom + delta);
-                    } else {
-                        // Re-centering code from Leaflet's map.setZoomAround() function
-                        var latlng = this._lastMousePos,
-                            newZoom = zoom + delta,
-                            scale = map.getZoomScale(newZoom),
-                            viewHalf = map.getSize().divideBy(2),
-                            containerPoint = latlng instanceof L.Point ? latlng : map.latLngToContainerPoint(latlng),
-
-                            centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale),
-                            newCenter = map.containerPointToLatLng(viewHalf.add(centerOffset));
-
-                        map._move(newCenter, newZoom);
-                    }
-
-                    layer.debounceViewReset();
-                };
-
-                if (enabled) {
-                    map.scrollWheelZoom.enable(); // re-enable after modifying
-                }
-            }
-        },
-
-        updateView: function () {
-            var view = this._map.getCenter();
-            view.zoom = Math.min(this._map.getZoom(), this._map.getMaxZoom() || Geo.max_zoom);
-            this.scene.setView(view);
-        },
-
-        updateSize: function () {
-            var size = this._map.getSize();
-            this.scene.resizeMap(size.x, size.y);
-        },
-
-        onTangramViewUpdate: function () {
-            if (!this._map || this._updating_tangram) {
-                return;
-            }
-            this._updating_tangram = true;
-            this._map.setView([this.scene.center.lat, this.scene.center.lng], this.scene.zoom, { animate: false });
-            this._updating_tangram = false;
-        },
-
-        render: function () {
-            if (!this.scene) {
-                return;
-            }
-            this.scene.update();
-        },
-
-        // Reverse the CSS positioning Leaflet applies to the layer, since Tangram's WebGL canvas
-        // is expected to be 'absolutely' positioned.
-        reverseTransform: function () {
-            if (!this._map || !this.scene || !this.scene.container) {
-                return;
-            }
-
-            var top_left = this._map.containerPointToLayerPoint([0, 0]);
-            L.DomUtil.setPosition(this.scene.container, top_left);
+        // If extending leaflet 0.7.x TileLayer, make add/remove tile no ops
+        if (layerBaseClass === L.TileLayer) {
+            layerClassConfig._addTile = function(){};
+            layerClassConfig._removeTile = function(){};
         }
 
-    });
+        // Define custom layer methods
+        Object.assign(layerClassConfig, {
 
-    // Create the layer class
-    LeafletLayer = layerBaseClass.extend(layerClassConfig);
+            initialize: function (options) {
+                // Defaults
+                options.showDebug = (!options.showDebug ? false : true);
+                options.wheelDebounceTime = options.wheelDebounceTime || 40;
 
-    // Polyfill some 1.0 methods
-    if (typeof LeafletLayer.remove !== 'function') {
-        LeafletLayer.prototype.remove = function() {
-            if (this._map) {
-                this._map.removeLayer(this);
+                L.setOptions(this, options);
+                this.createScene();
+                this.hooks = {};
+                this._updating_tangram = false;
+
+                // Force leaflet zoom animations off
+                this._zoomAnimated = false;
+
+                this.debounceViewReset = Utils.debounce(() => {
+                    this._map.fire('zoomend');
+                    this._map.fire('moveend');
+                }, this.options.wheelDebounceTime);
+            },
+
+            createScene: function () {
+                this.scene = Scene.create(
+                    this.options.scene,
+                    {
+                        numWorkers: this.options.numWorkers,
+                        preUpdate: this.options.preUpdate,
+                        postUpdate: this.options.postUpdate,
+                        continuousZoom: (LeafletLayer.leafletVersion === '1.x'),
+                        highDensityDisplay: this.options.highDensityDisplay,
+                        logLevel: this.options.logLevel,
+                        // advanced option, app will have to manually called scene.update() per frame
+                        disableRenderLoop: this.options.disableRenderLoop,
+                        // advanced option, will require library to be served as same host as page
+                        allowCrossDomainWorkers: this.options.allowCrossDomainWorkers
+                    });
+            },
+
+            // Finish initializing scene and setup events when layer is added to map
+            onAdd: function (map) {
+                if (!this.scene) {
+                    this.createScene();
+                }
+
+                layerBaseClass.prototype.onAdd.apply(this, arguments);
+
+                this.hooks.resize = () => {
+                    this._updating_tangram = true;
+                    this.updateSize();
+                    this._updating_tangram = false;
+                };
+                map.on('resize', this.hooks.resize);
+
+                this.hooks.move = () => {
+                    if (this._updating_tangram) {
+                        return;
+                    }
+
+                    this._updating_tangram = true;
+                    var view = map.getCenter();
+                    view.zoom = Math.min(map.getZoom(), map.getMaxZoom() || Geo.max_zoom);
+
+                    this.scene.setView(view);
+                    this.scene.immediateRedraw();
+                    this.reverseTransform();
+                    this._updating_tangram = false;
+                };
+                map.on('move', this.hooks.move);
+
+                this.hooks.zoomstart = () => {
+                    if (this._updating_tangram) {
+                        return;
+                    }
+
+                    this._updating_tangram = true;
+                    this.scene.startZoom();
+                    this._updating_tangram = false;
+                };
+                map.on('zoomstart', this.hooks.zoomstart);
+
+                this.hooks.dragstart = () => {
+                    this.scene.panning = true;
+                };
+                map.on('dragstart', this.hooks.dragstart);
+
+                this.hooks.dragend = () => {
+                    this.scene.panning = false;
+                };
+                map.on('dragend', this.hooks.dragend);
+
+                // Force leaflet zoom animations off
+                map._zoomAnimated = false;
+
+                // Modify default leaflet scroll wheel behavior
+                this.modifyScrollWheelBehavior(map);
+
+                // Add GL canvas to layer container
+                this.scene.container = this.getContainer();
+
+                // Initial view
+                this.updateView();
+
+                // Subscribe to tangram events
+                this.scene.subscribe({
+                    move: this.onTangramViewUpdate.bind(this)
+                });
+
+                // Use leaflet's existing event system as the callback mechanism
+                this.scene.load().then(() => {
+                    this._updating_tangram = true;
+
+                    this.updateSize();
+                    this.updateView();
+                    this.reverseTransform();
+
+                    this._updating_tangram = false;
+
+                    this.fire('init');
+                }).catch(error => {
+                    this.fire('error', error);
+                });
+            },
+
+            onRemove: function (map) {
+                layerBaseClass.prototype.onRemove.apply(this, arguments);
+
+                map.off('resize', this.hooks.resize);
+                map.off('move', this.hooks.move);
+                map.off('zoomstart', this.hooks.zoomstart);
+                map.off('dragstart', this.hooks.dragstart);
+                map.off('dragend', this.hooks.dragend);
+                this.hooks = {};
+
+                if (this.scene) {
+                    this.scene.destroy();
+                    this.scene = null;
+                }
+            },
+
+            createTile: function (coords) {
+                var key = coords.x + '/' + coords.y + '/' + coords.z;
+                var div = document.createElement('div');
+                div.setAttribute('data-tile-key', key);
+                div.style.width = '256px';
+                div.style.height = '256px';
+
+                if (this.options.showDebug) {
+                    var debug_overlay = document.createElement('div');
+                    debug_overlay.textContent = key;
+                    debug_overlay.style.position = 'absolute';
+                    debug_overlay.style.left = 0;
+                    debug_overlay.style.top = 0;
+                    debug_overlay.style.color = 'white';
+                    debug_overlay.style.fontSize = '16px';
+                    debug_overlay.style.textOutline = '1px #000000';
+                    debug_overlay.style.padding = '8px';
+
+                    div.appendChild(debug_overlay);
+                    div.style.borderStyle = 'solid';
+                    div.style.borderColor = 'white';
+                    div.style.borderWidth = '1px';
+                }
+
+                return div;
+            },
+
+            // Modify leaflet's default scroll wheel behavior to have a much more sensitve/continuous zoom
+            // Note: this should be deprecated once leaflet continuous zoom is more widely used and the
+            // default behavior is presumably improved
+            modifyScrollWheelBehavior: function (map) {
+                if (this.scene.continuous_zoom && map.scrollWheelZoom && this.options.modifyScrollWheel !== false) {
+                    let layer = this;
+                    let enabled = map.scrollWheelZoom.enabled();
+                    if (enabled) {
+                        map.scrollWheelZoom.disable(); // disable before modifying
+                    }
+
+                    // modify prototype and current instance, so add/remove hooks work on existing references
+                    L.Map.ScrollWheelZoom._onWheelScroll = map.scrollWheelZoom._onWheelScroll = function(e) {
+                        // modify to skip debounce, as it seems to cause animation-sync issues in Chrome
+                        // with Tangram continuous rendering
+                        this._delta += L.DomEvent.getWheelDelta(e);
+                        this._lastMousePos = this._map.mouseEventToContainerPoint(e);
+                        this._performZoom();
+                        L.DomEvent.stop(e);
+                    };
+
+                    L.Map.ScrollWheelZoom._performZoom = map.scrollWheelZoom._performZoom = function () {
+                        var map = this._map,
+                            delta = this._delta,
+                            zoom = map.getZoom();
+
+                        map.stop(); // stop panning and fly animations if any
+
+                        // NOTE: this is the only real modification to default leaflet behavior
+                        delta /= 40;
+
+                        delta = Math.max(Math.min(delta, 4), -4);
+                        delta = map._limitZoom(zoom + delta) - zoom;
+
+                        this._delta = 0;
+                        this._startTime = null;
+
+                        if (!delta) { return; }
+
+                        if (map.options.scrollWheelZoom === 'center') {
+                            map._move(map.getCenter(), zoom + delta);
+                        } else {
+                            // Re-centering code from Leaflet's map.setZoomAround() function
+                            var latlng = this._lastMousePos,
+                                newZoom = zoom + delta,
+                                scale = map.getZoomScale(newZoom),
+                                viewHalf = map.getSize().divideBy(2),
+                                containerPoint = latlng instanceof L.Point ? latlng : map.latLngToContainerPoint(latlng),
+
+                                centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale),
+                                newCenter = map.containerPointToLatLng(viewHalf.add(centerOffset));
+
+                            map._move(newCenter, newZoom);
+                        }
+
+                        layer.debounceViewReset();
+                    };
+
+                    if (enabled) {
+                        map.scrollWheelZoom.enable(); // re-enable after modifying
+                    }
+                }
+            },
+
+            updateView: function () {
+                var view = this._map.getCenter();
+                view.zoom = Math.min(this._map.getZoom(), this._map.getMaxZoom() || Geo.max_zoom);
+                this.scene.setView(view);
+            },
+
+            updateSize: function () {
+                var size = this._map.getSize();
+                this.scene.resizeMap(size.x, size.y);
+            },
+
+            onTangramViewUpdate: function () {
+                if (!this._map || this._updating_tangram) {
+                    return;
+                }
+                this._updating_tangram = true;
+                this._map.setView([this.scene.center.lat, this.scene.center.lng], this.scene.zoom, { animate: false });
+                this._updating_tangram = false;
+            },
+
+            render: function () {
+                if (!this.scene) {
+                    return;
+                }
+                this.scene.update();
+            },
+
+            // Reverse the CSS positioning Leaflet applies to the layer, since Tangram's WebGL canvas
+            // is expected to be 'absolutely' positioned.
+            reverseTransform: function () {
+                if (!this._map || !this.scene || !this.scene.container) {
+                    return;
+                }
+
+                var top_left = this._map.containerPointToLayerPoint([0, 0]);
+                L.DomUtil.setPosition(this.scene.container, top_left);
             }
-            this.fire('remove');
-        };
+
+        });
+
+        // Create the layer class
+        LeafletLayer = layerBaseClass.extend(layerClassConfig);
+
+        // Polyfill some 1.0 methods
+        if (typeof LeafletLayer.remove !== 'function') {
+            LeafletLayer.prototype.remove = function() {
+                if (this._map) {
+                    this._map.removeLayer(this);
+                }
+                this.fire('remove');
+            };
+        }
+
+        LeafletLayer.layerBaseClass = layerBaseClass;
+        LeafletLayer.leafletVersion = leafletVersion;
+
+        return new LeafletLayer(options);
     }
-
-    LeafletLayer.layerBaseClass = layerBaseClass;
-    LeafletLayer.leafletVersion = leafletVersion;
-
 }

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -10,6 +10,12 @@ export function leafletLayer(options) {
 
 function extendLeaflet(options) {
 
+    // If LeafletLayer is already defined when this is called just return that immediately
+    // e.g. if you call leafletLayer multiple times (which is valid)
+    if (typeof LeafletLayer !== 'undefined') {
+        return new LeafletLayer(options);
+    }
+
     // Leaflet layer functionality is only defined in main thread
     if (Utils.isMainThread) {
 

--- a/src/module.js
+++ b/src/module.js
@@ -4,7 +4,7 @@
 import Utils from './utils/utils';
 
 // The leaflet layer plugin is currently the primary public API
-import {LeafletLayer, leafletLayer} from './leaflet_layer';
+import {leafletLayer} from './leaflet_layer';
 
 // The scene worker is only activated when a worker thread is instantiated, but must always be loaded
 import {SceneWorker} from '../src/scene_worker';
@@ -64,7 +64,6 @@ if (Utils.isMainThread) {
     WorkerBroker.addTarget('Texture', Texture);
 
     window.Tangram = module.exports = {
-        LeafletLayer,
         leafletLayer,
         debug,
         version: version.string

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import Scene from '../src/scene';
-import {leafletLayer} from '../src/leaflet_layer';
+import {leafletLayer, LeafletLayer} from '../src/leaflet_layer';
 import sampleScene from './fixtures/sample-scene';
 let assert = chai.assert;
 

--- a/test/leaflet_layer_spec.js
+++ b/test/leaflet_layer_spec.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import Scene from '../src/scene';
-import {LeafletLayer} from '../src/leaflet_layer';
+import {leafletLayer} from '../src/leaflet_layer';
 import sampleScene from './fixtures/sample-scene';
 let assert = chai.assert;
 
@@ -11,7 +11,7 @@ let map = L.map(
 map.setView([0, 0], 0); // required to put leaflet in a "ready" state, or it will never call the layer's onAdd() method
 
 let makeOne = () => {
-    let layer = new LeafletLayer({
+    let layer = leafletLayer({
         scene: sampleScene,
         disableRenderLoop: true,
         workerUrl: 'http://localhost:9876/tangram.debug.js'


### PR DESCRIPTION
### The bottom line

Now, you can bundle up all of your app's front-end dependencies via Browserify except for Tangram. Tangram will wait until `Tangram.leafletLayer()` is called before looking for Leaflet.

### Usage

In HTML:

```html
  <script src='./path/to/tangram.min.js'></script>
  <script src='/js/bundle.js'></script>
```

In your `bundle.js`:

```js
var L = require('leaflet')
// Your other required dependencies

// [Init Leaflet map...]

// Add Tangram scene layer
// Provide the required Leaflet variable to Tangram
var layer = Tangram.leafletLayer({
  leaflet: L,
  scene: 'https://raw.githubusercontent.com/tangrams/refill/gh-pages/refill.yaml',
}).addTo(map);
```

### Changelog

- An entry point for `dist/tangram.min.js` is provided in `package.json` in case the repository is downloaded as an NPM module.
- When building the module, the output is piped through `derequire` so that other requires won't break by looking for submodules of Tangram.
- `Tangram.leafletLayer()` is wrapped so that `leaflet_layer.js` does not look for Leaflet until this function is called
- `Tangram.LeafletLayer` is never defined so it's removed from `module.js`

### Notes re: browserify & browserify-shim

Tangram cannot currently be bundled with other JS because this prevents Tangram from discovering its own URL for web workers.

The [browserify-shim module](https://github.com/thlorenz/browserify-shim) is not required to use Tangram. However, with it you can do this:

In `package.json`:

```json
  "browserify": {
    "transform": [ "browserify-shim" ]
  },
  "browserify-shim": {
    "tangram": "global:Tangram"
  }
```

In your `bundle.js`:

```js
var L = require('leaflet')
var Tangram = require('tangram') // via browserify-shim
```

This allows the developer to maintain consistency about dependencies although Tangram is still a global object. This is also more future proof because if the issues within Tangram are resolved this allows a developer to throw away the shim and the code is already prepared to accept Tangram as a normal `require`. [More details here](https://github.com/thlorenz/browserify-shim#a-expose-global-variables-via-global).

### Next steps

Webpages that load all scripts in individual tags should behave normally.

Check to see how it works in Webpack (for web map, cc @hanbyul-here)

~~Argh, tests are broken.~~ fixed
