### PR TITLE
Resolve ambiguous draw rules by lexical sort

### DIFF
--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -15,17 +15,18 @@ function cacheKey (rules) {
     return k;
 }
 
-export function mergeTrees(matchingTrees, key, context) {
-    var draw = {},
-        draws,
-        treeDepth = 0,
-        x, t;
+// Merge matching layer rule trees into a final draw group
+export function mergeTrees(matchingTrees, group) {
+    let draws, treeDepth = 0;
 
-    // Visible by default
-    draw.visible = true;
+    let draw = {
+        visible: true // visible by default
+    };
+
+    let layers = new Set(); // layers that contributed to the draw group
 
     // Find deepest tree
-    for (t = 0; t < matchingTrees.length; t++) {
+    for (let t=0; t < matchingTrees.length; t++) {
         if (matchingTrees[t].length > treeDepth) {
             treeDepth = matchingTrees[t].length;
         }
@@ -37,15 +38,45 @@ export function mergeTrees(matchingTrees, key, context) {
     }
 
     // Iterate trees in parallel
-    for (x = 0; x < treeDepth; x++) {
-        draws = matchingTrees.map(tree => tree[x] && tree[x][key]);
+    for (let x=0; x < treeDepth; x++) {
+        // Pull out the requested draw group, for each tree, at this depth
+        draws = matchingTrees.map(tree => tree[x] && tree[x][group]);
         if (draws.length === 0) {
             continue;
         }
 
-        // Merge remaining draw objects
+        // Check if any draw group is present
+        // Find deepest-level layer name for this tree
+        // Find ambiguous properties at this level
+        let present = false;
+        for (let i=0; i < draws.length; i++) {
+            if (draws[i]) {
+                present = true;
+
+                if (draws[i].full_name) {
+                    layers.add(draws[i].full_name);
+                }
+            }
+        }
+        if (!present) {
+            continue;
+        }
+
+        // Sort by layer name before merging, so rules are applied deterministically
+        // when multiple rules modify the same properties
+        draws.sort((a, b) => (a && a.full_name) > (b && b.full_name) ? 1 : -1);
+
+        // Merge draw objects
         mergeObjects(draw, ...draws);
+
+        // Remove layer names, they were only used transiently to sort and calculate final layer
+        // (final merged names will not be accurate since only one tree can win)
+        delete draw.name;
+        delete draw.full_name;
     }
+
+    // Layer names as array
+    draw.layers = [...layers];
 
     // Short-circuit if not visible
     if (draw.visible === false) {
@@ -62,15 +93,18 @@ class Rule {
         this.id = Rule.id++;
         this.parent = parent;
         this.name = name;
-        this.full_name = this.parent ? this.parent.full_name + '.' + this.name : this.name;
+        this.full_name = this.parent ? (this.parent.full_name + ':' + this.name) : this.name;
         this.draw = draw;
         this.filter = filter;
         this.visible = visible !== undefined ? visible : (this.parent && this.parent.visible);
         this.properties = properties !== undefined ? properties : (this.parent && this.parent.properties);
 
-        // Denormalize properties to draw groups
+        // Denormalize layer name & properties to draw groups
         if (this.draw) {
             for (let group in this.draw) {
+                this.draw[group].name = this.name;
+                this.draw[group].full_name = this.full_name;
+
                 if (this.properties !== undefined) {
                     this.draw[group].properties = this.properties;
                 }
@@ -155,7 +189,7 @@ export class RuleTree extends Rule {
                     // Calculate each draw group
                     for (let draw_key in draw_keys) {
                         ruleCache[cache_key] = ruleCache[cache_key] || {};
-                        ruleCache[cache_key][draw_key] = mergeTrees(draw_rules, draw_key, context);
+                        ruleCache[cache_key][draw_key] = mergeTrees(draw_rules, draw_key);
 
                         // Only save the ones that weren't null
                         if (!ruleCache[cache_key][draw_key]) {

--- a/test/rule_spec.js
+++ b/test/rule_spec.js
@@ -43,7 +43,8 @@ describe('.mergeTrees()', () => {
                 a: 1,
                 b: 2,
                 c: 10,
-                d: 'x'
+                d: 'x',
+                layers: []
             };
             assert.deepEqual(result, compare);
         });
@@ -87,7 +88,26 @@ describe('.mergeTrees()', () => {
                 order: 3,
                 a: 'y',
                 b: 'z',
-                color: [7, 8, 9]
+                color: [7, 8, 9],
+                layers: []
+            });
+        });
+
+    });
+
+    describe('when given layers with ambiguous properties', () => {
+
+        const subject = [
+            [ { group: { a: 1, full_name: 'x' } } ],
+            [ { group: { a: 2, full_name: 'z' } } ],
+            [ { group: { a: 3, full_name: 'y' } } ]
+        ];
+
+        it('the lexically sorted highest rule wins', () => {
+            assert.deepEqual(mergeTrees(subject, 'group', {}), {
+                a: 2,
+                layers: ['x', 'z', 'y'],
+                visible: true
             });
         });
 

--- a/test/rule_spec.js
+++ b/test/rule_spec.js
@@ -98,9 +98,9 @@ describe('.mergeTrees()', () => {
     describe('when given layers with ambiguous properties', () => {
 
         const subject = [
-            [ { group: { a: 1, full_name: 'x' } } ],
-            [ { group: { a: 2, full_name: 'z' } } ],
-            [ { group: { a: 3, full_name: 'y' } } ]
+            [ { group: { a: 1, layer_name: 'x' } } ],
+            [ { group: { a: 2, layer_name: 'z' } } ],
+            [ { group: { a: 3, layer_name: 'y' } } ]
         ];
 
         it('the lexically sorted highest rule wins', () => {

--- a/test/rule_spec.js
+++ b/test/rule_spec.js
@@ -26,10 +26,10 @@ describe('RuleGroup', () => {
 
 describe('.mergeTrees()', () => {
     let subject = [
-        [ { group: { a: 0.001 } }, { group: { b: 2 } }, { group: { c: 3 } }, { group: { d: 4 } } ],
-        [ { group: { a: 3.14 } }, { group: { d: 3 } }, { group: { a: 1 } }, { group: { b: 2 } } ],
-        [ { group: { b: 'y' } }, { group: { a: 'x' } }, { group:{ b: 0.0003 } }, { group: { c: 10 } } ],
-        [ { group: { b: 3.14 } }, { group: { a: 2.71828 } }, { group:{ b: 0.0001 } }, { group: { d: 'x' } } ]
+        [ { group: { a: 0.001 } }, { group: { a: 1, b: 2 } }, { group: { b: 4, c: 3 } }, { group: { d: 4 } } ],
+        [ { group: { x: 3.14 } }, { group: { y: 3 } }, { group: { x: 10, z: 1 } }, { group: { w: 2 } } ],
+        [ { group: { e: 'y' } }, { group: { f: 'x' } }, { group:{ g: 0.0003 } }, { group: { h: 10 } } ],
+        [ { group: { s: 3.14 } }, { group: { t: 2.71828 } }, { group:{ u: 0.0001 } }, { group: { v: 'x' } } ]
     ];
 
     const {mergeTrees} = require('../src/styles/rule');
@@ -40,11 +40,10 @@ describe('.mergeTrees()', () => {
             let result = mergeTrees(subject, 'group', {});
             let compare = {
                 visible: true,
-                a: 1,
-                b: 2,
-                c: 10,
-                d: 'x',
-                layers: []
+                a: 1, b: 4, c: 3, d: 4,
+                x: 10, y: 3, z: 1, w: 2,
+                e: 'y', f: 'x', g: 0.0003, h: 10,
+                s: 3.14, t: 2.71828, u: 0.0001, v: 'x'
             };
             assert.deepEqual(result, compare);
         });
@@ -82,15 +81,16 @@ describe('.mergeTrees()', () => {
         ];
 
         it('returns the correct object', () => {
-            assert.deepEqual(mergeTrees(subject, 'group', {}), {
+            let result = mergeTrees(subject, 'group');
+            let compare = {
                 visible: true,
                 width: 10,
                 order: 3,
                 a: 'y',
                 b: 'z',
-                color: [7, 8, 9],
-                layers: []
-            });
+                color: [7, 8, 9]
+            };
+            assert.deepEqual(result, compare);
         });
 
     });
@@ -104,11 +104,12 @@ describe('.mergeTrees()', () => {
         ];
 
         it('the lexically sorted highest rule wins', () => {
-            assert.deepEqual(mergeTrees(subject, 'group', {}), {
+            let result = mergeTrees(subject, 'group');
+            let compare = {
                 a: 2,
-                layers: ['x', 'z', 'y'],
                 visible: true
-            });
+            };
+            assert.deepEqual(result, compare);
         });
 
     });


### PR DESCRIPTION
Sometimes a feature matches multiple layers, at the same depth, that set the same property (or properties). This isn't desirable because it's ambiguous, and should be avoided when authoring layer rules (it *is* often useful to write multiple layers that match the same feature, they should just be used to control different properties, for example one set of rules to control color and another parallel set to control order). However, it's also a little too easy to do accidentally :)

Previously, the resolution of which layer would "win" was undefined, leading to divergent behavior between Tangram JS and ES. This PR resolves the conflict by **lexically sorting the layers by name**. As with deeper layers overwriting the properties of shallower layers, the **last layer sorted by name** will overwrite any earlier layers. This means that if layers named `layerA` and `layerB` both try to set a property, the value defined in `layerB` will be used:

```
layers:
   layerA:
      color: red

   layerB:
      color: blue   # feature will be blue because `layerB` sorts after `layerA`
```  

This is not intended as the final solution for this issue. But before we introduce additional syntax for reducing collisions, it provides a deterministic fallback behavior that can be used by both platforms. Note, a suggested and preferred resolution would be to use the rule that occurs *later* in the file, e.g. last definition wins. However, since plain JS objects don't guarantee sorting of keys by insertion order, it is not currently possible to implement this on the JS side; this could possibly be enabled by future additions to the js-yaml parser to either use an ES6 Map (which does support enumeration of keys by insertion order), or the addition of positional metadata for YAML mappings.

