### PR TITLE
World normal accessor

### DIFF
--- a/src/gl/shaders/accessors.glsl
+++ b/src/gl/shaders/accessors.glsl
@@ -1,9 +1,11 @@
 // Vertex position in model space: [0, 1] range over the local tile
 // Note positions can be outside that range due to unclipped geometry, geometry higher than a unit cube, etc.
 #ifdef TANGRAM_VERTEX_SHADER
+
 vec4 modelPosition() {
     return vec4(SHORT(a_position.xyz) / TANGRAM_TILE_SCALE, 1.);
 }
+
 #endif
 
 // Vertex position in world coordinates, useful for 3d procedural textures, etc.
@@ -14,6 +16,7 @@ vec4 worldPosition() {
 // Optionally wrap world coordinates (allows more precision at higher zooms)
 // e.g. at wrap 1000, the world space will wrap every 1000 meters
 #ifdef TANGRAM_VERTEX_SHADER
+
 vec4 wrapWorldPosition(vec4 world_position) {
     #if defined(TANGRAM_WORLD_POSITION_WRAP)
     vec2 anchor = u_tile_origin.xy - mod(u_tile_origin.xy, TANGRAM_WORLD_POSITION_WRAP);
@@ -21,4 +24,20 @@ vec4 wrapWorldPosition(vec4 world_position) {
     #endif
     return world_position;
 }
+
+#endif
+
+// Normal in world space
+#if defined(TANGRAM_VERTEX_SHADER)
+
+vec3 worldNormal() {
+    return TANGRAM_NORMAL;
+}
+
+#elif defined(TANGRAM_FRAGMENT_SHADER)
+
+vec3 worldNormal() {
+    return u_inverseNormalMatrix * TANGRAM_NORMAL;
+}
+
 #endif

--- a/src/scene.js
+++ b/src/scene.js
@@ -98,6 +98,7 @@ export default class Scene {
         this.modelViewMatrix32 = new Float32Array(16);
         this.normalMatrix = new Float64Array(9);
         this.normalMatrix32 = new Float32Array(9);
+        this.inverseNormalMatrix32 = new Float32Array(9);
 
         this.selection = null;
         this.texture_listener = null;
@@ -736,10 +737,12 @@ export default class Scene {
                     program.uniform('1f', 'u_meters_per_pixel', this.meters_per_pixel);
                     program.uniform('1f', 'u_device_pixel_ratio', Utils.device_pixel_ratio);
 
-                    // Normal matrix - transforms surface normals into view space
-                    // this matrix is constant since the view doesn't rotate for now
+                    // Normal matrices - transforms surface normals into view space
                     mat3.normalFromMat4(this.normalMatrix32, this.modelViewMatrix32);
+                    mat3.invert(this.inverseNormalMatrix32, this.normalMatrix32);
+
                     program.uniform('Matrix3fv', 'u_normalMatrix', false, this.normalMatrix32);
+                    program.uniform('Matrix3fv', 'u_inverseNormalMatrix', false, this.inverseNormalMatrix32);
 
                     this.camera.setupProgram(program);
                     for (let i in this.lights) {

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -5,11 +5,16 @@ uniform vec3 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
+uniform mat3 u_normalMatrix;
+uniform mat3 u_inverseNormalMatrix;
+
 uniform sampler2D u_texture;
 
 varying vec4 v_color;
 varying vec2 v_texcoord;
 varying vec4 v_world_position;
+
+#define TANGRAM_NORMAL vec3(0., 0., 1.)
 
 // Alpha discard threshold (substitute for alpha blending)
 #ifndef TANGRAM_ALPHA_DISCARD

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -7,12 +7,16 @@ uniform float u_device_pixel_ratio;
 
 uniform mat4 u_model;
 uniform mat4 u_modelView;
+uniform mat3 u_normalMatrix;
+uniform mat3 u_inverseNormalMatrix;
 
 attribute vec4 a_position;
 attribute vec4 a_shape;
 attribute vec4 a_color;
 attribute vec2 a_texcoord;
 attribute vec2 a_offset;
+
+#define TANGRAM_NORMAL vec3(0., 0., 1.)
 
 varying vec4 v_color;
 varying vec2 v_texcoord;

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -5,10 +5,15 @@ uniform vec3 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
+uniform mat3 u_normalMatrix;
+uniform mat3 u_inverseNormalMatrix;
+
 varying vec4 v_position;
 varying vec3 v_normal;
 varying vec4 v_color;
 varying vec4 v_world_position;
+
+#define TANGRAM_NORMAL v_normal
 
 #ifdef TANGRAM_TEXTURE_COORDS
     varying vec2 v_texcoord;
@@ -25,7 +30,7 @@ varying vec4 v_world_position;
 
 void main (void) {
     vec4 color = v_color;
-    vec3 normal = v_normal;
+    vec3 normal = TANGRAM_NORMAL;
 
     #ifdef TANGRAM_MATERIAL_NORMAL_TEXTURE
         calculateNormal(normal);

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -8,6 +8,7 @@ uniform float u_device_pixel_ratio;
 uniform mat4 u_model;
 uniform mat4 u_modelView;
 uniform mat3 u_normalMatrix;
+uniform mat3 u_inverseNormalMatrix;
 
 attribute vec4 a_position;
 attribute vec4 a_color;

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -41,6 +41,9 @@ StyleManager.init = function () {
     // Feature selection vertex shader support
     ShaderProgram.replaceBlock('feature-selection-vertex', shaderSources['gl/shaders/selection_vertex']);
 
+    // Minimum value for float comparisons
+    ShaderProgram.defines.TANGRAM_EPSILON = 0.00001;
+
     // assume min 16-bit depth buffer, in practice uses 14-bits, 1 extra bit to handle virtual half-layers
     // for outlines (inserted in between layers), another extra bit to prevent precision loss
     ShaderProgram.defines.TANGRAM_LAYER_DELTA = 1 / (1 << 14);

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -30,7 +30,7 @@ StyleManager.init = function () {
     ShaderProgram.addBlock('global', shaderSources['gl/shaders/unpack']);
 
     // Model and world position accessors
-    ShaderProgram.addBlock('global', shaderSources['gl/shaders/position_accessors']);
+    ShaderProgram.addBlock('global', shaderSources['gl/shaders/accessors']);
 
     // Layer re-ordering function
     ShaderProgram.addBlock('global', shaderSources['gl/shaders/layer_order']);


### PR DESCRIPTION
Adds `vec3 worldNormal()` accessor, to match ES behavior from https://github.com/tangrams/tangram-es/pull/375.

Adds inverse normal matrix (`u_inverseNormalMatrix`), and `TANGRAM_EPSILON` for floating point comparisons (to match ES).

![tangram-1446574135689](https://cloud.githubusercontent.com/assets/16733/10920265/35539252-823d-11e5-9226-8d2ba242c2c9.png)
