### PR TITLE
Add screenshot support

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -184,19 +184,6 @@ Enjoy!
     map.setView(map_start_location.slice(0, 2), map_start_location[2]);
     map.on('move', updateURL);
 
-    // Take a screenshot and save file
-    function screenshot() {
-        // Adapted from: https://gist.github.com/unconed/4370822
-        var image = scene.canvas.toDataURL('image/png').slice(22); // slice strips host/mimetype/etc.
-        var data = atob(image); // convert base64 to binary without UTF-8 mangling
-        var buf = new Uint8Array(data.length);
-        for (var i = 0; i < data.length; ++i) {
-            buf[i] = data.charCodeAt(i);
-        }
-        var blob = new Blob([buf], { type: 'image/png' });
-        saveAs(blob, 'tangram-' + (+new Date()) + '.png'); // uses FileSaver.js: https://github.com/eligrey/FileSaver.js/
-    }
-
     // Render/GL stats: http://spite.github.io/rstats/
     // Activate with 'rstats' anywhere in options list in URL
     if (url_ui && url_ui.indexOf('rstats') >= 0) {
@@ -419,10 +406,12 @@ Enjoy!
         gui['feature info'] = true;
         gui.add(gui, 'feature info');
 
-        // Screenshot
+        // Take a screenshot and save to file
         gui.screenshot = function () {
-            gui.queue_screenshot = true;
-            scene.requestRedraw();
+            return scene.screenshot().then(function(screenshot) {
+                // uses FileSaver.js: https://github.com/eligrey/FileSaver.js/
+                saveAs(screenshot.blob, 'tangram-' + (+new Date()) + '.png');
+            });
         };
         gui.add(gui, 'screenshot');
 
@@ -552,12 +541,6 @@ Enjoy!
             rS('glbuffers').set((scene.tile_manager.getDebugSum('buffer_size') / (1024*1024)).toFixed(2));
             rS('features').set(scene.tile_manager.getDebugSum('features'));
             rS().update();
-        }
-
-        // Screenshot needs to happen in the requestAnimationFrame callback, or the frame buffer might already be cleared
-        if (gui.queue_screenshot == true) {
-            gui.queue_screenshot = false;
-            screenshot();
         }
     }
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -1248,7 +1248,7 @@ export default class Scene {
             var blob = new Blob([buffer], { type: 'image/png' });
 
             // Resolve with both blob, and raw buffer
-            this.queue_screenshot.resolve({ blob, buffer });
+            this.queue_screenshot.resolve({ blob });
             this.queue_screenshot = null;
         }
     }

--- a/src/scene.js
+++ b/src/scene.js
@@ -1238,17 +1238,19 @@ export default class Scene {
     // Called after rendering, captures render buffer and resolves promise with image data
     completeScreenshot () {
         if (this.queue_screenshot != null) {
+            // Get data URL, convert to blob
+            // Strip host/mimetype/etc., convert base64 to binary without UTF-8 mangling
             // Adapted from: https://gist.github.com/unconed/4370822
-            var image = this.canvas.toDataURL('image/png').slice(22); // slice strips host/mimetype/etc.
-            var data = atob(image); // convert base64 to binary without UTF-8 mangling
+            var url = this.canvas.toDataURL('image/png');
+            var data = atob(url.slice(22));
             var buffer = new Uint8Array(data.length);
             for (var i = 0; i < data.length; ++i) {
                 buffer[i] = data.charCodeAt(i);
             }
             var blob = new Blob([buffer], { type: 'image/png' });
 
-            // Resolve with both blob, and raw buffer
-            this.queue_screenshot.resolve({ blob });
+            // Resolve with screenshot data
+            this.queue_screenshot.resolve({ url, blob });
             this.queue_screenshot = null;
         }
     }

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -123,6 +123,10 @@ export default TileManager = {
         return tiles;
     },
 
+    isLoadingVisibleTiles() {
+        return Object.keys(this.tiles).some(k => this.tiles[k].visible && this.tiles[k].loading);
+    },
+
     // Queue a tile for load
     queueCoordinate(coords) {
         this.queued_coords[this.queued_coords.length] = coords;


### PR DESCRIPTION
Incorporates screenshot-related support from the demo into Tangram itself. This will be useful for automated render testing, for apps like Tangram Play that may want to capture the view periodically, and for other users who would like to incorporate screenshot support.

API changes:

- A new scene method, `Scene.screenshot()`, which queues a screenshot request, and returns a Promise that fulfills when the screenshot is available. (The screenshot must be "queued" because it cannot be captured immediately: we must ensure that the GL buffer is finished drawing, and then must capture the buffer contents just after rendering, before it is cleared by other operations.)
   - The promise resolves with an object containing two properties:
      - `url`: a data URL of the Canvas contents, suitable for loading into an `<img>` or opening in a new tab/window
      - `blob`: a `Blob` of type `image/png`, suitable for saving to a file. Note that actually saving the blob to disk is left to the user or 3rd party library such as [FileSaver.js](https://github.com/eligrey/FileSaver.js/), as this goes a step beyond what can be considered generic Tangram functionality.
   - Example usage of requesting and saving a screenshot:
```
scene.screenshot().then(function(screenshot) {
    // uses FileSaver.js: https://github.com/eligrey/FileSaver.js/
    saveAs(screenshot.blob, 'tangram-' + (+new Date()) + '.png');
});
```
- A new scene event called `view_complete`, which fires when the view is in a "resting state", meaning new geometry is rendered, and no further tiles are loading/building. For example, when a scene is loaded, a `view_complete` event will fire when all tiles have loaded and the map renders. If the view is then zoomed in a level, another `view_complete` event will fire when the next zoom finishes rendering. `view_complete` can be subscribed to like other scene events:
```
scene.subscribe({
    view_complete: function () {
        console.log('scene view complete, rendered ' + 
            scene.render_count + ' primitives at: ' + 
            [scene.center.lng, scene.center.lat, scene.zoom].join('/'));
    }
});
```
- `Scene.screenshot()` can be paired with `view_complete` to automate screenshots, e.g. take a screenshot on initial scene view, take a screenshot for each new view, or a list of views for automated test generation, etc.