### PR TITLE
Filter lines on all tile edges

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -678,25 +678,27 @@ Builders.triangulatePolygon = function (contours)
 };
 
 // Tests if a line segment (from point A to B) is nearly coincident with the edge of a tile
+// Note: mod operation filters out *any* tile edge, not just the edges of the "local" tile,
+// this is useful for cases where geometry is clipped to some other tile multiple, e.g. 3-tile bbox
 Builders.isOnTileEdge = function (pa, pb, tolerance) {
     var tolerance_function = Builders.valuesWithinTolerance;
     var tile_min = Builders.tile_bounds[0];
     var tile_max = Builders.tile_bounds[1];
 
     // Left
-    if (tolerance_function(pa[0], tile_min.x, tolerance) && tolerance_function(pb[0], tile_min.x, tolerance)) {
+    if (tolerance_function(pa[0] % Geo.tile_scale, tile_min.x, tolerance) && tolerance_function(pb[0] % Geo.tile_scale, tile_min.x, tolerance)) {
         return true;
     }
     // Right
-    else if (tolerance_function(pa[0], tile_max.x, tolerance) && tolerance_function(pb[0], tile_max.x, tolerance)) {
+    else if (tolerance_function(pa[0] % Geo.tile_scale, tile_max.x, tolerance) && tolerance_function(pb[0] % Geo.tile_scale, tile_max.x, tolerance)) {
         return true;
     }
     // Top
-    else if (tolerance_function(pa[1], tile_min.y, tolerance) && tolerance_function(pb[1], tile_min.y, tolerance)) {
+    else if (tolerance_function(pa[1] % Geo.tile_scale, tile_min.y, tolerance) && tolerance_function(pb[1] % Geo.tile_scale, tile_min.y, tolerance)) {
         return true;
     }
     // Bottom
-    else if (tolerance_function(pa[1], tile_max.y, tolerance) && tolerance_function(pb[1], tile_max.y, tolerance)) {
+    else if (tolerance_function(pa[1] % Geo.tile_scale, tile_max.y, tolerance) && tolerance_function(pb[1] % Geo.tile_scale, tile_max.y, tolerance)) {
         return true;
     }
     return false;


### PR DESCRIPTION
Adjusts our tile edge filtering (which removes line segments that fall on tile edges, as they are generally not desirable to draw) so that it will filter out lines that fall on **any** tile edge, not just the edges of the "local" tile. This is done by simply modding the coordinates against the tile size.

This is useful for cases where geometry is clipped to some other tile multiple, e.g. 3-tile bbox range. See https://github.com/mapzen/vector-datasource/issues/197 for background.

Before:
![tangram-1453403245861](https://cloud.githubusercontent.com/assets/16733/12491509/5c8981b6-c030-11e5-811d-ef4f0cec9807.png)

After:
![tangram-1453403090822](https://cloud.githubusercontent.com/assets/16733/12491511/5f5f6112-c030-11e5-9be2-cea3082d56b2.png)

