### PR TITLE
Support anchors for points/sprites

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -426,8 +426,12 @@ layers:
         data: { source: osm, layer: pois }
         filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
         draw:
+            points:
+                visible: false # turn on for debug
+                color: red
+                size: 8px
             icons:
-                # offset: [0px, -13px]
+                anchor: top
                 size: [[13, 12px], [15, 18px]]
                 interactive: true
 
@@ -560,9 +564,9 @@ layers:
                 $zoom: { min: 18 }
             draw:
                 text:
-                    anchor: right
+                    anchor: bottom
                     # align: left
-                    offset: [13px, 0]
+                    offset: [0, 2px]
                     move_into_tile: false
                     priority: 6
                     font:

--- a/src/styles/points/point_anchor.js
+++ b/src/styles/points/point_anchor.js
@@ -1,0 +1,53 @@
+// Sets of values to match for directional and corner anchors
+const lefts = ['left', 'top-left', 'bottom-left'];
+const rights = ['right', 'top-right', 'bottom-right'];
+const tops = ['top', 'top-left', 'top-right'];
+const bottoms = ['bottom', 'bottom-left', 'bottom-right'];
+
+var PointAnchor;
+
+export default PointAnchor = {
+
+    computeOffset (offset, size, anchor) {
+        if (!anchor || anchor === 'center') {
+            return offset;
+        }
+
+        let offset2 = [offset[0], offset[1]];
+
+        // An optional left/right offset
+        if (this.isLeftAnchor(anchor)) {
+            offset2[0] -= size[0] / 2;
+        }
+        else if (this.isRightAnchor(anchor)) {
+            offset2[0] += size[0] / 2;
+        }
+
+        // An optional top/bottom offset
+        if (this.isTopAnchor(anchor)) {
+            offset2[1] -= size[1] / 2;
+        }
+        else if (this.isBottomAnchor(anchor)) {
+            offset2[1] += size[1] / 2;
+        }
+
+        return offset2;
+    },
+
+    isLeftAnchor (anchor) {
+        return (lefts.indexOf(anchor) > -1);
+    },
+
+    isRightAnchor (anchor) {
+        return (rights.indexOf(anchor) > -1);
+    },
+
+    isTopAnchor (anchor) {
+        return (tops.indexOf(anchor) > -1);
+    },
+
+    isBottomAnchor (anchor) {
+        return (bottoms.indexOf(anchor) > -1);
+    }
+
+};

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -9,6 +9,7 @@ import Texture from '../../gl/texture';
 import Geo from '../../geo';
 import Utils from '../../utils/utils';
 import Vector from '../../vector';
+import PointAnchor from './point_anchor';
 
 import log from 'loglevel';
 
@@ -143,9 +144,17 @@ Object.assign(Points, {
         style.centroid = rule_style.centroid;
 
         // Offset applied to point in screen space
-        style.offset = rule_style.offset || [0, 0];
-        style.offset[0] = parseInt(style.offset[0]);
-        style.offset[1] = parseInt(style.offset[1]);
+        if (rule_style.offset) {
+            style.offset = rule_style.offset;
+            style.offset[0] = parseInt(style.offset[0]) * Utils.device_pixel_ratio;
+            style.offset[1] = parseInt(style.offset[1]) * Utils.device_pixel_ratio;
+        }
+        else {
+            style.offset = [0, 0];
+        }
+
+        // anchor
+        style.offset = PointAnchor.computeOffset(style.offset, style.size, rule_style.anchor);
 
         return style;
     },
@@ -203,7 +212,7 @@ Object.assign(Points, {
             {
                 quad: [ Utils.scaleInt16(size[0], 256), Utils.scaleInt16(size[1], 256) ],
                 quad_scale: Utils.scaleInt16(1, 256),
-                offset: Vector.mult(offset, Utils.device_pixel_ratio),
+                offset,
                 angle: Utils.scaleInt16(angle, 360),
                 texcoord_scale: this.texcoord_scale,
                 texcoord_normalize: 65535

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -1,7 +1,7 @@
 import Utils from '../../utils/utils';
 import Geo from '../../geo';
 import {StyleParser} from '../style_parser';
-import LabelPoint from './label_point';
+import PointAnchor from '../points/point_anchor';
 
 export default class FeatureLabel {
 
@@ -79,10 +79,10 @@ export default class FeatureLabel {
 
         // default alignment to match anchor
         if (!rule.align && rule.anchor && rule.anchor !== 'center') {
-            if (LabelPoint.isLeftAnchor(rule.anchor)) {
+            if (PointAnchor.isLeftAnchor(rule.anchor)) {
                 rule.align = 'right';
             }
-            else if (LabelPoint.isRightAnchor(rule.anchor)) {
+            else if (PointAnchor.isRightAnchor(rule.anchor)) {
                 rule.align = 'left';
             }
         }

--- a/src/styles/text/label_point.js
+++ b/src/styles/text/label_point.js
@@ -1,12 +1,7 @@
 import Label from './label';
 import Geo from '../../geo';
 import OBB from '../../utils/obb';
-
-// Sets of values to match for directional and corner anchors
-const lefts = ['left', 'top-left', 'bottom-left'];
-const rights = ['right', 'top-right', 'bottom-right'];
-const tops = ['top', 'top-left', 'top-right'];
-const bottoms = ['bottom', 'bottom-left', 'bottom-right'];
+import PointAnchor from '../points/point_anchor';
 
 export default class LabelPoint extends Label {
 
@@ -22,30 +17,7 @@ export default class LabelPoint extends Label {
     }
 
     computeOffset () {
-        if (!this.options.anchor || this.options.anchor === 'center') {
-            return this.options.offset;
-        }
-
-        let offset = [this.options.offset[0], this.options.offset[1]];
-        let anchor = this.options.anchor;
-
-        // An optional left/right offset
-        if (LabelPoint.isLeftAnchor(anchor)) {
-            offset[0] -= this.size.text_size[0] / 2;
-        }
-        else if (LabelPoint.isRightAnchor(anchor)) {
-            offset[0] += this.size.text_size[0] / 2;
-        }
-
-        // An optional top/bottom offset
-        if (LabelPoint.isTopAnchor(anchor)) {
-            offset[1] -= this.size.text_size[1] / 2;
-        }
-        else if (LabelPoint.isBottomAnchor(anchor)) {
-            offset[1] += this.size.text_size[1] / 2;
-        }
-
-        return offset;
+        return PointAnchor.computeOffset(this.options.offset, this.size.text_size, this.options.anchor);
     }
 
     computeAABB () {
@@ -92,22 +64,6 @@ export default class LabelPoint extends Label {
         }
 
         return !this.inTileBounds();
-    }
-
-    static isLeftAnchor (anchor) {
-        return (lefts.indexOf(anchor) > -1);
-    }
-
-    static isRightAnchor (anchor) {
-        return (rights.indexOf(anchor) > -1);
-    }
-
-    static isTopAnchor (anchor) {
-        return (tops.indexOf(anchor) > -1);
-    }
-
-    static isBottomAnchor (anchor) {
-        return (bottoms.indexOf(anchor) > -1);
     }
 
 }


### PR DESCRIPTION
Generalizes the logic from point labels so that it also applies to points/sprites. The same `anchor` values apply (`left`, `bottom-right`, etc.). Unlike with labels, the `align` keyword is not needed.