### PR TITLE
Font property interpolation by zoom

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -270,102 +270,89 @@ layers:
                 style: flat_lines
                 color: white
                 width: 12
-                # width: [[13, 0px], [14, 1px], [15, 8], [18, 8], [19, 0]]
                 order: function () { return feature.sort_key + 5; }
                 outline:
                     color: [[16, '#999'], [18, '#aaa']]
-                    # color: red
-                    width: [[15, 0], [16, 2], [18, 2], [19, 0]]
-                    # width: 2px
+                    width: [[15, 0], [16, 2]]
                     order: 4 # put all outlines below all roads (for now)
 
-        #        style: flat_lines
-        #         color: white
-        #         width: 12
-        #         order: function () { return feature.sort_key + 5; }
-        #         outline:
-        #             color: [[16, '#999'], [18, '#aaa']]
-        #             width: [[15, 0], [16, 2]]
-        #             order: 4 # put all outlines below all roads (for now)
+        rounded:
+            filter: { $zoom: { min: 18 } }
+            draw:
+                lines:
+                    cap: round
 
-        # rounded:
-        #     filter: { $zoom: { min: 18 } }
-        #     draw:
-        #         lines:
-        #             cap: round
+        highway:
+            filter: { kind: highway }
+            draw:
+                lines:
+                    color: '#D16768'
+                    width: [[14, 2px], [15, 12]]
+                    outline:
+                        width: [[14, 0], [15, 2]]
+            link:
+                filter: { is_link: yes }
+                draw:
+                    lines:
+                        color: '#aaa'
+                        width: [[13, 0], [14, 12]]
+        major_road:
+            filter: { kind: major_road, $zoom: { min: 10 } }
+            draw:
+                lines:
+                    width: [[10, 0], [13, 2px], [14, 2px], [16, 12]]
+                    outline:
+                        width: [[16, 0], [17, 1]]
+        minor_road:
+            filter: { kind: minor_road }
+            draw:
+                lines:
+                    width: [[13, 0px], [14, 1px], [15, 8]]
+                    outline:
+                        width: [[17, 0], [18, 1]]
+        paths:
+            filter: { kind: path }
+            draw:
+                lines:
+                    color: '#bbb'
+                    width: [[15, 0px], [18, 2px]]
+                    outline:
+                        width: 0
+        airports:
+            filter: { aeroway: true }
+            draw:
+                lines:
+                    color: '#ddd'
+                    outline:
+                        width: 0
 
-        # highway:
-        #     filter: { kind: highway }
-        #     draw:
-        #         lines:
-        #             color: '#D16768'
-        #             width: [[14, 2px], [15, 12]]
-        #             outline:
-        #                 width: [[14, 0], [15, 2]]
-        #     link:
-        #         filter: { is_link: yes }
-        #         draw:
-        #             lines:
-        #                 color: '#aaa'
-        #                 width: [[13, 0], [14, 12]]
-        # major_road:
-        #     filter: { kind: major_road, $zoom: { min: 10 } }
-        #     draw:
-        #         lines:
-        #             width: [[10, 0], [13, 2px], [14, 2px], [16, 12]]
-        #             outline:
-        #                 width: [[16, 0], [17, 1]]
-        # minor_road:
-        #     filter: { kind: minor_road }
-        #     draw:
-        #         lines:
-        #             width: [[13, 0px], [14, 1px], [15, 8]]
-        #             # width: [[13, 0px], [14, 1px], [15, 8], [18, 8], [19, 0]]
-        #             outline:
-        #                 width: [[17, 0], [18, 1]]
-        # paths:
-        #     filter: { kind: path }
-        #     draw:
-        #         lines:
-        #             color: '#bbb'
-        #             width: [[15, 0px], [18, 2px]]
-        #             outline:
-        #                 width: 0
-        # airports:
-        #     filter: { aeroway: true }
-        #     draw:
-        #         lines:
-        #             color: '#ddd'
-        #             outline:
-        #                 width: 0
+            taxiways:
+                filter: { aeroway: taxiway }
+                draw:
+                    lines:
+                        width: [[13, 0px], [14, 2px], [17, 10px]]
 
-        #     taxiways:
-        #         filter: { aeroway: taxiway }
-        #         draw:
-        #             lines:
-        #                 width: [[13, 0px], [14, 2px], [17, 10px]]
+            runways:
+                filter: { aeroway: runway }
+                draw:
+                    lines:
+                        color: [[13, '#FFE4B5'], [16, white]]
+                        width: [[11, 3px], [12, 5px], [13, 10px], [15, 75]]
+                        order: 39
+                        cap: square
+                        outline:
+                            color: orange
+                            width: [[11, 0px], [12, 1px], [13, 2px], [15, 12.5]]
+                            order: 38
 
-        #     runways:
-        #         filter: { aeroway: runway }
-        #         draw:
-        #             lines:
-        #                 color: [[13, '#FFE4B5'], [16, white]]
-        #                 width: [[11, 3px], [12, 5px], [13, 10px], [15, 75]]
-        #                 order: 39
-        #                 cap: square
-        #                 outline:
-        #                     color: orange
-        #                     width: [[11, 0px], [12, 1px], [13, 2px], [15, 12.5]]
-        #                     order: 38
-
-        # # apply outline to roads intersecting parks - see data source transform example in `sources`
-        # land:
-        #     filter: { intersects_park: true }
-        #     draw:
-        #         lines:
-        #             outline:
-        #                 color: yellow
-        #                 width: 2px
+        # apply outline to roads intersecting parks - see data source transform example in `sources`
+        land:
+            filter: { intersects_park: true }
+            draw:
+                lines:
+                    outline:
+                        color: yellow
+                        width: 2px
 
     buildings:
         data: { source: osm }

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -270,89 +270,102 @@ layers:
                 style: flat_lines
                 color: white
                 width: 12
+                # width: [[13, 0px], [14, 1px], [15, 8], [18, 8], [19, 0]]
                 order: function () { return feature.sort_key + 5; }
                 outline:
                     color: [[16, '#999'], [18, '#aaa']]
-                    width: [[15, 0], [16, 2]]
+                    # color: red
+                    width: [[15, 0], [16, 2], [18, 2], [19, 0]]
+                    # width: 2px
                     order: 4 # put all outlines below all roads (for now)
 
-        rounded:
-            filter: { $zoom: { min: 18 } }
-            draw:
-                lines:
-                    cap: round
+        #        style: flat_lines
+        #         color: white
+        #         width: 12
+        #         order: function () { return feature.sort_key + 5; }
+        #         outline:
+        #             color: [[16, '#999'], [18, '#aaa']]
+        #             width: [[15, 0], [16, 2]]
+        #             order: 4 # put all outlines below all roads (for now)
 
-        highway:
-            filter: { kind: highway }
-            draw:
-                lines:
-                    color: '#D16768'
-                    width: [[14, 2px], [15, 12]]
-                    outline:
-                        width: [[14, 0], [15, 2]]
-            link:
-                filter: { is_link: yes }
-                draw:
-                    lines:
-                        color: '#aaa'
-                        width: [[13, 0], [14, 12]]
-        major_road:
-            filter: { kind: major_road, $zoom: { min: 10 } }
-            draw:
-                lines:
-                    width: [[10, 0], [13, 2px], [14, 2px], [16, 12]]
-                    outline:
-                        width: [[16, 0], [17, 1]]
-        minor_road:
-            filter: { kind: minor_road }
-            draw:
-                lines:
-                    width: [[13, 0px], [14, 1px], [15, 8]]
-                    outline:
-                        width: [[17, 0], [18, 1]]
-        paths:
-            filter: { kind: path }
-            draw:
-                lines:
-                    color: '#bbb'
-                    width: [[15, 0px], [18, 2px]]
-                    outline:
-                        width: 0
-        airports:
-            filter: { aeroway: true }
-            draw:
-                lines:
-                    color: '#ddd'
-                    outline:
-                        width: 0
+        # rounded:
+        #     filter: { $zoom: { min: 18 } }
+        #     draw:
+        #         lines:
+        #             cap: round
 
-            taxiways:
-                filter: { aeroway: taxiway }
-                draw:
-                    lines:
-                        width: [[13, 0px], [14, 2px], [17, 10px]]
+        # highway:
+        #     filter: { kind: highway }
+        #     draw:
+        #         lines:
+        #             color: '#D16768'
+        #             width: [[14, 2px], [15, 12]]
+        #             outline:
+        #                 width: [[14, 0], [15, 2]]
+        #     link:
+        #         filter: { is_link: yes }
+        #         draw:
+        #             lines:
+        #                 color: '#aaa'
+        #                 width: [[13, 0], [14, 12]]
+        # major_road:
+        #     filter: { kind: major_road, $zoom: { min: 10 } }
+        #     draw:
+        #         lines:
+        #             width: [[10, 0], [13, 2px], [14, 2px], [16, 12]]
+        #             outline:
+        #                 width: [[16, 0], [17, 1]]
+        # minor_road:
+        #     filter: { kind: minor_road }
+        #     draw:
+        #         lines:
+        #             width: [[13, 0px], [14, 1px], [15, 8]]
+        #             # width: [[13, 0px], [14, 1px], [15, 8], [18, 8], [19, 0]]
+        #             outline:
+        #                 width: [[17, 0], [18, 1]]
+        # paths:
+        #     filter: { kind: path }
+        #     draw:
+        #         lines:
+        #             color: '#bbb'
+        #             width: [[15, 0px], [18, 2px]]
+        #             outline:
+        #                 width: 0
+        # airports:
+        #     filter: { aeroway: true }
+        #     draw:
+        #         lines:
+        #             color: '#ddd'
+        #             outline:
+        #                 width: 0
 
-            runways:
-                filter: { aeroway: runway }
-                draw:
-                    lines:
-                        color: [[13, '#FFE4B5'], [16, white]]
-                        width: [[11, 3px], [12, 5px], [13, 10px], [15, 75]]
-                        order: 39
-                        cap: square
-                        outline:
-                            color: orange
-                            width: [[11, 0px], [12, 1px], [13, 2px], [15, 12.5]]
-                            order: 38
+        #     taxiways:
+        #         filter: { aeroway: taxiway }
+        #         draw:
+        #             lines:
+        #                 width: [[13, 0px], [14, 2px], [17, 10px]]
 
-        # apply outline to roads intersecting parks - see data source transform example in `sources`
-        land:
-            filter: { intersects_park: true }
-            draw:
-                lines:
-                    outline:
-                        color: yellow
-                        width: 2px
+        #     runways:
+        #         filter: { aeroway: runway }
+        #         draw:
+        #             lines:
+        #                 color: [[13, '#FFE4B5'], [16, white]]
+        #                 width: [[11, 3px], [12, 5px], [13, 10px], [15, 75]]
+        #                 order: 39
+        #                 cap: square
+        #                 outline:
+        #                     color: orange
+        #                     width: [[11, 0px], [12, 1px], [13, 2px], [15, 12.5]]
+        #                     order: 38
+
+        # # apply outline to roads intersecting parks - see data source transform example in `sources`
+        # land:
+        #     filter: { intersects_park: true }
+        #     draw:
+        #         lines:
+        #             outline:
+        #                 color: yellow
+        #                 width: 2px
 
     buildings:
         data: { source: osm }
@@ -521,7 +534,7 @@ layers:
                 text:
                     font:
                         family: Helvetica
-                        size: 12pt
+                        size: [[6, 12px], [9, 16px]]
                         style: italic
                         fill: black
                         stroke: { color: white, width: 3 }

--- a/src/scene.js
+++ b/src/scene.js
@@ -505,8 +505,10 @@ export default class Scene {
     // Resize the map when device pixel ratio changes, e.g. when switching between displays
     updateDevicePixelRatio () {
         if (Utils.updateDevicePixelRatio()) {
-            this.workers.forEach(w => WorkerBroker.postMessage(w, 'updateDevicePixelRatio', Utils.device_pixel_ratio));
-            this.resizeMap(this.css_size.width, this.css_size.height);
+            Promise
+                .all(this.workers.map(w => WorkerBroker.postMessage(w, 'updateDevicePixelRatio', Utils.device_pixel_ratio)))
+                .then(() => this.rebuild())
+                .then(() => this.resizeMap(this.css_size.width, this.css_size.height));
         }
     }
 

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -156,7 +156,7 @@ Object.assign(Lines, {
         return style;
     },
 
-    preprocess (draw) {
+    _preprocess (draw) {
         draw.color = draw.color && { value: draw.color };
         draw.width = draw.width && { value: draw.width };
         draw.next_width = draw.width && { value: draw.width.value };

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -157,15 +157,15 @@ Object.assign(Lines, {
     },
 
     _preprocess (draw) {
-        draw.color = this.cacheObject(draw.color);
-        draw.width = this.cacheObject(draw.width);
-        draw.next_width = this.cacheObject(draw.width); // width will be computed for next zoom
-        draw.z = this.cacheObject(draw.z);
+        draw.color = StyleParser.cacheObject(draw.color);
+        draw.width = StyleParser.cacheObject(draw.width);
+        draw.next_width = StyleParser.cacheObject(draw.width); // width will be computed for next zoom
+        draw.z = StyleParser.cacheObject(draw.z);
 
         if (draw.outline) {
-            draw.outline.color = this.cacheObject(draw.outline.color);
-            draw.outline.width = this.cacheObject(draw.outline.width);
-            draw.outline.next_width = this.cacheObject(draw.outline.width); // width re-computed for next zoom
+            draw.outline.color = StyleParser.cacheObject(draw.outline.color);
+            draw.outline.width = StyleParser.cacheObject(draw.outline.width);
+            draw.outline.next_width = StyleParser.cacheObject(draw.outline.width); // width re-computed for next zoom
         }
     },
 

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -157,15 +157,15 @@ Object.assign(Lines, {
     },
 
     _preprocess (draw) {
-        draw.color = draw.color && { value: draw.color };
-        draw.width = draw.width && { value: draw.width };
-        draw.next_width = draw.width && { value: draw.width.value };
-        draw.z = draw.z && { value: draw.z };
+        draw.color = this.cacheObject(draw.color);
+        draw.width = this.cacheObject(draw.width);
+        draw.next_width = this.cacheObject(draw.width); // width will be computed for next zoom
+        draw.z = this.cacheObject(draw.z);
 
         if (draw.outline) {
-            draw.outline.color = draw.outline.color && { value: draw.outline.color };
-            draw.outline.width = draw.outline.width && { value: draw.outline.width };
-            draw.outline.next_width = draw.outline.width && { value: draw.outline.width.value };
+            draw.outline.color = this.cacheObject(draw.outline.color);
+            draw.outline.width = this.cacheObject(draw.outline.width);
+            draw.outline.next_width = this.cacheObject(draw.outline.width); // width re-computed for next zoom
         }
     },
 

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -160,9 +160,9 @@ Object.assign(Points, {
     },
 
     _preprocess (draw) {
-        draw.color = this.cacheObject(draw.color);
-        draw.z = this.cacheObject(draw.z);
-        draw.size = this.cacheObject(draw.size);
+        draw.color = StyleParser.cacheObject(draw.color);
+        draw.z = StyleParser.cacheObject(draw.z);
+        draw.size = StyleParser.cacheObject(draw.size);
     },
 
     /**

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -160,9 +160,9 @@ Object.assign(Points, {
     },
 
     _preprocess (draw) {
-        draw.color = draw.color && { value: draw.color };
-        draw.z = draw.z && { value: draw.z };
-        draw.size = draw.size && { value: draw.size };
+        draw.color = this.cacheObject(draw.color);
+        draw.z = this.cacheObject(draw.z);
+        draw.size = this.cacheObject(draw.size);
     },
 
     /**

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -159,7 +159,7 @@ Object.assign(Points, {
         return style;
     },
 
-    preprocess (draw) {
+    _preprocess (draw) {
         draw.color = draw.color && { value: draw.color };
         draw.z = draw.z && { value: draw.z };
         draw.size = draw.size && { value: draw.size };

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -92,7 +92,7 @@ Object.assign(Polygons, {
         return style;
     },
 
-    preprocess (draw) {
+    _preprocess (draw) {
         draw.color = draw.color && { value: draw.color };
         draw.z = draw.z && { value: draw.z };
     },

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -93,8 +93,8 @@ Object.assign(Polygons, {
     },
 
     _preprocess (draw) {
-        draw.color = draw.color && { value: draw.color };
-        draw.z = draw.z && { value: draw.z };
+        draw.color = this.cacheObject(draw.color);
+        draw.z = this.cacheObject(draw.z);
     },
 
     /**

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -93,8 +93,8 @@ Object.assign(Polygons, {
     },
 
     _preprocess (draw) {
-        draw.color = this.cacheObject(draw.color);
-        draw.z = this.cacheObject(draw.z);
+        draw.color = StyleParser.cacheObject(draw.color);
+        draw.z = StyleParser.cacheObject(draw.z);
     },
 
     /**

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -218,6 +218,12 @@ export var Style = {
 
     _preprocess () {}, // optionally implemented by subclass
 
+    // Build a style param cache object
+    // `value` is raw value, cache methods will add other properties as needed
+    cacheObject (obj) {
+        return obj && { value: obj };
+    },
+
     // Parse an order value
     parseOrder (order, context) {
         // Calculate order if it was not cached

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -165,15 +165,19 @@ export var Style = {
         }
     },
 
+    preprocessFeatureStyle (rule_style) {
+        // Preprocess first time
+        if (!rule_style.preprocessed) {
+            this.preprocess(rule_style); // optional subclass implementation
+            rule_style.preprocessed = true;
+        }
+    },
+
     parseFeature (feature, rule_style, context) {
         try {
             var style = this.feature_style;
 
-            // Preprocess first time
-            if (!rule_style.preprocessed) {
-                this.preprocess(rule_style);
-                rule_style.preprocessed = true;
-            }
+            this.preprocessFeatureStyle(rule_style);
 
             // Calculate order if it was not cached
             style.order = this.parseOrder(rule_style.order, context);

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -165,19 +165,11 @@ export var Style = {
         }
     },
 
-    preprocessFeatureStyle (rule_style) {
-        // Preprocess first time
-        if (!rule_style.preprocessed) {
-            this.preprocess(rule_style); // optional subclass implementation
-            rule_style.preprocessed = true;
-        }
-    },
-
     parseFeature (feature, rule_style, context) {
         try {
             var style = this.feature_style;
 
-            this.preprocessFeatureStyle(rule_style);
+            this.preprocess(rule_style);
 
             // Calculate order if it was not cached
             style.order = this.parseOrder(rule_style.order, context);
@@ -216,7 +208,15 @@ export var Style = {
         throw new MethodNotImplemented('_parseFeature');
     },
 
-    preprocess () {},
+    preprocess (rule_style) {
+        // Preprocess first time
+        if (!rule_style.preprocessed) {
+            this._preprocess(rule_style); // optional subclass implementation
+            rule_style.preprocessed = true;
+        }
+    },
+
+    _preprocess () {}, // optionally implemented by subclass
 
     // Parse an order value
     parseOrder (order, context) {

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -218,12 +218,6 @@ export var Style = {
 
     _preprocess () {}, // optionally implemented by subclass
 
-    // Build a style param cache object
-    // `value` is raw value, cache methods will add other properties as needed
-    cacheObject (obj) {
-        return obj && { value: obj };
-    },
-
     // Parse an order value
     parseOrder (order, context) {
         // Calculate order if it was not cached

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -300,34 +300,20 @@ StyleParser.parseColor = function(val, context = {}) {
     // Parse CSS-style colors
     // TODO: change all colors to use 0-255 range internally to avoid dividing and then re-multiplying in geom builder
     if (typeof val === 'string') {
-        val = parseCSSColor.parseCSSColor(val);
-        if (val && val.length === 4) {
-            val[0] /= 255;
-            val[1] /= 255;
-            val[2] /= 255;
-        }
-        else {
-            val = null;
-        }
+        val = StyleParser.colorForString(val);
     }
     else if (Array.isArray(val) && Array.isArray(val[0])) {
         // Array of zoom-interpolated stops, e.g. [zoom, color] pairs
         for (let i=0; i < val.length; i++) {
             let v = val[i];
             if (typeof v[1] === 'string') {
-                var vc = parseCSSColor.parseCSSColor(v[1]);
-                if (vc && vc.length === 4) {
-                    vc[0] /= 255;
-                    vc[1] /= 255;
-                    vc[2] /= 255;
-                    v[1] = vc;
-                }
+                v[1] = StyleParser.colorForString(v[1]);
             }
         }
-    }
 
-    if (context.zoom) {
-        val = Utils.interpolate(context.zoom, val);
+        if (context.zoom) {
+            val = Utils.interpolate(context.zoom, val);
+        }
     }
 
     // Defaults

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -142,6 +142,65 @@ StyleParser.getFeatureParseContext = function (feature, tile) {
     };
 };
 
+// Build a style param cache object
+// `value` is raw value, cache methods will add other properties as needed
+// `transform` is optional transform function to run on values
+StyleParser.cacheObject = function (obj, transform = null) {
+    if (obj == null) {
+        return;
+    }
+
+    if (typeof transform === 'function') {
+        if (Array.isArray(obj) && Array.isArray(obj[0])) {
+            obj = obj.map(v => [v[0], transform(v[1])]);
+        }
+        else {
+            obj = transform(obj);
+        }
+    }
+
+    return { value: obj };
+};
+
+// Interpolation and caching for a generic property (not a color or distance)
+// { value: original, static: val, zoom: { 1: val1, 2: val2, ... }, dynamic: function(){...} }
+StyleParser.cacheProperty = function(val, context) {
+    if (val == null) {
+        return;
+    }
+    else if (val.dynamic) { // function, compute each time (no caching)
+        let v = val.dynamic(context);
+        return v;
+    }
+    else if (val.static) { // single static value
+        return val.static;
+    }
+    else if (val.zoom && val.zoom[context.zoom]) { // interpolated, cached
+        return val.zoom[context.zoom];
+    }
+    else { // not yet evaulated for cache
+        // Dynamic function-based
+        if (typeof val.value === 'function') {
+            val.dynamic = val.value;
+            let v = val.dynamic(context);
+            return v;
+        }
+        // Array of zoom-interpolated stops, e.g. [zoom, value] pairs
+        else if (Array.isArray(val.value) && Array.isArray(val.value[0])) {
+            // Calculate value for current zoom
+            val.zoom = val.zoom || {};
+            val.zoom = {};
+            val.zoom[context.zoom] = Utils.interpolate(context.zoom, val.value);
+            return val.zoom[context.zoom];
+        }
+        // Single static value
+        else {
+            val.static = val.value;
+            return val.static;
+        }
+    }
+};
+
 StyleParser.convertUnits = function(val, context, convert = 'meters') {
     if (typeof val === 'string') {
         var units = val.match(/([0-9.-]+)([a-z]+)/);

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -236,4 +236,31 @@ export default class CanvasText {
         return text;
     }
 
+    // Convert font CSS-style size ('12px', '14pt', '1.5em', etc.) to pixel size (adjusted for device pixel ratio)
+    // Defaults units to pixels if not specified
+    static fontPixelSize (size) {
+        if (size == null) {
+            return;
+        }
+        size = (typeof size === 'string') ? size : String(size); // need a string for regex
+
+        let [, px_size, units] = size.match(CanvasText.font_size_re) || [];
+        units = units || 'px';
+
+        if (units === "em") {
+            px_size *= 16;
+        } else if (units === "pt") {
+            px_size /= 0.75;
+        } else if (units === "%") {
+            px_size /= 6.25;
+        }
+
+        px_size = parseFloat(px_size);
+        px_size *= Utils.device_pixel_ratio;
+        return px_size;
+    }
+
 }
+
+// Extract font size and units
+CanvasText.font_size_re = /((?:[0-9]*\.)?[0-9]+)\s*(px|pt|em|%)?/;

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -23,7 +23,7 @@ export default class FeatureLabel {
         rule.font = rule.font || default_font_style;
 
         // Use fill if specified, or default
-        style.fill = (rule.font.fill && Utils.toCSSColor(StyleParser.parseColor(rule.font.fill, context))) || default_font_style.fill;
+        style.fill = (rule.font.fill && Utils.toCSSColor(StyleParser.cacheColor(rule.font.fill, context))) || default_font_style.fill;
 
         // Font properties are modeled after CSS names:
         // - family: Helvetica, Futura, etc.
@@ -52,7 +52,7 @@ export default class FeatureLabel {
 
         // Use stroke if specified
         if (rule.font.stroke && rule.font.stroke.color) {
-            style.stroke = Utils.toCSSColor(StyleParser.parseColor(rule.font.stroke.color, context));
+            style.stroke = Utils.toCSSColor(StyleParser.cacheColor(rule.font.stroke.color, context));
 
             if (rule.font.stroke.width_by_zoom) { // zoom stops
                 if (rule.font.stroke.width_by_zoom[context.zoom] == null) { // calc and cache

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -112,6 +112,3 @@ export default class FeatureLabel {
     }
 
 }
-
-// Extract font size and units
-// FeatureLabel.font_size_re = /((?:[0-9]*\.)?[0-9]+)\s*(px|pt|em|%)/;

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -52,7 +52,7 @@ export default class FeatureLabel {
 
         // Use stroke if specified
         if (rule.font.stroke && rule.font.stroke.color) {
-            style.stroke = Utils.toCSSColor(StyleParser.parseColor(rule.font.stroke.color));
+            style.stroke = Utils.toCSSColor(StyleParser.parseColor(rule.font.stroke.color, context));
 
             if (rule.font.stroke.width_by_zoom) { // zoom stops
                 if (rule.font.stroke.width_by_zoom[context.zoom] == null) { // calc and cache

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -25,13 +25,6 @@ export default class FeatureLabel {
         // Use fill if specified, or default
         style.fill = (rule.font.fill && Utils.toCSSColor(StyleParser.parseColor(rule.font.fill, context))) || default_font_style.fill;
 
-        // Use stroke if specified
-        if (rule.font.stroke && rule.font.stroke.color) {
-            style.stroke = Utils.toCSSColor(StyleParser.parseColor(rule.font.stroke.color));
-            style.stroke_width = rule.font.stroke.width || default_font_style.stroke.width;
-            style.stroke_width = style.stroke_width && parseFloat(style.stroke_width);
-        }
-
         // Font properties are modeled after CSS names:
         // - family: Helvetica, Futura, etc.
         // - size: in pt, px, or em
@@ -53,11 +46,26 @@ export default class FeatureLabel {
             }
             style.px_size = rule.font.px_size_by_zoom[context.zoom];
         }
-        else {
-            style.px_size = rule.font.px_size || default_font_style.px_size; // single size
+        else { // single value
+            style.px_size = rule.font.px_size || default_font_style.px_size;
         }
 
-        style.stroke_width *= Utils.device_pixel_ratio;
+        // Use stroke if specified
+        if (rule.font.stroke && rule.font.stroke.color) {
+            style.stroke = Utils.toCSSColor(StyleParser.parseColor(rule.font.stroke.color));
+
+            if (rule.font.stroke.width_by_zoom) { // zoom stops
+                if (rule.font.stroke.width_by_zoom[context.zoom] == null) { // calc and cache
+                    rule.font.stroke.width_by_zoom[context.zoom] =
+                        Utils.interpolate(context.zoom, rule.font.stroke.width);
+                }
+                style.stroke_width = rule.font.stroke.width_by_zoom[context.zoom];
+            }
+            else { // single value
+                style.stroke_width = rule.font.stroke.width || default_font_style.stroke.width;
+            }
+            style.stroke_width *= Utils.device_pixel_ratio;
+        }
 
         if (rule.font.typeface) { // 'typeface' legacy syntax, deprecate
             style.font_css = rule.font.typeface;

--- a/src/styles/text/feature_label.js
+++ b/src/styles/text/feature_label.js
@@ -40,30 +40,12 @@ export default class FeatureLabel {
         style.size = rule.font.size || rule.font.typeface || default_font_style.size; // TODO: 'typeface' legacy syntax, deprecate
 
         // calculated pixel size
-        if (rule.font.px_size_by_zoom) { // zoom stops
-            if (rule.font.px_size_by_zoom[context.zoom] == null) { // calc and cache
-                rule.font.px_size_by_zoom[context.zoom] = Utils.interpolate(context.zoom, rule.font.px_size);
-            }
-            style.px_size = rule.font.px_size_by_zoom[context.zoom];
-        }
-        else { // single value
-            style.px_size = rule.font.px_size || default_font_style.px_size;
-        }
+        style.px_size = StyleParser.cacheProperty(rule.font.px_size, context) || default_font_style.px_size;
 
         // Use stroke if specified
         if (rule.font.stroke && rule.font.stroke.color) {
-            style.stroke = Utils.toCSSColor(StyleParser.cacheColor(rule.font.stroke.color, context));
-
-            if (rule.font.stroke.width_by_zoom) { // zoom stops
-                if (rule.font.stroke.width_by_zoom[context.zoom] == null) { // calc and cache
-                    rule.font.stroke.width_by_zoom[context.zoom] =
-                        Utils.interpolate(context.zoom, rule.font.stroke.width);
-                }
-                style.stroke_width = rule.font.stroke.width_by_zoom[context.zoom];
-            }
-            else { // single value
-                style.stroke_width = rule.font.stroke.width || default_font_style.stroke.width;
-            }
+            style.stroke = Utils.toCSSColor(StyleParser.cacheColor(rule.font.stroke.color, context) || default_font_style.stroke);
+            style.stroke_width = StyleParser.cacheProperty(rule.font.stroke.width, context) || default_font_style.stroke_width;
             style.stroke_width *= Utils.device_pixel_ratio;
         }
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -447,9 +447,9 @@ Object.assign(TextStyle, {
         }
 
         // Setup caching for colors
-        draw.font.fill = draw.font.fill && { value: draw.font.fill };
+        draw.font.fill = this.cacheObject(draw.font.fill);
         if (draw.font.stroke) {
-            draw.font.stroke.color = draw.font.stroke.color && { value: draw.font.stroke.color };
+            draw.font.stroke.color = this.cacheObject(draw.font.stroke.color);
         }
 
         // Convert font units and setup caching for zoom interpolation if needed

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -446,6 +446,12 @@ Object.assign(TextStyle, {
             return;
         }
 
+        // Setup caching for colors
+        draw.font.fill = draw.font.fill && { value: draw.font.fill };
+        if (draw.font.stroke) {
+            draw.font.stroke.color = draw.font.stroke.color && { value: draw.font.stroke.color };
+        }
+
         // Convert font units and setup caching for zoom interpolation if needed
         if (Array.isArray(draw.font.size)) {
             // convert all stops

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -447,32 +447,15 @@ Object.assign(TextStyle, {
         }
 
         // Setup caching for colors
-        draw.font.fill = this.cacheObject(draw.font.fill);
+        draw.font.fill = StyleParser.cacheObject(draw.font.fill);
         if (draw.font.stroke) {
-            draw.font.stroke.color = this.cacheObject(draw.font.stroke.color);
+            draw.font.stroke.color = StyleParser.cacheObject(draw.font.stroke.color);
         }
 
-        // Convert font units and setup caching for zoom interpolation if needed
-        if (Array.isArray(draw.font.size)) {
-            // convert all stops
-            draw.font.px_size = draw.font.size.map(v => [v[0], CanvasText.fontPixelSize(v[1])]);
-
-            // presence of this property indicates size should be evaluated + cached at each zoom
-            draw.font.px_size_by_zoom = {};
-        }
-        else {
-            draw.font.px_size = CanvasText.fontPixelSize(draw.font.size);
-        }
-
-        // Same prep as above, for text stroke
+        // Convert font and text stroke and setup caching
+        draw.font.px_size = StyleParser.cacheObject(draw.font.size, CanvasText.fontPixelSize);
         if (draw.font.stroke && draw.font.stroke.width != null) {
-            if (Array.isArray(draw.font.stroke.width)) {
-                draw.font.stroke.width = draw.font.stroke.width.map(v => [v[0], parseFloat(v[1])]);
-                draw.font.stroke.width_by_zoom = {};
-            }
-            else {
-                draw.font.stroke.width = parseFloat(draw.font.stroke.width);
-            }
+            draw.font.stroke.width = StyleParser.cacheObject(draw.font.stroke.width, parseFloat);
         }
     },
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -332,7 +332,7 @@ Object.assign(TextStyle, {
 
         // Called here because otherwise it will be delayed until the feature queue is parsed,
         // and we want the preprocessing done before we evaluate text style below
-        this.preprocessFeatureStyle(rule);
+        this.preprocess(rule);
 
         // Collect text - default source is feature.properties.name
         let text;
@@ -441,7 +441,7 @@ Object.assign(TextStyle, {
         }
     },
 
-    preprocess (draw) {
+    _preprocess (draw) {
         if (!draw.font) {
             return;
         }

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -457,6 +457,17 @@ Object.assign(TextStyle, {
         else {
             draw.font.px_size = CanvasText.fontPixelSize(draw.font.size);
         }
+
+        // Same prep as above, for text stroke
+        if (draw.font.stroke && draw.font.stroke.width != null) {
+            if (Array.isArray(draw.font.stroke.width)) {
+                draw.font.stroke.width = draw.font.stroke.width.map(v => [v[0], parseFloat(v[1])]);
+                draw.font.stroke.width_by_zoom = {};
+            }
+            else {
+                draw.font.stroke.width = parseFloat(draw.font.stroke.width);
+            }
+        }
     },
 
     build (style, vertex_data) {

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -42,6 +42,7 @@ Object.assign(TextStyle, {
             style: 'normal',
             weight: null,
             size: '12px',
+            px_size: 12,
             family: 'Helvetica',
             fill: 'white',
             text_wrap: 15,
@@ -329,6 +330,10 @@ Object.assign(TextStyle, {
             return;
         }
 
+        // Called here because otherwise it will be delayed until the feature queue is parsed,
+        // and we want the preprocessing done before we evaluate text style below
+        this.preprocessFeatureStyle(rule);
+
         // Collect text - default source is feature.properties.name
         let text;
         let source = rule.text_source || 'name';
@@ -433,6 +438,24 @@ Object.assign(TextStyle, {
                 this.startData(tile.key);
             }
             this.tile_data[tile.key].queue.push([feature, rule, context]);
+        }
+    },
+
+    preprocess (draw) {
+        if (!draw.font) {
+            return;
+        }
+
+        // Convert font units and setup caching for zoom interpolation if needed
+        if (Array.isArray(draw.font.size)) {
+            // convert all stops
+            draw.font.px_size = draw.font.size.map(v => [v[0], CanvasText.fontPixelSize(v[1])]);
+
+            // presence of this property indicates size should be evaluated + cached at each zoom
+            draw.font.px_size_by_zoom = {};
+        }
+        else {
+            draw.font.px_size = CanvasText.fontPixelSize(draw.font.size);
         }
     },
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -431,17 +431,6 @@ Utils.toCSSColor = function (color) {
     return `rgba(${color.map((c, i) => (i < 3 && Math.round(c * 255)) || c).join(', ')})`;
 };
 
-Utils.toFontPixelSize = function (size, kind) {
-    if (kind === "em") {
-        size *= 16;
-    } else if (kind === "pt") {
-        size /= 0.75;
-    } else if (kind === "%") {
-        size /= 6.25;
-    }
-    return parseFloat(size);
-};
-
 Utils.pointInTile = function (point) {
     return point[0] >= 0 && point[1] > -Geo.tile_scale && point[0] < Geo.tile_scale && point[1] <= 0;
 };


### PR DESCRIPTION
Adds zoom-based interpolation ("stops") for the following font properties:

- Font size (specified in px, pt, or em)
- Fill color (partially worked previously, fixes bugs with using string colors)
- Stroke width (specified in px)
- Stroke color

```
draw:
  text:
    font:
      family: Helvetica
      fill: [[14, white], [18, gray]]
      size: [[14, 12px], [16, 16px], [20, 24px]]
      stroke:
        color: [[16, white], [18, red], [20, blue]] 
        width: [[14, 3px], [20, 8px]]
 ```