### PR TITLE
Add `density` parameter for native pixel density of textures

### DIFF
--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -27,6 +27,7 @@ export default class Texture {
 
         this.name = name;
         this.filtering = options.filtering;
+        this.pixel_density = options.pixel_density || 1;
 
         // Destroy previous texture if present
         if (Texture.textures[this.name]) {
@@ -40,6 +41,7 @@ export default class Texture {
         this.sprites = options.sprites;
         this.texcoords = {};    // sprite UVs ([0, 1] range)
         this.sizes = {};        // sprite sizes (pixel size)
+        this.css_sizes = {};    // sprite sizes, adjusted for native texture pixel density
         log.trace(`creating Texture ${this.name}`);
     }
 
@@ -244,7 +246,9 @@ export default class Texture {
                 );
 
                 // Pixel size of sprite
+                // Divide by native texture density to get correct CSS pixels
                 this.sizes[s] = [sprite[2], sprite[3]];
+                this.css_sizes[s] = [sprite[2] / this.pixel_density, sprite[3] / this.pixel_density];
             }
         }
     }
@@ -268,7 +272,11 @@ Texture.destroy = function (gl) {
 // Get sprite pixel size and UVs
 Texture.getSpriteInfo = function (texname, sprite) {
     let texture = Texture.textures[texname];
-    return texture && { size: texture.sizes[sprite], texcoords: texture.texcoords[sprite] };
+    return texture && {
+        size: texture.sizes[sprite],
+        css_size: texture.css_sizes[sprite],
+        texcoords: texture.texcoords[sprite]
+    };
 };
 
 // Create a set of textures keyed in an object
@@ -332,9 +340,11 @@ Texture.getInfo = function (name) {
                 name: tex.name,
                 width: tex.width,
                 height: tex.height,
+                pixel_density: tex.pixel_density,
                 sprites: tex.sprites,
                 texcoords: tex.texcoords,
                 sizes: tex.sizes,
+                css_sizes: tex.css_sizes,
                 filtering: tex.filtering,
                 power_of_2: tex.power_of_2,
                 valid: tex.valid

--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -27,7 +27,7 @@ export default class Texture {
 
         this.name = name;
         this.filtering = options.filtering;
-        this.pixel_density = options.pixel_density || 1;
+        this.density = options.density || 1;
 
         // Destroy previous texture if present
         if (Texture.textures[this.name]) {
@@ -248,7 +248,7 @@ export default class Texture {
                 // Pixel size of sprite
                 // Divide by native texture density to get correct CSS pixels
                 this.sizes[s] = [sprite[2], sprite[3]];
-                this.css_sizes[s] = [sprite[2] / this.pixel_density, sprite[3] / this.pixel_density];
+                this.css_sizes[s] = [sprite[2] / this.density, sprite[3] / this.density];
             }
         }
     }
@@ -340,7 +340,7 @@ Texture.getInfo = function (name) {
                 name: tex.name,
                 width: tex.width,
                 height: tex.height,
-                pixel_density: tex.pixel_density,
+                density: tex.density,
                 sprites: tex.sprites,
                 texcoords: tex.texcoords,
                 sizes: tex.sizes,


### PR DESCRIPTION
Adds a `density` parameter to texture definitions, to indicate the intended native pixel density that the texture was created for (e.g. mostly this means retina 1x or non-retina 2x, though other densities are possible). 

When style rules explicitly define the `size` of a sprite, this info isn't needed, because `size` is specified in CSS pixels, and the underlying texture is scaled to fit as necessary. But we found that in order to let sprites _automatically_ set their `size` appropriately, we needed this additional information about the sprite texture -- if the sprite was created for 1x resolution, it should be scaled up for retina display; if created for 2x resolution, scaled down on non-retina, etc.

`density` captures this information, and defaults to `1`. Example:

```
textures:
   pois:
      url: pois.png
      density: 2 # authored at 2x resolution
      sprites:
         # define sprites: [x origin, y origin, width, height]
         airport: [631, 105, 36, 38]
         ...
```

"Density" terminology was borrowed from HTML's relatively new [`srcset` attribute](http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-srcset) for supporting multiple resolution/density images (best image for current display is selected by browser). Alternatives could include `pixel_ratio`, from the browser's `window.devicePixelRatio`.
