### PR TITLE
Add data source

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -987,10 +987,19 @@ export default class Scene {
         });
     }
 
-    // Add source, `name` and `config` need to be provided:
+    // Add source to a scene, arguments `name` and `config` need to be provided:
     //  - If the name doesn't match a sources it will create it
-    //  - the config obj follow the YAML scene spec: {type: ['topoJSON'|'geoJSON'|'MVT'], [url: string | data: obj]} 
-    //    Note that you could provide a `url` or a `data` object 
+    //  - the `config` obj follow the YAML scene spec, ex: ```{type: 'TopoJSON', url: "//vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson"]}```
+    //    that looks like:
+    //
+    //      scene.setDataSource("osm", {type: 'TopoJSON', url: "//vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson" });
+    //
+    //  - also can be pass a ```data``` obj: ```{type: 'GeoJSON', data: JSObj ]}```
+    //
+    //      var geojson_data = {};
+    //      ...
+    //      scene.setDataSource("dynamic_data", {type: 'GeoJSON', data: geojson_data });
+    //
     setDataSource (name, config) {
         if (!name || !config || !config.type || (!config.url && !config.data)) {
             log.error("No name provide or not valid config:", name, config);

--- a/src/scene.js
+++ b/src/scene.js
@@ -987,6 +987,30 @@ export default class Scene {
         });
     }
 
+    // Add source. The config should have {type: ['topoJSON'|'geoJSON'], [url: string | data: obj]}
+    setDataSource (name, config) {
+        if ( !name || !config || !config.type || (!config.url && !config.data ) ) {
+            log.error("No name provide or not valid config:", name, config);
+            return;
+        }
+
+        let load = (this.config.sources[name] == null);
+        let source = this.config.sources[name] = Object.assign({}, config);
+
+        if (source.data && typeof source.data === 'object') {
+            source.url = Utils.createObjectURL(new Blob([JSON.stringify(source.data)]));
+            delete source.data;
+            // TODO: add path normalization logic
+        }
+
+        if (load) {
+            this.updateConfig({ rebuild: true });
+            // this.loadDataSources();
+        } else {
+            this.rebuild();
+        }
+    }
+    
     loadDataSources() {
         for (var name in this.config.sources) {
             let source = this.config.sources[name];

--- a/src/scene.js
+++ b/src/scene.js
@@ -1002,7 +1002,7 @@ export default class Scene {
     //
     setDataSource (name, config) {
         if (!name || !config || !config.type || (!config.url && !config.data)) {
-            log.error("No name provide or not valid config:", name, config);
+            log.error("No name provided or not a valid config:", name, config);
             return;
         }
 
@@ -1012,7 +1012,6 @@ export default class Scene {
         if (source.data && typeof source.data === 'object') {
             source.url = Utils.createObjectURL(new Blob([JSON.stringify(source.data)]));
             delete source.data;
-            // TODO: add path normalization logic
         }
 
         if (load) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -987,9 +987,12 @@ export default class Scene {
         });
     }
 
-    // Add source. The config should have {type: ['topoJSON'|'geoJSON'], [url: string | data: obj]}
+    // Add source, `name` and `config` need to be provided:
+    //  - If the name doesn't match a sources it will create it
+    //  - the config obj follow the YAML scene spec: {type: ['topoJSON'|'geoJSON'|'MVT'], [url: string | data: obj]} 
+    //    Note that you could provide a `url` or a `data` object 
     setDataSource (name, config) {
-        if ( !name || !config || !config.type || (!config.url && !config.data ) ) {
+        if (!name || !config || !config.type || (!config.url && !config.data)) {
             log.error("No name provide or not valid config:", name, config);
             return;
         }
@@ -1005,7 +1008,6 @@ export default class Scene {
 
         if (load) {
             this.updateConfig({ rebuild: true });
-            // this.loadDataSources();
         } else {
             this.rebuild();
         }


### PR DESCRIPTION
Add data source **method** from JS through an interface:

```scene.setDataSource (name, config)```

**Arguments** `name` and `config` must be provide. 
Notes:

+ If ```name``` doesn't match an existing source it will create one for you
+ the ```config``` obj follow the YAML scene spec.
    - ```type``` need to be provide (it's content could be: 'TopoJSON', 'GeoJSON' or 'MVT'), together with ..
   - a source (```url``` or ```data```): ```url``` expect a string with or with out ```{x}```, ```{y}``` and ```{z}``` template or ```data``` expects directly a JavaScript object which will be interpreted acording to the ```type```

Examples:
 ```scene.setDataSource("osm", {type: 'TopoJSON', url: "//vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson" });```

 ```
var geojson_data = {};
...
scene.setDataSource("dynamic_data", {type: 'GeoJSON', data: geojson_data });
```