### PR TITLE
Raster tile support

### DIFF
--- a/src/gl/shader_program.js
+++ b/src/gl/shader_program.js
@@ -375,7 +375,8 @@ export default class ShaderProgram {
     setTextureUniform(uniform_name, texture_name) {
         var texture = Texture.textures[texture_name];
         if (texture == null) {
-            texture = Texture.create(this.gl, texture_name, { url: texture_name });
+            log.warn(`Can't find texture '${texture_name}'`);
+            return;
         }
 
         texture.bind(this.texture_unit);

--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -51,6 +51,7 @@ export default class Texture {
     destroy() {
         if (this.retain_count > 0) {
             log.error(`Texture '${this.name}': destroying texture with retain count of '${this.retain_count}'`);
+            return;
         }
 
         if (!this.valid) {

--- a/src/module.js
+++ b/src/module.js
@@ -18,6 +18,7 @@ import DataSource from './sources/data_source';
 import './sources/geojson';
 import './sources/topojson';
 import './sources/mvt';
+import './sources/raster';
 import TileManager from './tile_manager';
 import GLSL from './gl/glsl';
 import ShaderProgram from './gl/shader_program';

--- a/src/scene.js
+++ b/src/scene.js
@@ -21,12 +21,14 @@ import {Polygons} from './styles/polygons/polygons';
 import {Lines} from './styles/lines/lines';
 import {Points} from './styles/points/points';
 import {TextStyle} from './styles/text/text';
+import {RasterStyle} from './styles/raster/raster';
 
 // Add built-in rendering styles
 StyleManager.register(Polygons);
 StyleManager.register(Lines);
 StyleManager.register(Points);
 StyleManager.register(TextStyle);
+StyleManager.register(RasterStyle);
 
 // Load scene definition: pass an object directly, or a URL as string to load remotely
 export default class Scene {

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -1,0 +1,56 @@
+import DataSource, {NetworkTileSource} from './data_source';
+import Geo from '../geo';
+
+export class RasterTileSource extends NetworkTileSource {
+
+    constructor(source) {
+        super(source);
+
+        this.filtering = source.filtering; // optional texture filtering (nearest, linear, mipmap)
+
+        // save texture objects by tile key, so URL remains stable if tile is built multiple times,
+        // e.g. avoid re-loading the same tile texture under a different subdomain when using tile hosts
+        this.textures = {};
+    }
+
+    load(tile) {
+        tile.source_data = {};
+        tile.source_data.layers = {};
+        tile.pad_scale = this.pad_scale;
+
+        // Set texture info for this tile
+        tile.texture = this.tileTexture(tile);
+
+        // Generate a single quad that fills the entire tile
+        tile.source_data.layers = {
+            _default: {
+                type: 'FeatureCollection',
+                features: [{
+                    geometry: {
+                        type: 'Polygon',
+                        coordinates: [[
+                            [0, 0], [Geo.tile_scale, 0],
+                            [Geo.tile_scale, -Geo.tile_scale], [0, -Geo.tile_scale], [0, 0]
+                        ]]
+                    },
+                    properties: {}
+                }]
+            }
+        };
+
+        tile.default_winding = 'CW';
+        return Promise.resolve(tile);
+    }
+
+    // Return texture info for a raster tile
+    tileTexture (tile) {
+        if (!this.textures[tile.key]) {
+            let url = this.formatUrl(this.url, tile);
+            this.textures[tile.key] = { url, filtering: this.filtering };
+        }
+        return this.textures[tile.key];
+    }
+
+}
+
+DataSource.register(RasterTileSource, 'Raster');

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -45,9 +45,9 @@ export class RasterTileSource extends NetworkTileSource {
 
     // Return texture info for a raster tile
     tileTexture (tile) {
-        let key = tile.coord_key;
+        let key = tile.coords.key;
         if (!this.textures[key]) {
-            let coords = Tile.overZoomedCoordinate(tile.coords, this.max_zoom);
+            let coords = Tile.coordinateWithMaxZoom(tile.coords, this.max_zoom);
             let url = this.formatUrl(this.url, { coords });
             this.textures[key] = { url, filtering: this.filtering };
         }

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -1,4 +1,5 @@
 import DataSource, {NetworkTileSource} from './data_source';
+import Tile from '../tile';
 import Geo from '../geo';
 
 export class RasterTileSource extends NetworkTileSource {
@@ -44,11 +45,13 @@ export class RasterTileSource extends NetworkTileSource {
 
     // Return texture info for a raster tile
     tileTexture (tile) {
-        if (!this.textures[tile.key]) {
-            let url = this.formatUrl(this.url, tile);
-            this.textures[tile.key] = { url, filtering: this.filtering };
+        let key = tile.coord_key;
+        if (!this.textures[key]) {
+            let coords = Tile.overZoomedCoordinate(tile.coords, this.max_zoom);
+            let url = this.formatUrl(this.url, { coords });
+            this.textures[key] = { url, filtering: this.filtering };
         }
-        return this.textures[tile.key];
+        return this.textures[key];
     }
 
 }

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -9,7 +9,9 @@ uniform mat3 u_normalMatrix;
 uniform mat3 u_inverseNormalMatrix;
 
 #ifdef TANGRAM_RASTER_TEXTURE
-    uniform sampler2D TANGRAM_RASTER_TEXTURE;
+    uniform sampler2D u_raster_texture;         // raster texture sampler
+    uniform vec2 u_raster_texture_size;         // width/height pixel dimensions of raster texture
+    uniform vec2 u_raster_texture_pixel_size;   // UV size of a single pixel in raster texture
 #endif
 
 varying vec4 v_position;
@@ -49,7 +51,7 @@ void main (void) {
     // Get color from raster tile texture
     #ifdef TANGRAM_RASTER_TEXTURE
         // note: vertex color is multiplied to tint texture color
-        color *= texture2D(TANGRAM_RASTER_TEXTURE, v_texcoord.xy);
+        color *= texture2D(u_raster_texture, v_texcoord.xy);
     #endif
 
     // Modify color and material properties before lighting

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -8,6 +8,10 @@ uniform float u_device_pixel_ratio;
 uniform mat3 u_normalMatrix;
 uniform mat3 u_inverseNormalMatrix;
 
+#ifdef TANGRAM_RASTER_TEXTURE
+    uniform sampler2D TANGRAM_RASTER_TEXTURE;
+#endif
+
 varying vec4 v_position;
 varying vec3 v_normal;
 varying vec4 v_color;
@@ -41,6 +45,12 @@ void main (void) {
 
     // Modify normal before lighting
     #pragma tangram: normal
+
+    // Get color from raster tile texture
+    #ifdef TANGRAM_RASTER_TEXTURE
+        // note: vertex color is multiplied to tint texture color
+        color *= texture2D(TANGRAM_RASTER_TEXTURE, v_texcoord.xy);
+    #endif
 
     // Modify color and material properties before lighting
     #if !defined(TANGRAM_LIGHTING_VERTEX)

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -41,18 +41,26 @@ void main (void) {
     vec4 color = v_color;
     vec3 normal = TANGRAM_NORMAL;
 
+    // Get value from raster tile texture
+    #ifdef TANGRAM_RASTER_TEXTURE
+        vec4 raster = texture2D(u_raster_texture, v_texcoord.xy);
+
+        #ifdef TANGRAM_RASTER_TEXTURE_COLOR
+            // note: vertex color is multiplied to tint texture color
+            color *= raster;
+        #endif
+        #ifdef TANGRAM_RASTER_TEXTURE_NORMAL
+            normal = normalize(raster.rgb * 2. - 1.);
+        #endif
+    #endif
+
+    // Apply normal from material
     #ifdef TANGRAM_MATERIAL_NORMAL_TEXTURE
         calculateNormal(normal);
     #endif
 
     // Modify normal before lighting
     #pragma tangram: normal
-
-    // Get color from raster tile texture
-    #ifdef TANGRAM_RASTER_TEXTURE
-        // note: vertex color is multiplied to tint texture color
-        color *= texture2D(u_raster_texture, v_texcoord.xy);
-    #endif
 
     // Modify color and material properties before lighting
     #if !defined(TANGRAM_LIGHTING_VERTEX)

--- a/src/styles/raster/raster.js
+++ b/src/styles/raster/raster.js
@@ -56,6 +56,11 @@ Object.assign(RasterStyle, {
                 // to avoid flickering while loading (texture will render as black)
                 return WorkerBroker.postMessage(this.main_thread_target+'.loadTextures', { [texture.url]: texture })
                     .then((textures) => {
+                        if (!textures || textures.length < 1) {
+                            // TODO: warning
+                            return tile_data;
+                        }
+
                         // Set texture width/height (returned after loading from main thread)
                         tile_data.uniforms.u_raster_texture_size = textures[0];
                         tile_data.uniforms.u_raster_texture_pixel_size = [1 / textures[0][0], 1 / textures[0][1]];

--- a/src/styles/raster/raster.js
+++ b/src/styles/raster/raster.js
@@ -26,8 +26,14 @@ Object.assign(RasterStyle, {
             WorkerBroker.addTarget(this.main_thread_target, this);
         }
 
-        // Enable raster flag
+        // Enable raster texture and configure how it is applied
         this.defines.TANGRAM_RASTER_TEXTURE = true;
+        if (this.apply == null || this.apply === 'color') { // default to applying as color
+            this.defines.TANGRAM_RASTER_TEXTURE_COLOR = true;
+        }
+        else if (this.apply === 'normal') {
+            this.defines.TANGRAM_RASTER_TEXTURE_NORMAL = true;
+        }
     },
 
     _preprocess (draw) {

--- a/src/styles/raster/raster.js
+++ b/src/styles/raster/raster.js
@@ -68,7 +68,7 @@ Object.assign(RasterStyle, {
         return Texture.createFromObject(this.gl, textures)
             .then(() => {
                 return Promise.all(Object.keys(textures).map(t => {
-                    return Texture.textures[t] && Texture.textures[t].load()
+                    return Texture.textures[t] && Texture.textures[t].load();
                 }).filter(x => x));
             })
             .then(textures => {

--- a/src/styles/raster/raster.js
+++ b/src/styles/raster/raster.js
@@ -66,7 +66,14 @@ Object.assign(RasterStyle, {
     loadTextures (textures) {
         // NB: only return size of textures loaded, because we can't send actual texture objects to worker
         return Texture.createFromObject(this.gl, textures)
-            .then(textures => textures.map(t => [t.width, t.height]));
+            .then(() => {
+                return Promise.all(Object.keys(textures).map(t => {
+                    return Texture.textures[t] && Texture.textures[t].load()
+                }).filter(x => x));
+            })
+            .then(textures => {
+                return textures.map(t => [t.width, t.height]);
+            });
     }
 
 });

--- a/src/styles/raster/raster.js
+++ b/src/styles/raster/raster.js
@@ -83,6 +83,7 @@ Object.assign(RasterStyle, {
                 }).filter(x => x));
             })
             .then(textures => {
+                textures.forEach(t => t.retain());
                 return textures.map(t => [t.width, t.height]);
             });
     }

--- a/src/styles/raster/raster.js
+++ b/src/styles/raster/raster.js
@@ -1,0 +1,66 @@
+// Raster tile rendering style
+
+import Texture from '../../gl/texture';
+import WorkerBroker from '../../utils/worker_broker';
+import Utils from '../../utils/utils';
+import {StyleParser} from '../style_parser';
+import {Polygons} from '../polygons/polygons';
+
+export let RasterStyle = Object.create(Polygons);
+
+Object.assign(RasterStyle, {
+    name: 'raster',
+    super: Polygons,
+    built_in: true,
+    selection: false, // no feature selection by default
+
+    init() {
+        // Enable texture UVs since they're required for raster tiles
+        this.texcoords = true;
+
+        this.super.init.apply(this, arguments);
+
+        // Provide a hook for this object to be called from worker threads
+        this.main_thread_target = 'RasterStyle-' + this.name;
+        if (Utils.isMainThread) {
+            WorkerBroker.addTarget(this.main_thread_target, this);
+        }
+
+        // Enable raster flag
+        this.defines.TANGRAM_RASTER_TEXTURE = 'u_raster_texture';
+    },
+
+    _preprocess (draw) {
+        // Raster tiles default to white vertex color, as this color will tint the underlying texture
+        draw.color = draw.color || StyleParser.defaults.color;
+        return this.super._preprocess.apply(this, arguments);
+    },
+
+    endData (tile) {
+        return this.super.endData.call(this, tile).then(tile_data => {
+            // Add tile texture to mesh
+            let texture = tile.texture; // TODO: call data source to get this directly?
+            if (texture) {
+                tile_data.uniforms = tile_data.uniforms || {};
+                tile_data.uniforms[this.defines.TANGRAM_RASTER_TEXTURE] = texture.url;
+                tile_data.textures = [texture.url]; // assign texture ownership to tile
+
+                // Load textures on main thread and return when done
+                // We want to block the building of a raster tile mesh until its texture is loaded,
+                // to avoid flickering while loading (texture will render as black)
+                return WorkerBroker.postMessage(this.main_thread_target+'.loadTextures', { [texture.url]: texture }).then(() => {
+                    return tile_data;
+                });
+            }
+
+            return tile_data;
+        });
+    },
+
+    // Called on main thread
+    loadTextures (textures) {
+        // NB: only return # of textures loaded, because we can't send actual texture objects to worker
+        return Texture.createFromObject(this.gl, textures).then(textures => textures.length);
+    }
+
+});

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -225,6 +225,7 @@ StyleManager.mix = function (style, styles) {
     style.base = sources.map(x => x.base).filter(x => x).pop();
     style.lighting = sources.map(x => x.lighting).filter(x => x != null).pop();
     style.texture = sources.map(x => x.texture).filter(x => x).pop();
+    style.apply = sources.map(x => x.apply).filter(x => x != null).pop(); // specifies how raster texture is applied
     if (sources.some(x => x.hasOwnProperty('blend') && x.blend)) {
         // only mix blend if explicitly set, otherwise let base style choose blending mode
         // hasOwnProperty check gives preference to base style prototype

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -262,6 +262,7 @@ Object.assign(TextStyle, {
             filtering: 'linear',
             UNPACK_PREMULTIPLY_ALPHA_WEBGL: true
         });
+        Texture.retain(t);
 
         return { texts, texture: t }; // texture is returned by name (not instance)
     },

--- a/src/tile.js
+++ b/src/tile.js
@@ -375,9 +375,8 @@ export default class Tile {
                     this.debug.geometries += meshes[s].geometry_count;
                 }
 
-                // Retain textures
+                // Assign texture ownership to tiles
                 if (mesh_data[s].textures) {
-                    mesh_data[s].textures.forEach(t => Texture.retain(t));
                     textures.push(...mesh_data[s].textures);
                 }
             }
@@ -406,8 +405,8 @@ export default class Tile {
                     for (let t of textures) {
                         let texture = Texture.textures[t];
                         if (texture) {
-                            log.trace(`destroying texture ${t} for tile ${tile.key}`);
-                            texture.destroy();
+                            log.trace(`releasing texture ${t} for tile ${tile.key}`);
+                            texture.release();
                         }
                     }
                 }

--- a/src/tile.js
+++ b/src/tile.js
@@ -121,8 +121,7 @@ export default class Tile {
     }
 
     // Free resources owned by tile
-    // Optionally pass textures to preserve
-    freeResources(preserve = {}) {
+    freeResources () {
         if (this.meshes) {
             for (let m in this.meshes) {
                 this.meshes[m].destroy();
@@ -131,12 +130,7 @@ export default class Tile {
 
         if (this.textures) {
             for (let t of this.textures) {
-                if (!preserve.textures || preserve.textures.indexOf(t) === -1) {
-                    let texture = Texture.textures[t];
-                    if (texture) {
-                        texture.destroy();
-                    }
-                }
+                Texture.release(t);
             }
         }
 
@@ -381,8 +375,9 @@ export default class Tile {
                     this.debug.geometries += meshes[s].geometry_count;
                 }
 
-                // Assign ownership to textures if needed
+                // Retain textures
                 if (mesh_data[s].textures) {
+                    mesh_data[s].textures.forEach(t => Texture.retain(t));
                     textures.push(...mesh_data[s].textures);
                 }
             }
@@ -390,7 +385,7 @@ export default class Tile {
         delete this.mesh_data; // TODO: might want to preserve this for rebuilding geometries when styles/etc. change?
 
         // Swap in new data, free old data
-        this.freeResources({ textures }); // textures to preserve are passed (avoid flickering from delete/re-create)
+        this.freeResources();
         this.meshes = meshes;
         this.textures = textures;
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -295,7 +295,7 @@ export default class Tile {
             Collision.resetTile(tile.key);
 
             // Return keys to be transfered to main thread
-            return ['mesh_data'];
+            return ['mesh_data', 'texture'];
         });
     }
 


### PR DESCRIPTION
Adds support for raster tile rendering, with addition of new data source and built-in styles:

- `Raster` data source type
  - Requires a `url` tile template, in the same manner as other tiled sources.
  - Optionally allows the GL texture `filtering` mode to be set, with the same allowed values (`mipmap`, `linear`, `nearest`) as for other texture definitions in the scene file. Default is `mipmap` for power-of-2 images, and `linear` for non-power-of-2 images (raster tiles are generally power-of-2, though other sizes would be scaled to fit the tile square). Setting `filtering: nearest` allows for the raster tiles to be pixelated when scaled past their `max_zoom`.
  - Optionally defines a `max_zoom` beyond which tiles are over-zoomed. As with other data sources, defaults to `18`.
  - Implementation-wise, the raster source simply synthesizes a single quad geometry covering the entire tile area, and accompanying texture UVs from [0, 1].
  - Example:
   ```
   sources:
       stamen-terrain:
           type: Raster
           url: http://a.tile.stamen.com/terrain-background/{z}/{x}/{y}.jpg
   ```
- `raster` built-in rendering style
  - Raster data sources must be added to a `layer` and `draw` group before they are rendered. This is done with the `raster` style.
  - `order` determines the layer order as with other styles.
  - `color` defaults to white and any other value set by the draw group will *tint* the raster texture. For example, setting `color: [0.5, 0.5, 0.5]` will darken the underlying tiles by 50%.
  - Implementation-wise, the raster style is simply a textured polygon, that automatically samples from the provided raster source for that tile.
  - Example:
   ```
   layers:
       terrain:
           data: { source: stamen-terrain }
           draw:
               raster:
                   order: 0 # draw on bottom
                   color: [0.5, 0.5, 0.5] # darken by 50%
   ```
![tangram-tue feb 16 2016 18-28-13 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/13094787/1d522a10-d4db-11e5-8daa-ae53704dceb1.png)
- Custom raster styles can be defined in `styles` with `base: raster`.
  - The `raster` style is derived from the `polygons` rendering style, and provides the same shader blocks. 
  - Raster-specific uniforms are defined for:
    - `u_raster_texture`: texture sampler (`sampler2D`) for that tile's texture
    - `u_raster_texture_size`: `vec2` of width/height pixel dimensions of the raster texture
    - `u_raster_texture_pixel_size`: `vec2` of UV size of a single pixel in the raster texture, e.g. inverse of width/height or 1/256 for a 256x256 image, for sampling nearby pixels
  - Example style that converts raster tiles to greyscale:
   ```
    greyscale:
        base: raster
        shaders:
            blocks:
                filter: |
                    float luma = dot(color.rgb, vec3(0.299, 0.587, 0.114));
                    color.rgb = vec3(luma);
   ```
![tangram-tue feb 16 2016 18-27-50 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/13094788/20029b0a-d4db-11e5-8145-1b60675bc7a8.png)
  - That example could itself be extended to apply a colorize effect, in this case yellow:
   ```
    colorize:
        mix: greyscale
        shaders:
            uniforms:
                colorize: [0.9, 0.9, 0.2] # yellow
            blocks:
                filter: |
                    color.rgb *= colorize;
   ```
![tangram-tue feb 16 2016 18-28-00 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/13094805/2d487726-d4db-11e5-91ae-d2f4af2f4d4c.png)