### PR TITLE
Add miter limit for line builder

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -190,11 +190,18 @@ Builders.buildPolylines = function (
         texcoord_normalize,
         scaling_index,
         scaling_normalize,
-        join, cap
+        join, cap,
+        miter_limit
     }) {
 
     var cornersOnCap = cornersForCap[cap] || 0;         // default 'butt'
     var trianglesOnJoin = trianglesForJoin[join] || 0;  // default 'miter'
+
+    // Configure miter limit
+    if (trianglesOnJoin === 0) {
+        miter_limit = miter_limit || 3; // default miter limit
+        var miter_len_sq = miter_limit * miter_limit;
+    }
 
     // Build variables
     if (texcoord_index) {
@@ -330,8 +337,13 @@ Builders.buildPolylines = function (
                     addCap(coordCurr, normCurr, cornersOnCap, true, constants);
                 }
 
+                //  Miter limit: if miter join is too sharp, convert to bevel instead
+                if (trianglesOnJoin === 0 && Vector.lengthSq(normCurr) > miter_len_sq) {
+                    trianglesOnJoin = trianglesForJoin['bevel']; // switch to bevel
+                }
+
                 // If it's a JOIN
-                if(trianglesOnJoin !== 0 && isPrev && isNext) {
+                if (trianglesOnJoin !== 0 && isPrev && isNext) {
                     addJoin([coordPrev, coordCurr, coordNext],
                             [normPrev,normCurr, normNext],
                             i/lineSize, trianglesOnJoin,

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -107,6 +107,7 @@ Object.assign(Lines, {
 
         style.cap = rule_style.cap;
         style.join = rule_style.join;
+        style.miter_limit = rule_style.miter_limit;
         style.tile_edges = rule_style.tile_edges; // usually activated for debugging, or rare visualization needs
 
         // Construct an outline style
@@ -133,6 +134,7 @@ Object.assign(Lines, {
                 style.outline.color = rule_style.outline.color;
                 style.outline.cap = rule_style.outline.cap || rule_style.cap;
                 style.outline.join = rule_style.outline.join || rule_style.join;
+                style.outline.miter_limit = rule_style.outline.miter_limit || rule_style.miter_limit;
                 style.outline.style = rule_style.outline.style || this.name;
 
                 // Explicitly defined outline order, or inherited from inner line
@@ -233,6 +235,7 @@ Object.assign(Lines, {
             {
                 cap: style.cap,
                 join: style.join,
+                miter_limit: style.miter_limit,
                 scaling_index: this.vertex_layout.index.a_extrude,
                 scaling_normalize: Utils.scaleInt16(1, 256), // scale extrusion normals to signed shorts w/256 unit basis
                 texcoord_index: this.vertex_layout.index.a_texcoord,


### PR DESCRIPTION
Adds back the previously lost miter limit functionality for polyline builders. The miter limit converts miter joins to bevels when the join angle is very sharp, specifically when the miter join length is longer than the ratio of the `miter_limit` to the width of the line.  See [SVG miter limit](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-miterlimit) for reference.

Exposes as `miter_limit` in `lines` style, default miter limit is 3., e.g.:

```
draw:
   lines:
      color: red
      width: 5px
      miter_limit: 2
```

Examples from [Hong Kong paths](http:tangrams.github.io/eraser-map/#20/22.27658/114.21159):

**Miter limit 3 (default)**
![miter-3](https://cloud.githubusercontent.com/assets/16733/12268208/cb6e1ea2-b919-11e5-9949-a617b28dfc77.png)

**Miter limit 2**
![miter-2](https://cloud.githubusercontent.com/assets/16733/12268210/cb8bce2a-b919-11e5-9824-2307d5530aa1.png)

**Miter limit 1.5**
![miter-1 5](https://cloud.githubusercontent.com/assets/16733/12268209/cb885f10-b919-11e5-9e9e-4e1739fb9e43.png)