### PR TITLE
Label text can be defined as a series of fallbacks

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -397,6 +397,7 @@ layers:
             filter: { kind: highway, $zoom: { min: 7 } }
             draw:
                 text:
+                    text_source: [name:en, name]
                     priority: 2
                     font:
                         fill: '#666'
@@ -408,6 +409,7 @@ layers:
             filter: { not: { kind: highway }, $zoom: { min: 13 } }
             draw:
                 text:
+                    text_source: [name:en, name]
                     priority: 5
                     font:
                         fill: '#666'
@@ -503,6 +505,7 @@ layers:
                 - function() { return (feature.scalerank * .75) <= ($zoom - 4); }
         draw:
             text:
+                text_source: [name:en, name]
                 priority: 1
                 font:
                     family: Helvetica
@@ -568,6 +571,7 @@ layers:
                     - { $zoom: { min: 18 } }
             draw:
                 text:
+                    text_source: [name:en, name]
                     priority: 4
                     font:
                         family: Lucida Grande
@@ -584,6 +588,7 @@ layers:
                 $zoom: { min: 18 }
             draw:
                 text:
+                    text_source: [name:en, name]
                     # align: left
                     anchor: bottom
                     offset: [[13, [0, 6px]], [15, [0, 9px]]]


### PR DESCRIPTION
This adds the ability for `text_source` to be an array of possible sources of label text, in priority order. Each array element is evaluated as if it was a `text_source` value (meaning each element can be either a *string* value that specifies a feature property by name, or a *function* that returns displayable label text). The first non-null evaluated source in the array is used as the label text.

The primary use case here is to support **preferred language** for text labels. For example: 

`text_source: [name:en, name]`

This will display an English label (`name:en`) when available, and will fall back to the default local `name` when not available.

For example, here is Moscow with default `name` only, and with the English preference as specified above:

![output_gtv4rw](https://cloud.githubusercontent.com/assets/16733/12465101/4c0f6436-bf81-11e5-9682-361247e680dd.gif)

Looking to the future, once we have support for *scene properties* (see https://github.com/tangrams/tangram/compare/scene-properties), we will be able to control a preferred language with a single global scene variable, and even modify that preference at run-time (modify config and rebuild scene). For example (pending final scene property syntax):

```
scene:
   language: 'name:en' # prefer English

layers:
   labels:
      data: ...
      draw:
         text:
            text_source: [scene.language, name] # use scene preference, or fall back to local name
            ...
```

