### PR TITLE
Support arbitrary winding order

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -87,7 +87,8 @@ Builders.buildExtrudedPolygons = function (
         tile_edge_tolerance,
         texcoord_index,
         texcoord_scale,
-        texcoord_normalize
+        texcoord_normalize,
+        winding
     }) {
 
     // Top
@@ -124,23 +125,32 @@ Builders.buildExtrudedPolygons = function (
                     continue; // don't extrude tile edges
                 }
 
+                // Wall order is dependent on winding order, so that normals face outward
+                let w0, w1;
+                if (winding === 'CCW') {
+                    w0 = w;
+                    w1 = w+1;
+                }
+                else {
+                    w0 = w+1;
+                    w1 = w;
+                }
+
                 // Two triangles for the quad formed by each vertex pair, going from bottom to top height
                 var wall_vertices = [
                     // Triangle
-                    [contour[w+1][0], contour[w+1][1], max_z],
-                    [contour[w+1][0], contour[w+1][1], min_z],
-                    [contour[w][0], contour[w][1], min_z],
+                    [contour[w1][0], contour[w1][1], max_z],
+                    [contour[w1][0], contour[w1][1], min_z],
+                    [contour[w0][0], contour[w0][1], min_z],
                     // Triangle
-                    [contour[w][0], contour[w][1], min_z],
-                    [contour[w][0], contour[w][1], max_z],
-                    [contour[w+1][0], contour[w+1][1], max_z]
+                    [contour[w0][0], contour[w0][1], min_z],
+                    [contour[w0][0], contour[w0][1], max_z],
+                    [contour[w1][0], contour[w1][1], max_z]
                 ];
 
                 // Calc the normal of the wall from up vector and one segment of the wall triangles
-                var normal = Vector.cross(
-                    [0, 0, 1],
-                    Vector.normalize([contour[w+1][0] - contour[w][0], contour[w+1][1] - contour[w][1], 0])
-                );
+                let wall_vec = Vector.normalize([contour[w1][0] - contour[w0][0], contour[w1][1] - contour[w0][1], 0]);
+                let normal = Vector.cross([0, 0, 1], wall_vec);
 
                 // Update vertex template with current surface normal
                 vertex_template[normal_index + 0] = normal[0] * normal_normalize;

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -144,7 +144,8 @@ Object.assign(Polygons, {
             texcoord_scale: this.texcoord_scale,
             texcoord_normalize: 65535, // scale UVs to unsigned shorts
             remove_tile_edges: !style.tile_edges,
-            tile_edge_tolerance: Geo.tile_scale * context.tile.pad_scale * 4
+            tile_edge_tolerance: Geo.tile_scale * context.tile.pad_scale * 4,
+            winding: context.winding
         };
 
         // Extruded polygons (e.g. 3D buildings)

--- a/src/tile.js
+++ b/src/tile.js
@@ -205,6 +205,7 @@ export default class Tile {
                     }
 
                     let context = StyleParser.getFeatureParseContext(feature, tile);
+                    context.winding = tile.default_winding;
                     context.layer = source_layer.layer; // add data source layer name
 
                     // Get draw groups for this feature


### PR DESCRIPTION
Currently, Mapzen's own vector tiles have a CCW winding on polygon rings, which is opposite what the MVT format [currently specifies](https://github.com/mapbox/vector-tile-spec/tree/master/2.1) (Geo/TopoJSON do not have an officially specified winding order). We plan to rectify this in an upcoming tile release (see https://github.com/mapzen/mapbox-vector-tile/pull/21), but it raised the issue that Tangram ideally ought to support data sources with either winding order, for maximum compatibility.

This PR enables that by using the order of the first polygon ring processed in each data source, to indicate the expected order of outer rings. This allows for automatic switching between CW or CCW-wound polygons on a per-data-source level, even mixing sources with different winding orders. (Note this assumes that the data source is internally consistent in its winding between polygons, but there is no rational way to support a source that is not.)

See related issue to add support in ES: https://github.com/tangrams/tangram-es/issues/519