### PR TITLE
Exclude line segments that fall outside the tile bounds

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -694,10 +694,10 @@ Builders.outsideTile = function (_a, _b, tolerance) {
     let tile_max = Builders.tile_bounds[1];
 
     // TODO: fix flipped Y coords here, confusing with 'max' reference
-    if ((_a[0] < tile_min.x + tolerance && _b[0] < tile_min.x + tolerance) ||
-        (_a[0] > tile_max.x - tolerance && _b[0] > tile_max.x - tolerance) ||
-        (_a[1] > tile_min.y - tolerance && _b[1] > tile_min.y - tolerance) ||
-        (_a[1] < tile_max.y + tolerance && _b[1] < tile_max.y + tolerance)) {
+    if ((_a[0] <= tile_min.x + tolerance && _b[0] <= tile_min.x + tolerance) ||
+        (_a[0] >= tile_max.x - tolerance && _b[0] >= tile_max.x - tolerance) ||
+        (_a[1] >= tile_min.y - tolerance && _b[1] >= tile_min.y - tolerance) ||
+        (_a[1] <= tile_max.y + tolerance && _b[1] <= tile_max.y + tolerance)) {
         return true;
     }
 

--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -121,7 +121,7 @@ Builders.buildExtrudedPolygons = function (
             var contour = polygon[q];
 
             for (var w=0; w < contour.length - 1; w++) {
-                if (remove_tile_edges && Builders.isOnTileEdge(contour[w], contour[w+1], tile_edge_tolerance)) {
+                if (remove_tile_edges && Builders.outsideTile(contour[w], contour[w+1], tile_edge_tolerance)) {
                     continue; // don't extrude tile edges
                 }
 
@@ -274,7 +274,7 @@ Builders.buildPolylines = function (
 
                 var needToClose = true;
                 if (remove_tile_edges) {
-                    if(Builders.isOnTileEdge(line[i], line[lineSize-2], tile_edge_tolerance)) {
+                    if(Builders.outsideTile(line[i], line[lineSize-2], tile_edge_tolerance)) {
                         needToClose = false;
                     }
                 }
@@ -302,7 +302,7 @@ Builders.buildPolylines = function (
 
                 normNext = Vector.normalize(Vector.perp(coordCurr, coordNext));
                 if (remove_tile_edges) {
-                    if (Builders.isOnTileEdge(coordCurr, coordNext, tile_edge_tolerance)) {
+                    if (Builders.outsideTile(coordCurr, coordNext, tile_edge_tolerance)) {
                         normCurr = Vector.normalize(Vector.perp(coordPrev, coordCurr));
                         if (isPrev) {
                             addVertexPair(coordCurr, normCurr, i/lineSize, constants);
@@ -687,29 +687,19 @@ Builders.triangulatePolygon = function (contours)
     return earcut(contours);
 };
 
-// Tests if a line segment (from point A to B) is nearly coincident with the edge of a tile
-Builders.isOnTileEdge = function (_a, _b, tolerance) {
+// Tests if a line segment (from point A to B) is outside the tile bounds
+// (within a certain tolerance to account for geometry nearly on tile edges)
+Builders.outsideTile = function (_a, _b, tolerance) {
     let tile_min = Builders.tile_bounds[0];
     let tile_max = Builders.tile_bounds[1];
 
-    // Note: mod operation filters out *any* tile edge, not just the edges of the "local" tile,
-    // this is useful for cases where geometry is clipped to some other tile multiple, e.g. 3-tile bbox
-    if (nearlyEqual(_a[0], _b[0], tolerance)) {
-        let x = _a[0] % tile_max.x;
-        if (nearlyEqual(x, tile_min.x, tolerance) || nearlyEqual(x, tile_max.x, tolerance)) {
-            return true;
-        }
+    // TODO: fix flipped Y coords here, confusing with 'max' reference
+    if ((_a[0] < tile_min.x + tolerance && _b[0] < tile_min.x + tolerance) ||
+        (_a[0] > tile_max.x - tolerance && _b[0] > tile_max.x - tolerance) ||
+        (_a[1] > tile_min.y - tolerance && _b[1] > tile_min.y - tolerance) ||
+        (_a[1] < tile_max.y + tolerance && _b[1] < tile_max.y + tolerance)) {
+        return true;
     }
-    if (nearlyEqual(_a[1], _b[1], tolerance)) {
-        let y = _a[1] % tile_max.y;
-        if (nearlyEqual(y, tile_min.y, tolerance) || nearlyEqual(y, tile_min.y, tolerance)) {
-            return true;
-        }
-    }
+
     return false;
 };
-
-function nearlyEqual  (a, b, tolerance) {
-    tolerance = tolerance || 1;
-    return (Math.abs(a - b) < tolerance);
-}


### PR DESCRIPTION
Our previous tile edge removal logic only removed line segments that were *on* (or nearly on, within a tolerance) the tile bounds. This works for unbuffered tiles like Mapzen's, which are clipped to tile boundaries, but does not render properly for buffered tiles, such as Mapbox's.

This approach simply throws out line segments that lie outside the tile bounds (retaining the tolerance). Along with https://github.com/tangrams/tangram/pull/241, ensures proper support for Mapbox-served MVT tiles.

Before/after examples, where the "double lines" visible with the previous logic are lines at the edge of the tile buffer area (so one buffer for each adjacent tile, two lines total), which were not removed, but now are no longer rendered:

![output_g5tx0t](https://cloud.githubusercontent.com/assets/16733/12828005/4fe4161c-cb50-11e5-95fd-460e7b6cc4bd.gif)

![output_9x4pzh](https://cloud.githubusercontent.com/assets/16733/12828003/4df28744-cb50-11e5-9721-ad1992b2734c.gif)