### PR TITLE
Label repetition

### DIFF
--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -8,6 +8,7 @@ export const whiteList = ['filter', 'draw', 'visible', 'data', 'properties'];
 export let ruleCache = {};
 
 function cacheKey (rules) {
+    rules = rules.sort((a, b) => a - b);
     var k = rules[0].id;
     for (var i=1; i < rules.length; i++) {
         k += '/' + rules[i].id;

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -144,7 +144,7 @@ StyleParser.getFeatureParseContext = function (feature, tile) {
 
 // Build a style param cache object
 // `value` is raw value, cache methods will add other properties as needed
-// `transform` is optional transform function to run on values
+// `transform` is optional transform function to run on values (except function values)
 StyleParser.cacheObject = function (obj, transform = null) {
     if (obj == null) {
         return;
@@ -155,11 +155,11 @@ StyleParser.cacheObject = function (obj, transform = null) {
     }
 
     if (typeof transform === 'function') {
-        if (Array.isArray(obj) && Array.isArray(obj[0])) {
+        if (Array.isArray(obj) && Array.isArray(obj[0])) { // zoom stops
             obj = obj.map(v => [v[0], transform(v[1])]);
         }
-        else {
-            obj = transform(obj);
+        else if (typeof obj !== 'function') { // don't transform functions
+            obj = transform(obj); // single value
         }
     }
 

--- a/src/styles/text/label.js
+++ b/src/styles/text/label.js
@@ -4,6 +4,8 @@ import boxIntersect from 'box-intersect'; // https://github.com/mikolalysenko/bo
 import Utils from '../../utils/utils';
 import OBB from '../../utils/obb';
 
+import log from 'loglevel';
+
 export default class Label {
 
     constructor (text, size, options) {
@@ -23,20 +25,22 @@ export default class Label {
         // Broadphase
         if (aabbs.length > 0) {
             boxIntersect([this.aabb], aabbs, (i, j) => {
+                log.trace(`${this.text} broad phase collide`, this, this.aabb, aabbs[j]);
+
                 // Narrow phase
                 if (OBB.intersect(this.aabb.obb, aabbs[j].obb)) {
+                    log.trace(`${this.text} narrow phase collide`, this, this.aabb.obb, aabbs[j].obb);
                     intersect = true;
                     return true;
                 }
             });
         }
-
-        // No collision on aabb
-        if (!intersect) {
-            // it's clean, add it to the list of bboxes
-            aabbs.push(this.aabb);
-        }
         return intersect;
+    }
+
+    // Add this label's bounding box to the provided set
+    add (aabbs) {
+        aabbs.push(this.aabb);
     }
 
     // checks whether the label is within the tile boundaries

--- a/src/styles/text/layout_settings.js
+++ b/src/styles/text/layout_settings.js
@@ -1,3 +1,5 @@
+import Geo from '../../geo';
+
 var LayoutSettings;
 
 export default LayoutSettings = {
@@ -47,22 +49,22 @@ export default LayoutSettings = {
         }
 
         // repeat rules
-        if (typeof draw.repeat_key === 'function') {
-            layout.repeat_key = draw.repeat_key(context);
+        if (typeof draw.repeat_group === 'function') {
+            layout.repeat_key = draw.repeat_group(context);
         }
-        else if (typeof draw.repeat_key === 'string') {
-            layout.repeat_key = draw.repeat_key;
+        else if (typeof draw.repeat_group === 'string') {
+            layout.repeat_key = draw.repeat_group;
         }
         else {
-            layout.repeat_key = draw.key + '/' + text;
+            layout.repeat_key = draw.key; // default to unique set of matching layers
         }
-        layout.repeat_key = tile.key + '/' + layout.repeat_key;
+        layout.repeat_key += '/' + text;
 
-        if (typeof draw.repeat_dist === 'number') {
-            layout.repeat_dist = draw.repeat_dist * layout.units_per_pixel;
+        if (typeof draw.repeat === 'number') {
+            layout.repeat_dist = draw.repeat * layout.units_per_pixel;
         }
-        else if (draw.repeat_dist !== false) {
-            layout.repeat_dist = 200 * layout.units_per_pixel; // default
+        else if (draw.repeat !== false) {
+            layout.repeat_dist = Geo.tile_size * layout.units_per_pixel; // default
         }
 
         // collision flag

--- a/src/styles/text/layout_settings.js
+++ b/src/styles/text/layout_settings.js
@@ -56,6 +56,7 @@ export default LayoutSettings = {
         else {
             layout.repeat_key = draw.key + '/' + text;
         }
+        layout.repeat_key = tile.key + '/' + layout.repeat_key;
 
         if (typeof draw.repeat_dist === 'number') {
             layout.repeat_dist = draw.repeat_dist * layout.units_per_pixel;

--- a/src/styles/text/layout_settings.js
+++ b/src/styles/text/layout_settings.js
@@ -1,4 +1,5 @@
 import Geo from '../../geo';
+import {StyleParser} from '../style_parser';
 
 var LayoutSettings;
 
@@ -48,24 +49,24 @@ export default LayoutSettings = {
             layout.line_exceed = 80;
         }
 
-        // repeat rules
+        // repeat minimum distance
+        layout.repeat_distance = StyleParser.cacheProperty(draw.repeat_distance, context);
+        if (layout.repeat_distance == null) {
+            layout.repeat_distance = Geo.tile_size;
+        }
+        layout.repeat_distance *= layout.units_per_pixel;
+
+        // repeat group key
         if (typeof draw.repeat_group === 'function') {
-            layout.repeat_key = draw.repeat_group(context);
+            layout.repeat_group = draw.repeat_group(context);
         }
         else if (typeof draw.repeat_group === 'string') {
-            layout.repeat_key = draw.repeat_group;
+            layout.repeat_group = draw.repeat_group;
         }
         else {
-            layout.repeat_key = draw.key; // default to unique set of matching layers
+            layout.repeat_group = draw.key; // default to unique set of matching layers
         }
-        layout.repeat_key += '/' + text;
-
-        if (typeof draw.repeat === 'number') {
-            layout.repeat_dist = draw.repeat * layout.units_per_pixel;
-        }
-        else if (draw.repeat !== false) {
-            layout.repeat_dist = Geo.tile_size * layout.units_per_pixel; // default
-        }
+        layout.repeat_group += '/' + text;
 
         // collision flag
         layout.collide = (draw.collide === false) ? false : true;

--- a/src/styles/text/layout_settings.js
+++ b/src/styles/text/layout_settings.js
@@ -46,6 +46,10 @@ export default LayoutSettings = {
             layout.line_exceed = 80;
         }
 
+        // collision flag
+        layout.collide = (draw.collide === false) ? false : true;
+
+        // tile boundary handling
         layout.cull_from_tile = (draw.cull_from_tile != null) ? draw.cull_from_tile : true;
         layout.move_into_tile = (draw.move_into_tile != null) ? draw.move_into_tile : true;
 

--- a/src/styles/text/layout_settings.js
+++ b/src/styles/text/layout_settings.js
@@ -2,7 +2,7 @@ var LayoutSettings;
 
 export default LayoutSettings = {
 
-   compute (feature, draw, context, tile) {
+   compute (feature, draw, text, context, tile) {
         let layout = {};
         layout.units_per_pixel = tile.units_per_pixel || 1;
 
@@ -44,6 +44,24 @@ export default LayoutSettings = {
         }
         else {
             layout.line_exceed = 80;
+        }
+
+        // repeat rules
+        if (typeof draw.repeat_key === 'function') {
+            layout.repeat_key = draw.repeat_key(context);
+        }
+        else if (typeof draw.repeat_key === 'string') {
+            layout.repeat_key = draw.repeat_key;
+        }
+        else {
+            layout.repeat_key = draw.key + '/' + text;
+        }
+
+        if (typeof draw.repeat_dist === 'number') {
+            layout.repeat_dist = draw.repeat_dist * layout.units_per_pixel;
+        }
+        else if (draw.repeat_dist !== false) {
+            layout.repeat_dist = 200 * layout.units_per_pixel; // default
         }
 
         // collision flag

--- a/src/styles/text/repeat_group.js
+++ b/src/styles/text/repeat_group.js
@@ -1,45 +1,91 @@
+import Geo from '../../geo';
 
 export default class RepeatGroup {
 
-    constructor (key, repeat_dist) {
+    constructor (key, repeat_dist, max_repeat_dist) {
         this.key = key;
         this.repeat_dist = repeat_dist;
         this.repeat_dist_sq = this.repeat_dist * this.repeat_dist;
-        this.objs = [];
-        // TODO: if repeat dist past full tile threshold, mark as one-per-tile
-        // and skip future distance checks
+        this.max_repeat_dist_sq = max_repeat_dist * max_repeat_dist;
+        this.one_per_group = (this.repeat_dist_sq >= this.max_repeat_dist_sq) ? true : false;
+        this.positions = [];
     }
 
+    // Check an object to see if it's a repeat in this group
     check (obj) {
-        for (let i=0; i < this.objs.length; i++) {
-            let obj2 = this.objs[i];
-            let dx = obj.position[0] - obj2.position[0];
-            let dy = obj.position[1] - obj2.position[1];
+        // If only one object allowed per group, shortcut distance logic
+        if (this.one_per_group) {
+            if (this.positions.length > 0) {
+                // reported distance maxes out at threshold in this case
+                // (not true dist value since we skipped calculating it)
+                return {
+                    dist_sq: this.max_repeat_dist_sq,
+                    repeat_dist_sq: this.repeat_dist_sq,
+                    one_per_group: this.one_per_group
+                };
+            }
+            return; // no object for this group yet
+        }
+
+        // Check distance from new object to objects already in group
+        let p1 = obj.position;
+        for (let i=0; i < this.positions.length; i++) {
+            let p2 = this.positions[i];
+            let dx = p1[0] - p2[0];
+            let dy = p1[1] - p2[1];
             let dist_sq = dx * dx + dy * dy;
 
+            // Found an existing object within allowed distance
             if (dist_sq < this.repeat_dist_sq) {
-                return { dist_sq, repeat_dist_sq: this.repeat_dist_sq };
+                return {
+                    dist_sq,
+                    repeat_dist_sq: this.repeat_dist_sq
+                };
             }
         }
     }
 
+    // Add object to this group
     add (obj) {
-        this.objs.push(obj);
-    }
-
-    static check (obj, layout) {
-        if (layout.repeat_dist && this.groups[layout.repeat_key]) {
-            return this.groups[layout.repeat_key].check(obj);
+        // only store object's position, to save space / prevent unnecessary references
+        if (obj && obj.position) {
+            this.positions.push(obj.position);
         }
     }
 
-    static add (obj, layout) {
-        if (layout.repeat_dist && this.groups[layout.repeat_key] == null) {
-            this.groups[layout.repeat_key] = new RepeatGroup(layout.repeat_key, layout.repeat_dist);
+    // Static methods are used to manage repeat groups, within and across tiles
+
+    // Reset all groups for this tile
+    static clear (tile) {
+        this.groups[tile] = {};
+    }
+
+    // Check an object to see if it's a repeat within its designated group
+    static check (obj, layout, tile) {
+        if (layout.repeat_dist && this.groups[tile][layout.repeat_key]) {
+            return this.groups[tile][layout.repeat_key].check(obj);
         }
-        this.groups[layout.repeat_key].add(obj);
+    }
+
+    // Add an object to its designated group
+    static add (obj, layout, tile) {
+        if (layout.repeat_dist) {
+            if (this.groups[tile][layout.repeat_key] == null) {
+                this.groups[tile][layout.repeat_key] = new RepeatGroup(
+                    layout.repeat_key,
+                    layout.repeat_dist,
+                    RepeatGroup.max_repeat_dist * layout.units_per_pixel
+                );
+            }
+            this.groups[tile][layout.repeat_key].add(obj);
+        }
     }
 
 }
 
+// Current set of repeat groups, grouped and keyed by tile
 RepeatGroup.groups = {};
+
+// Max repeat dist: for groups with a repeat dist beyond this threshold, only one label
+// will be allowed per group, e.g. set to tile size for one-label-per-tile
+RepeatGroup.max_repeat_dist = Geo.tile_size;

--- a/src/styles/text/repeat_group.js
+++ b/src/styles/text/repeat_group.js
@@ -62,14 +62,14 @@ export default class RepeatGroup {
 
     // Check an object to see if it's a repeat within its designated group
     static check (obj, layout, tile) {
-        if (layout.repeat_distance != null && this.groups[tile][layout.repeat_group]) {
+        if (layout.repeat_distance && this.groups[tile][layout.repeat_group]) {
             return this.groups[tile][layout.repeat_group].check(obj);
         }
     }
 
     // Add an object to its designated group
     static add (obj, layout, tile) {
-        if (layout.repeat_distance != null) {
+        if (layout.repeat_distance) {
             if (this.groups[tile][layout.repeat_group] == null) {
                 this.groups[tile][layout.repeat_group] = new RepeatGroup(
                     layout.repeat_group,

--- a/src/styles/text/repeat_group.js
+++ b/src/styles/text/repeat_group.js
@@ -62,22 +62,22 @@ export default class RepeatGroup {
 
     // Check an object to see if it's a repeat within its designated group
     static check (obj, layout, tile) {
-        if (layout.repeat_dist && this.groups[tile][layout.repeat_key]) {
-            return this.groups[tile][layout.repeat_key].check(obj);
+        if (layout.repeat_distance != null && this.groups[tile][layout.repeat_group]) {
+            return this.groups[tile][layout.repeat_group].check(obj);
         }
     }
 
     // Add an object to its designated group
     static add (obj, layout, tile) {
-        if (layout.repeat_dist) {
-            if (this.groups[tile][layout.repeat_key] == null) {
-                this.groups[tile][layout.repeat_key] = new RepeatGroup(
-                    layout.repeat_key,
-                    layout.repeat_dist,
+        if (layout.repeat_distance != null) {
+            if (this.groups[tile][layout.repeat_group] == null) {
+                this.groups[tile][layout.repeat_group] = new RepeatGroup(
+                    layout.repeat_group,
+                    layout.repeat_distance,
                     RepeatGroup.max_repeat_dist * layout.units_per_pixel
                 );
             }
-            this.groups[tile][layout.repeat_key].add(obj);
+            this.groups[tile][layout.repeat_group].add(obj);
         }
     }
 

--- a/src/styles/text/repeat_group.js
+++ b/src/styles/text/repeat_group.js
@@ -1,0 +1,33 @@
+
+export default class RepeatGroup {
+
+    constructor (key, repeat_dist) {
+        this.key = key;
+        this.repeat_dist = repeat_dist;
+        this.repeat_dist_sq = this.repeat_dist * this.repeat_dist;
+        this.objs = [];
+        // TODO: if repeat dist past full tile threshold, mark as one-per-tile
+        // and skip future distance checks
+    }
+
+    check (obj) {
+        for (let i=0; i < this.objs.length; i++) {
+            let obj2 = this.objs[i];
+            let dx = obj.position[0] - obj2.position[0];
+            let dy = obj.position[1] - obj2.position[1];
+            let dist_sq = dx * dx + dy * dy;
+
+            if (dist_sq < this.repeat_dist_sq) {
+                // return false;
+                return { repeat: true, dist_sq };
+            }
+        }
+        // return true;
+        return { repeat: false };
+    }
+
+    add (obj) {
+        this.objs.push(obj);
+    }
+
+}

--- a/src/styles/text/repeat_group.js
+++ b/src/styles/text/repeat_group.js
@@ -18,16 +18,28 @@ export default class RepeatGroup {
             let dist_sq = dx * dx + dy * dy;
 
             if (dist_sq < this.repeat_dist_sq) {
-                // return false;
-                return { repeat: true, dist_sq };
+                return { dist_sq, repeat_dist_sq: this.repeat_dist_sq };
             }
         }
-        // return true;
-        return { repeat: false };
     }
 
     add (obj) {
         this.objs.push(obj);
     }
 
+    static check (obj, layout) {
+        if (layout.repeat_dist && this.groups[layout.repeat_key]) {
+            return this.groups[layout.repeat_key].check(obj);
+        }
+    }
+
+    static add (obj, layout) {
+        if (layout.repeat_dist && this.groups[layout.repeat_key] == null) {
+            this.groups[layout.repeat_key] = new RepeatGroup(layout.repeat_key, layout.repeat_dist);
+        }
+        this.groups[layout.repeat_key].add(obj);
+    }
+
 }
+
+RepeatGroup.groups = {};

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -310,6 +310,9 @@ Object.assign(TextStyle, {
             draw.font.stroke.width = StyleParser.cacheObject(draw.font.stroke.width, parseFloat);
         }
 
+        // Repeat rules
+        draw.repeat_distance = StyleParser.cacheObject(draw.repeat_distance, parseFloat);
+
         return draw;
     },
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -212,7 +212,7 @@ Object.assign(TextStyle, {
                 let { label, text_settings_key } = labels[priority][i];
 
                 // test the label for intersections with other labels in the tile
-                if (!label.discard(this.aabbs[tile])) {
+                if (!layout.collide || !label.discard(this.aabbs[tile])) {
                     keep_labels.push(labels[priority][i]);
 
                     // increment a count of how many times this style is used in the tile

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -218,15 +218,10 @@ Object.assign(TextStyle, {
                 let settings = texts[text_settings_key][label.text];
 
                 // check for repeats
-                if (layout.repeat_dist != null) {
-                    repeat_group = repeat_groups[layout.repeat_key];
-                    if (repeat_group) {
-                        let check = repeat_group.check(label);
-                        if (check.repeat) {
-                            console.log(`discard label '${label.text}', dist ${Math.sqrt(check.dist_sq)/layout.units_per_pixel} < ${Math.sqrt(repeat_group.repeat_dist_sq)/layout.units_per_pixel}`);
-                            continue;
-                        }
-                    }
+                let check = RepeatGroup.check(label, layout);
+                if (check) {
+                    console.log(`discard label '${label.text}', dist ${Math.sqrt(check.dist_sq)/layout.units_per_pixel} < ${Math.sqrt(check.repeat_dist_sq)/layout.units_per_pixel}`);
+                    continue;
                 }
 
                 // test the label for intersections with other labels in the tile
@@ -237,14 +232,7 @@ Object.assign(TextStyle, {
                     settings.ref++;
 
                     // register as placed for future repeat culling
-                    if (layout.repeat_dist != null) {
-                        if (repeat_group == null) {
-                            repeat_group =
-                                repeat_groups[layout.repeat_key] =
-                                new RepeatGroup(layout.repeat_key, layout.repeat_dist);
-                        }
-                        repeat_group.add(label);
-                    }
+                    RepeatGroup.add(label, layout);
                 }
             }
         }


### PR DESCRIPTION
This introduces draw parameters for controlling how often labels are allowed to repeat. Two style parameters are added to control this behavior, `repeat_distance` and `repeat_group`.

![output_lktevy](https://cloud.githubusercontent.com/assets/16733/11543440/ac7d6e28-990a-11e5-9418-28d10a3865d6.gif)

![output_j36n16](https://cloud.githubusercontent.com/assets/16733/11543444/afa2dd90-990a-11e5-8762-fbd9e29cd477.gif)

- The `repeat_distance` parameter (for `text`-based `draw` groups) that specifies **minimum distance in pixels** between labels.
  - Currently, this is simply calculated as a center-to-center distance between two label bounding boxes, though it could be expanded to account for label size. For performance, possibly a simpler approximation and not a true distance between bounding boxes; the behavior here needs to adhere reasonably close to the desired style, but does not need to be pixel-perfect.
  - Note that because the Tangram JS architecture processes each tile in isolation (and manages labels and their accompanying texture atlases per tile), we currently can only enforce minimum label distance **within a tile**. This means that you may still see labels near each other when they are drawn close to the edges of adjacent tiles. This can be addressed in a future overhaul of the collision system for now, the overall behavior is still much improved.
  - The *default value* for `repeat_distance` is the logical pixel size of a tile (256 pixels), meaning that by default, a given label will only be placed once per tile.
  - Note that if `repeat_distance: 0px`, no restrictions are made on placement, and labels are allowed to repeat freely.
  - Examples:
```
draw:
   text:
      repeat_distance: 100px # label can repeat every 100 pixels
      ...
```
```
draw:
   text:
      repeat_distance: 0px # labels can repeat anywhere
      ...
```
- By default, labels are **grouped by layer** before repetition logic is applied. This means that a unique text string is only checked for repetition against other labels that matched the same draw rules; another label with the same text may be placed within the `repeat_distance` if it is the result of a different set of draw rules. This allows two features with the same name but different classifications (such as a highway and nearby minor road) to both be labelled.
  - However, the grouping can also be controlled by setting the `repeat_group` property. This property defaults to an internal representation of all the feature's matching rules, but if set to another (arbitrary) string value, allows for more sophisticated control over which features are allowed to repeat.
  - Examples:
```
roads:
   major_roads:
      filter: { kind: major_road }
      draw:
         text:            
            ...
   minor_roads:
      filter: { kind: minor_road }
      draw:
         text:
            # labels from the major_roads layer can repeat near these, because they
            # are in different repeat groups by default            
            ... 
```
```
roads:
   draw:
      text:
         # labels in the sub-layers below won't repeat near each other, 
         # because they have been placed in the same repeat group
         repeat_group: roads-fewer-labels
   major_roads:
      filter: { kind: major_road }
      draw:
         text:            
            ...
   minor_roads:
      filter: { kind: minor_road }
      draw:
         text:            
            ...
```

These different behaviors can be observed here:

Repeat checking turned off with `repeat_distance: 0px` (e.g. same as current behavior):
![tangram-mon nov 30 2015 15-20-43 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/11543003/50dd5120-9908-11e5-89cb-8fa31010ee62.png)

With default repeat distance and grouping. Note that many road-related labels appear to repeat near each other because of classification differences (links, etc.):
![tangram-mon nov 30 2015 15-20-56 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/11543009/56a5f1ca-9908-11e5-841d-0f91ccac910e.png)

With all roads in the same repeat group (`repeat_group: roads-fewer-labels`), additional repetition is reduced:
![tangram-mon nov 30 2015 15-21-04 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/11543017/5ceb4576-9908-11e5-91eb-3035cbbae33a.png)
