### PR TITLE
Add `blend_order` to control render order of styles with non-opaque blending

### DIFF
--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -228,6 +228,7 @@ StyleManager.mix = function (style, styles) {
         // hasOwnProperty check gives preference to base style prototype
         style.blend = sources.map(x => x.hasOwnProperty('blend') && x.blend).filter(x => x).pop();
     }
+    style.blend_order = sources.map(x => x.blend_order).filter(x => x != null).pop();
 
     // Merges - property-specific rules for merging values
     style.defines = Object.assign({}, ...sources.map(x => x.defines).filter(x => x)); // internal defines (not user-defined)


### PR DESCRIPTION
`blend_order` is an optional parameter used when defining a render style, which controls the order in which styles *with non-opaque blending (`add`, `multiply`, `inlay`, `overlay`)* are rendered. `blend_order` is an integer greater than or equal to zero.

Previously, styles were bucketed by blending type, and rendered in the following order: `opaque`, `add`, `multiply`, `inlay`, `overlay`.

With this PR, the order is now:

- All `opaque` styles render first
- All non-`opaque` styles **without** a defined `blend_order` render next, sorted by `add`, `multiply`, `inlay`, `overlay`
- All non-opaque styles **with** a defined `blend_order` render last, sorted by `blend_order` (ascending), sub-sorted by `add`, `multiply`, `inlay`, `overlay`

Each group above also now has a final sub-sort by style `name`, to provide a consistent render order (to aid in debugging and/or reduce unforeseen visual differences caused by render order, though these should not occur if the intended behavior is correct).

The practical effect is that styles can be placed on top of others by assigning a `blend_order`. The following adds a `marker` style, which is rendered on top of the `icons` style, which is (implicitly) on top of the default `text` style (all use `overlay`):

```
styles:
   marker:
      base: points
      blend: overlay
      blend_order: 1   # marker goes on top of icons and text
      ...

   icons:
      base: points
      blend: overlay
      blend_order: 0   # icons go on top of text, underneath marker
      ...
```


