### PR TITLE
Proxy tiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,20 +45,21 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "babel": "5.8.29",
     "box-intersect": "1.0.0",
     "csscolorparser": "1.0.2",
     "earcut": "1.2.0",
-    "match-feature": "tangrams/match-feature#v1.0.0",
-    "gl-matrix": "2.2.1",
+    "geojson-vt": "2.1.6",
+    "gl-mat3": "1.0.0",
+    "gl-mat4": "1.1.4",
+    "gl-shader-errors": "1.0.3",
     "js-yaml": "3.4.6",
     "loglevel": "1.2.0",
-    "strip-comments": "0.3.2",
-    "gl-shader-errors": "1.0.3",
+    "match-feature": "tangrams/match-feature#v1.0.0",
     "pbf": "1.3.2",
-    "vector-tile": "1.1.2",
+    "strip-comments": "0.3.2",
     "topojson": "1.6.19",
-    "geojson-vt": "2.1.6",
-    "babel": "5.8.29"
+    "vector-tile": "1.1.2"
   },
   "devDependencies": {
     "babel-runtime": "5.8.29",

--- a/src/camera.js
+++ b/src/camera.js
@@ -53,7 +53,7 @@ export default class Camera {
             if (this.zoom) {
                 view.zoom = this.zoom;
             }
-            this.scene.setView(view);
+            this.scene.view.setView(view);
         }
     }
 
@@ -141,17 +141,17 @@ class PerspectiveCamera extends Camera {
         // TODO: only re-calculate these vars when necessary
 
         // Height of the viewport in meters at current zoom
-        var viewport_height = this.scene.css_size.height * Geo.metersPerPixel(this.scene.zoom);
+        var viewport_height = this.scene.view.css_size.height * Geo.metersPerPixel(this.scene.view.zoom);
 
         // Compute camera properties to fit desired view
         var { height, fov } = this.constrainCamera({
             view_height: viewport_height,
-            focal_length: Utils.interpolate(this.scene.zoom, this.focal_length),
-            fov: Utils.interpolate(this.scene.zoom, this.fov)
+            focal_length: Utils.interpolate(this.scene.view.zoom, this.focal_length),
+            fov: Utils.interpolate(this.scene.view.zoom, this.fov)
          });
 
         // View matrix
-        var position = [this.scene.center_meters.x, this.scene.center_meters.y, height];
+        var position = [this.scene.view.center_meters.x, this.scene.view.center_meters.y, height];
         this.position_meters = position;
 
         // mat4.lookAt(this.viewMatrix,
@@ -165,11 +165,11 @@ class PerspectiveCamera extends Camera {
             vec3.fromValues(0, 1, 0));
 
         // Projection matrix
-        mat4.perspective(this.projectionMatrix, fov, this.scene.view_aspect, 1, height * 2);
+        mat4.perspective(this.projectionMatrix, fov, this.scene.view.view_aspect, 1, height * 2);
 
         // Convert vanishing point from pixels to viewport space
-        this.vanishing_point_skew[0] = this.vanishing_point[0] / this.scene.css_size.width;
-        this.vanishing_point_skew[1] = this.vanishing_point[1] / this.scene.css_size.height;
+        this.vanishing_point_skew[0] = this.vanishing_point[0] / this.scene.view.css_size.width;
+        this.vanishing_point_skew[1] = this.vanishing_point[1] / this.scene.view.css_size.height;
 
         // Adjust projection matrix to include vanishing point skew
         this.projectionMatrix[8] = -this.vanishing_point_skew[0]; // z column of x row, e.g. amount z skews x
@@ -180,7 +180,7 @@ class PerspectiveCamera extends Camera {
         // plane of the map matches that expected by a traditional web mercator map at this [lat, lng, zoom].
         mat4.translate(this.projectionMatrix, this.projectionMatrix,
             vec3.fromValues(
-                viewport_height/2 * this.scene.view_aspect * -this.vanishing_point_skew[0],
+                viewport_height/2 * this.scene.view.view_aspect * -this.vanishing_point_skew[0],
                 viewport_height/2 * -this.vanishing_point_skew[1],
                 0
             )
@@ -245,8 +245,8 @@ class IsometricCamera extends Camera {
     update() {
         super.update();
 
-        this.viewport_height = this.scene.css_size.height * Geo.metersPerPixel(this.scene.zoom);
-        var position = [this.scene.center_meters.x, this.scene.center_meters.y, this.viewport_height];
+        this.viewport_height = this.scene.view.css_size.height * Geo.metersPerPixel(this.scene.view.zoom);
+        var position = [this.scene.view.center_meters.x, this.scene.view.center_meters.y, this.viewport_height];
         this.position_meters = position;
 
         // View
@@ -257,15 +257,15 @@ class IsometricCamera extends Camera {
         mat4.identity(this.projectionMatrix);
 
         // apply isometric skew
-        this.projectionMatrix[8] = this.axis.x / this.scene.view_aspect;    // z column of x row, e.g. amount z skews x
+        this.projectionMatrix[8] = this.axis.x / this.scene.view.view_aspect;    // z column of x row, e.g. amount z skews x
         this.projectionMatrix[9] = this.axis.y;                             // z column of x row, e.g. amount z skews y
 
         // convert meters to viewport
         mat4.scale(this.projectionMatrix, this.projectionMatrix,
             vec3.fromValues(
-                2 / this.scene.viewport_meters.x,
-                2 / this.scene.viewport_meters.y,
-                2 / this.scene.viewport_meters.y
+                2 / this.scene.view.viewport_meters.x,
+                2 / this.scene.view.viewport_meters.y,
+                2 / this.scene.view.viewport_meters.y
             )
         );
     }

--- a/src/camera.js
+++ b/src/camera.js
@@ -1,9 +1,7 @@
 import Utils from './utils/utils';
 import ShaderProgram from './gl/shader_program';
 
-import glMatrix from 'gl-matrix';
-var mat4 = glMatrix.mat4;
-var vec3 = glMatrix.vec3;
+import {mat4, mat3, vec3} from 'gl-matrix';
 
 // Abstract base class
 export default class Camera {
@@ -50,6 +48,19 @@ export default class Camera {
         }
     }
 
+    // Set model-view and normal matrices
+    setMatrices (matrix, program) {
+        // Model view matrix - transform tile space into view space (meters, relative to camera)
+        mat4.multiply(matrix.model_view32, this.view_matrix, matrix.model);
+        program.uniform('Matrix4fv', 'u_modelView', false, matrix.model_view32);
+
+        // Normal matrices - transforms surface normals into view space
+        mat3.normalFromMat4(matrix.normal32, matrix.model_view32);
+        mat3.invert(matrix.inverse_normal32, matrix.normal32);
+        program.uniform('Matrix3fv', 'u_normalMatrix', false, matrix.normal32);
+        program.uniform('Matrix3fv', 'u_inverseNormalMatrix', false, matrix.inverse_normal32);
+    }
+
 }
 
 /**
@@ -86,8 +97,8 @@ class PerspectiveCamera extends Camera {
         this.vanishing_point_skew = [];
 
         this.position_meters = null;
-        this.viewMatrix = new Float64Array(16);
-        this.projectionMatrix = new Float32Array(16);
+        this.view_matrix = new Float64Array(16);
+        this.projection_matrix = new Float32Array(16);
 
         // 'camera' is the name of the shader block, e.g. determines where in the shader this code is injected
         ShaderProgram.replaceBlock('camera', `
@@ -147,31 +158,31 @@ class PerspectiveCamera extends Camera {
         var position = [this.view.center.meters.x, this.view.center.meters.y, height];
         this.position_meters = position;
 
-        // mat4.lookAt(this.viewMatrix,
+        // mat4.lookAt(this.view_matrix,
         //     vec3.fromValues(...position),
         //     vec3.fromValues(position[0], position[1], height - 1),
         //     vec3.fromValues(0, 1, 0));
         // Exclude camera height from view matrix
-        mat4.lookAt(this.viewMatrix,
+        mat4.lookAt(this.view_matrix,
             vec3.fromValues(position[0], position[1], 0),
             vec3.fromValues(position[0], position[1], -1),
             vec3.fromValues(0, 1, 0));
 
         // Projection matrix
-        mat4.perspective(this.projectionMatrix, fov, this.view.aspect, 1, height * 2);
+        mat4.perspective(this.projection_matrix, fov, this.view.aspect, 1, height * 2);
 
         // Convert vanishing point from pixels to viewport space
         this.vanishing_point_skew[0] = this.vanishing_point[0] / this.view.size.css.width;
         this.vanishing_point_skew[1] = this.vanishing_point[1] / this.view.size.css.height;
 
         // Adjust projection matrix to include vanishing point skew
-        this.projectionMatrix[8] = -this.vanishing_point_skew[0]; // z column of x row, e.g. amount z skews x
-        this.projectionMatrix[9] = -this.vanishing_point_skew[1]; // z column of y row, e.g. amount z skews y
+        this.projection_matrix[8] = -this.vanishing_point_skew[0]; // z column of x row, e.g. amount z skews x
+        this.projection_matrix[9] = -this.vanishing_point_skew[1]; // z column of y row, e.g. amount z skews y
 
         // Translate geometry into the distance so that camera is appropriate height above ground
         // Additionally, adjust xy to compensate for any vanishing point skew, e.g. move geometry so that the displayed g
         // plane of the map matches that expected by a traditional web mercator map at this [lat, lng, zoom].
-        mat4.translate(this.projectionMatrix, this.projectionMatrix,
+        mat4.translate(this.projection_matrix, this.projection_matrix,
             vec3.fromValues(
                 viewport_height/2 * this.view.aspect * -this.vanishing_point_skew[0],
                 viewport_height/2 * -this.vanishing_point_skew[1],
@@ -180,7 +191,7 @@ class PerspectiveCamera extends Camera {
         );
 
         // Include camera height in projection matrix
-        mat4.translate(this.projectionMatrix, this.projectionMatrix, vec3.fromValues(0, 0, -height));
+        mat4.translate(this.projection_matrix, this.projection_matrix, vec3.fromValues(0, 0, -height));
     }
 
     update() {
@@ -189,7 +200,7 @@ class PerspectiveCamera extends Camera {
     }
 
     setupProgram(program) {
-        program.uniform('Matrix4fv', 'u_projection', false, this.projectionMatrix);
+        program.uniform('Matrix4fv', 'u_projection', false, this.projection_matrix);
         program.uniform('3f', 'u_eye', 0, 0, this.position_meters[2]);
         program.uniform('2fv', 'u_vanishing_point', this.vanishing_point_skew);
     }
@@ -214,8 +225,8 @@ class IsometricCamera extends Camera {
         this.position_meters = null;
         this.viewport_height = null;
 
-        this.viewMatrix = new Float64Array(16);
-        this.projectionMatrix = new Float32Array(16);
+        this.view_matrix = new Float64Array(16);
+        this.projection_matrix = new Float32Array(16);
 
         // 'camera' is the name of the shader block, e.g. determines where in the shader this code is injected
         ShaderProgram.replaceBlock('camera', `
@@ -243,18 +254,18 @@ class IsometricCamera extends Camera {
         this.position_meters = position;
 
         // View
-        mat4.identity(this.viewMatrix);
-        mat4.translate(this.viewMatrix, this.viewMatrix, vec3.fromValues(-position[0], -position[1], 0));
+        mat4.identity(this.view_matrix);
+        mat4.translate(this.view_matrix, this.view_matrix, vec3.fromValues(-position[0], -position[1], 0));
 
         // Projection
-        mat4.identity(this.projectionMatrix);
+        mat4.identity(this.projection_matrix);
 
         // apply isometric skew
-        this.projectionMatrix[8] = this.axis.x / this.view.aspect; // z column of x row, e.g. amount z skews x
-        this.projectionMatrix[9] = this.axis.y;                    // z column of x row, e.g. amount z skews y
+        this.projection_matrix[8] = this.axis.x / this.view.aspect; // z column of x row, e.g. amount z skews x
+        this.projection_matrix[9] = this.axis.y;                    // z column of x row, e.g. amount z skews y
 
         // convert meters to viewport
-        mat4.scale(this.projectionMatrix, this.projectionMatrix,
+        mat4.scale(this.projection_matrix, this.projection_matrix,
             vec3.fromValues(
                 2 / this.view.size.meters.x,
                 2 / this.view.size.meters.y,
@@ -264,7 +275,7 @@ class IsometricCamera extends Camera {
     }
 
     setupProgram(program) {
-        program.uniform('Matrix4fv', 'u_projection', false, this.projectionMatrix);
+        program.uniform('Matrix4fv', 'u_projection', false, this.projection_matrix);
 
         program.uniform('3f', 'u_eye', 0, 0, this.viewport_height);
         // program.uniform('3f', 'u_eye', this.viewport_height * this.axis.x, this.viewport_height * this.axis.y, this.viewport_height);

--- a/src/camera.js
+++ b/src/camera.js
@@ -1,7 +1,6 @@
 import Utils from './utils/utils';
 import ShaderProgram from './gl/shader_program';
-
-import {mat4, mat3, vec3} from 'gl-matrix';
+import {mat4, mat3, vec3} from './utils/gl-matrix';
 
 // Abstract base class
 export default class Camera {

--- a/src/camera.js
+++ b/src/camera.js
@@ -49,16 +49,16 @@ export default class Camera {
     }
 
     // Set model-view and normal matrices
-    setMatrices (matrix, program) {
+    setupMatrices (matrices, program) {
         // Model view matrix - transform tile space into view space (meters, relative to camera)
-        mat4.multiply(matrix.model_view32, this.view_matrix, matrix.model);
-        program.uniform('Matrix4fv', 'u_modelView', false, matrix.model_view32);
+        mat4.multiply(matrices.model_view32, this.view_matrix, matrices.model);
+        program.uniform('Matrix4fv', 'u_modelView', false, matrices.model_view32);
 
         // Normal matrices - transforms surface normals into view space
-        mat3.normalFromMat4(matrix.normal32, matrix.model_view32);
-        mat3.invert(matrix.inverse_normal32, matrix.normal32);
-        program.uniform('Matrix3fv', 'u_normalMatrix', false, matrix.normal32);
-        program.uniform('Matrix3fv', 'u_inverseNormalMatrix', false, matrix.inverse_normal32);
+        mat3.normalFromMat4(matrices.normal32, matrices.model_view32);
+        mat3.invert(matrices.inverse_normal32, matrices.normal32);
+        program.uniform('Matrix3fv', 'u_normalMatrix', false, matrices.normal32);
+        program.uniform('Matrix3fv', 'u_inverseNormalMatrix', false, matrices.inverse_normal32);
     }
 
 }

--- a/src/camera.js
+++ b/src/camera.js
@@ -1,4 +1,3 @@
-import Geo from './geo';
 import Utils from './utils/utils';
 import ShaderProgram from './gl/shader_program';
 
@@ -135,7 +134,7 @@ class PerspectiveCamera extends Camera {
         // TODO: only re-calculate these vars when necessary
 
         // Height of the viewport in meters at current zoom
-        var viewport_height = this.view.css_size.height * Geo.metersPerPixel(this.view.zoom);
+        var viewport_height = this.view.size.css.height * this.view.meters_per_pixel;
 
         // Compute camera properties to fit desired view
         var { height, fov } = this.constrainCamera({
@@ -145,7 +144,7 @@ class PerspectiveCamera extends Camera {
          });
 
         // View matrix
-        var position = [this.view.center_meters.x, this.view.center_meters.y, height];
+        var position = [this.view.center.meters.x, this.view.center.meters.y, height];
         this.position_meters = position;
 
         // mat4.lookAt(this.viewMatrix,
@@ -159,11 +158,11 @@ class PerspectiveCamera extends Camera {
             vec3.fromValues(0, 1, 0));
 
         // Projection matrix
-        mat4.perspective(this.projectionMatrix, fov, this.view.view_aspect, 1, height * 2);
+        mat4.perspective(this.projectionMatrix, fov, this.view.aspect, 1, height * 2);
 
         // Convert vanishing point from pixels to viewport space
-        this.vanishing_point_skew[0] = this.vanishing_point[0] / this.view.css_size.width;
-        this.vanishing_point_skew[1] = this.vanishing_point[1] / this.view.css_size.height;
+        this.vanishing_point_skew[0] = this.vanishing_point[0] / this.view.size.css.width;
+        this.vanishing_point_skew[1] = this.vanishing_point[1] / this.view.size.css.height;
 
         // Adjust projection matrix to include vanishing point skew
         this.projectionMatrix[8] = -this.vanishing_point_skew[0]; // z column of x row, e.g. amount z skews x
@@ -174,7 +173,7 @@ class PerspectiveCamera extends Camera {
         // plane of the map matches that expected by a traditional web mercator map at this [lat, lng, zoom].
         mat4.translate(this.projectionMatrix, this.projectionMatrix,
             vec3.fromValues(
-                viewport_height/2 * this.view.view_aspect * -this.vanishing_point_skew[0],
+                viewport_height/2 * this.view.aspect * -this.vanishing_point_skew[0],
                 viewport_height/2 * -this.vanishing_point_skew[1],
                 0
             )
@@ -239,8 +238,8 @@ class IsometricCamera extends Camera {
     update() {
         super.update();
 
-        this.viewport_height = this.view.css_size.height * Geo.metersPerPixel(this.view.zoom);
-        var position = [this.view.center_meters.x, this.view.center_meters.y, this.viewport_height];
+        this.viewport_height = this.view.size.css.height * this.view.meters_per_pixel;
+        var position = [this.view.center.meters.x, this.view.center.meters.y, this.viewport_height];
         this.position_meters = position;
 
         // View
@@ -251,15 +250,15 @@ class IsometricCamera extends Camera {
         mat4.identity(this.projectionMatrix);
 
         // apply isometric skew
-        this.projectionMatrix[8] = this.axis.x / this.view.view_aspect;    // z column of x row, e.g. amount z skews x
-        this.projectionMatrix[9] = this.axis.y;                             // z column of x row, e.g. amount z skews y
+        this.projectionMatrix[8] = this.axis.x / this.view.aspect; // z column of x row, e.g. amount z skews x
+        this.projectionMatrix[9] = this.axis.y;                    // z column of x row, e.g. amount z skews y
 
         // convert meters to viewport
         mat4.scale(this.projectionMatrix, this.projectionMatrix,
             vec3.fromValues(
-                2 / this.view.viewport_meters.x,
-                2 / this.view.viewport_meters.y,
-                2 / this.view.viewport_meters.y
+                2 / this.view.size.meters.x,
+                2 / this.view.size.meters.y,
+                2 / this.view.size.meters.y
             )
         );
     }

--- a/src/geo.js
+++ b/src/geo.js
@@ -4,7 +4,8 @@ var Geo;
 export default Geo = {};
 
 // Projection constants
-Geo.default_max_zoom = 18;
+Geo.default_source_max_zoom = 18;
+Geo.default_view_max_zoom = 20;
 Geo.tile_size = 256;
 Geo.half_circumference_meters = 20037508.342789244;
 Geo.circumference_meters = Geo.half_circumference_meters * 2;

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -39,8 +39,8 @@ export default Collision = {
     collide (objects, style, tile) {
         let state = this.tiles[tile];
         if (!state) {
-            log.warn('Collision.collide() called with null tile', tile, this.tiles, Object.keys(this.tiles[tile]).length, style, objects);
-            return;
+            log.trace('Collision.collide() called with null tile', tile, this.tiles, style, objects);
+            return Promise.reject(Error('Collision.collide() called with null tile', tile, this.tiles, style, objects));
         }
 
         // Group by priority and style

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -94,7 +94,7 @@ function extendLeaflet(options) {
 
                     this._updating_tangram = true;
                     var view = map.getCenter();
-                    view.zoom = Math.min(map.getZoom(), map.getMaxZoom() || Geo.default_max_zoom);
+                    view.zoom = Math.min(map.getZoom(), map.getMaxZoom() || Geo.default_view_max_zoom);
 
                     this.scene.setView(view);
                     this.scene.immediateRedraw();
@@ -256,7 +256,7 @@ function extendLeaflet(options) {
 
             updateView: function () {
                 var view = this._map.getCenter();
-                view.zoom = Math.min(this._map.getZoom(), this._map.getMaxZoom() || Geo.default_max_zoom);
+                view.zoom = Math.min(this._map.getZoom(), this._map.getMaxZoom() || Geo.default_view_max_zoom);
                 this.scene.setView(view);
             },
 

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -96,7 +96,7 @@ function extendLeaflet(options) {
                     var view = map.getCenter();
                     view.zoom = Math.min(map.getZoom(), map.getMaxZoom() || Geo.default_view_max_zoom);
 
-                    this.scene.setView(view);
+                    this.scene.view.setView(view);
                     this.scene.immediateRedraw();
                     this.reverseTransform();
                     this._updating_tangram = false;
@@ -109,18 +109,18 @@ function extendLeaflet(options) {
                     }
 
                     this._updating_tangram = true;
-                    this.scene.startZoom();
+                    this.scene.view.startZoom();
                     this._updating_tangram = false;
                 };
                 map.on('zoomstart', this.hooks.zoomstart);
 
                 this.hooks.dragstart = () => {
-                    this.scene.panning = true;
+                    this.scene.view.panning = true;
                 };
                 map.on('dragstart', this.hooks.dragstart);
 
                 this.hooks.dragend = () => {
-                    this.scene.panning = false;
+                    this.scene.view.panning = false;
                 };
                 map.on('dragend', this.hooks.dragend);
 
@@ -204,7 +204,7 @@ function extendLeaflet(options) {
             // Note: this should be deprecated once leaflet continuous zoom is more widely used and the
             // default behavior is presumably improved
             modifyScrollWheelBehavior: function (map) {
-                if (this.scene.continuous_zoom && map.scrollWheelZoom && this.options.modifyScrollWheel !== false) {
+                if (this.scene.view.continuous_zoom && map.scrollWheelZoom && this.options.modifyScrollWheel !== false) {
                     let layer = this;
                     let enabled = map.scrollWheelZoom.enabled();
                     if (enabled) {
@@ -257,7 +257,7 @@ function extendLeaflet(options) {
             updateView: function () {
                 var view = this._map.getCenter();
                 view.zoom = Math.min(this._map.getZoom(), this._map.getMaxZoom() || Geo.default_view_max_zoom);
-                this.scene.setView(view);
+                this.scene.view.setView(view);
             },
 
             updateSize: function () {
@@ -270,7 +270,7 @@ function extendLeaflet(options) {
                     return;
                 }
                 this._updating_tangram = true;
-                this._map.setView([this.scene.center.lat, this.scene.center.lng], this.scene.zoom, { animate: false });
+                this._map.setView([this.scene.view.center.lat, this.scene.view.center.lng], this.scene.view.zoom, { animate: false });
                 this.reverseTransform();
                 this._updating_tangram = false;
             },

--- a/src/light.js
+++ b/src/light.js
@@ -7,9 +7,9 @@ import {StyleParser} from './styles/style_parser';
 // Abstract light
 export default class Light {
 
-    constructor (scene, config) {
+    constructor (view, config) {
         this.name = config.name;
-        this.scene = scene;
+        this.view = view;
 
         if (config.ambient == null || typeof config.ambient === 'number') {
             this.ambient = GLSL.expandVec4(config.ambient || 0);
@@ -35,9 +35,9 @@ export default class Light {
 
     // Create a light by type name, factory-style
     // 'config' must include 'name' and 'type', along with any other type-specific properties
-    static create (scene, config) {
+    static create (view, config) {
         if (Light.types[config.type]) {
-            return new Light.types[config.type](scene, config);
+            return new Light.types[config.type](view, config);
         }
     }
 
@@ -172,8 +172,8 @@ Light.enabled = true; // lighting can be globally enabled/disabled
 // Light subclasses
 class AmbientLight extends Light {
 
-    constructor(scene, config) {
-        super(scene, config);
+    constructor(view, config) {
+        super(view, config);
         this.type = 'ambient';
         this.struct_name = 'AmbientLight';
     }
@@ -192,8 +192,8 @@ Light.types['ambient'] = AmbientLight;
 
 class DirectionalLight extends Light {
 
-    constructor(scene, config) {
-        super(scene, config);
+    constructor(view, config) {
+        super(view, config);
         this.type = 'directional';
         this.struct_name = 'DirectionalLight';
 
@@ -216,8 +216,8 @@ Light.types['directional'] = DirectionalLight;
 
 class PointLight extends Light {
 
-    constructor (scene, config) {
-        super(scene, config);
+    constructor (view, config) {
+        super(view, config);
         this.type = 'point';
         this.struct_name = 'PointLight';
 
@@ -263,23 +263,23 @@ class PointLight extends Light {
 
             // Move light's world position into camera space
             let [x, y] = Geo.latLngToMeters(this.position);
-            this.position_eye[0] = x - this.scene.camera.position_meters[0];
-            this.position_eye[1] = y - this.scene.camera.position_meters[1];
+            this.position_eye[0] = x - this.view.camera.position_meters[0];
+            this.position_eye[1] = y - this.view.camera.position_meters[1];
 
             this.position_eye[2] = StyleParser.convertUnits(this.position[2],
-                { zoom: this.scene.zoom, meters_per_pixel: Geo.metersPerPixel(this.scene.zoom) });
-            this.position_eye[2] = this.position_eye[2] - this.scene.camera.position_meters[2];
+                { zoom: this.view.zoom, meters_per_pixel: Geo.metersPerPixel(this.view.zoom) });
+            this.position_eye[2] = this.position_eye[2] - this.view.camera.position_meters[2];
         }
         if (this.origin === 'ground' || this.origin === 'camera') {
             // For camera or ground origin, format is: [x, y, z] in meters (default) or pixels w/px units
 
             // Light is in camera space by default
             this.position_eye = StyleParser.convertUnits(this.position,
-                { zoom: this.scene.zoom, meters_per_pixel: Geo.metersPerPixel(this.scene.zoom) });
+                { zoom: this.view.zoom, meters_per_pixel: Geo.metersPerPixel(this.view.zoom) });
 
             if (this.origin === 'ground') {
                 // Leave light's xy in camera space, but z needs to be moved relative to ground plane
-                this.position_eye[2] = this.position_eye[2] - this.scene.camera.position_meters[2];
+                this.position_eye[2] = this.position_eye[2] - this.view.camera.position_meters[2];
             }
         }
     }
@@ -297,13 +297,13 @@ class PointLight extends Light {
         if(ShaderProgram.defines['TANGRAM_POINTLIGHT_ATTENUATION_INNER_RADIUS']) {
             _program.uniform('1f', `u_${this.name}.innerRadius`,
                 StyleParser.convertUnits(this.radius[0],
-                    { zoom: this.scene.zoom, meters_per_pixel: Geo.metersPerPixel(this.scene.zoom) }));
+                    { zoom: this.view.zoom, meters_per_pixel: Geo.metersPerPixel(this.view.zoom) }));
         }
 
         if(ShaderProgram.defines['TANGRAM_POINTLIGHT_ATTENUATION_OUTER_RADIUS']) {
             _program.uniform('1f', `u_${this.name}.outerRadius`,
                 StyleParser.convertUnits(this.radius[1],
-                    { zoom: this.scene.zoom, meters_per_pixel: Geo.metersPerPixel(this.scene.zoom) }));
+                    { zoom: this.view.zoom, meters_per_pixel: Geo.metersPerPixel(this.view.zoom) }));
         }
     }
 }
@@ -312,8 +312,8 @@ Light.types['point'] = PointLight;
 
 class SpotLight extends PointLight {
 
-    constructor (scene, config) {
-        super(scene, config);
+    constructor (view, config) {
+        super(view, config);
         this.type = 'spotlight';
         this.struct_name = 'SpotLight';
 

--- a/src/module.js
+++ b/src/module.js
@@ -33,10 +33,6 @@ import Collision from './labels/collision';
 import FeatureSelection from './selection';
 
 import yaml from 'js-yaml';
-import glMatrix from 'gl-matrix';
-
-// Default to 64-bit because we need the extra precision when multiplying matrices w/mercator projected values
-glMatrix.glMatrix.setMatrixArrayType(Float64Array);
 
 // Make some modules accessible for debugging
 var debug = {

--- a/src/module.js
+++ b/src/module.js
@@ -7,7 +7,8 @@ import Utils from './utils/utils';
 import {leafletLayer} from './leaflet_layer';
 
 // The scene worker is only activated when a worker thread is instantiated, but must always be loaded
-import {SceneWorker} from '../src/scene_worker';
+import Scene from './scene';
+import {SceneWorker} from './scene_worker';
 
 // Additional modules are exposed for debugging
 import version from './utils/version';
@@ -51,6 +52,7 @@ var debug = {
     Texture,
     Material,
     Light,
+    Scene,
     SceneWorker,
     WorkerBroker,
     ruleCache,

--- a/src/scene.js
+++ b/src/scene.js
@@ -11,6 +11,7 @@ import {StyleParser} from './styles/style_parser';
 import SceneLoader from './scene_loader';
 import Camera from './camera';
 import Light from './light';
+import Tile from './tile';
 import TileManager from './tile_manager';
 import DataSource from './sources/data_source';
 import FeatureSelection from './selection';
@@ -483,17 +484,13 @@ export default class Scene {
             }
 
             // Discard if too far from current zoom
-            let zdiff = tile.coords.z - style_zoom;
+            let zdiff = tile.style_zoom - style_zoom;
             if (Math.abs(zdiff) > this.preserve_tiles_within_zoom) {
                 return true;
             }
 
             // Handle tiles at different zooms
-            let ztrans = Math.pow(2, zdiff);
-            let coords = {
-                x: Math.floor(tile.coords.x / ztrans),
-                y: Math.floor(tile.coords.y / ztrans)
-            };
+            let coords = Tile.coordinateAtZoom(tile.coords, style_zoom);
 
             // Discard tiles outside an area surrounding the viewport
             if (Math.abs(coords.x - this.center_tile.x) - border_tiles[0] > border_buffer) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -340,26 +340,20 @@ export default class Scene {
         if (Utils.updateDevicePixelRatio()) {
             WorkerBroker.postMessage(this.workers, 'self.updateDevicePixelRatio', Utils.device_pixel_ratio)
                 .then(() => this.rebuild())
-                .then(() => this.resizeMap(this.view.css_size.width, this.view.css_size.height));
+                .then(() => this.resizeMap(this.view.size.css.width, this.view.size.css.height));
         }
     }
 
     resizeMap(width, height) {
         this.dirty = true;
 
-        this.view.css_size = { width: width, height: height };
-        this.view.device_size = {
-            width: Math.round(this.view.css_size.width * Utils.device_pixel_ratio),
-            height: Math.round(this.view.css_size.height * Utils.device_pixel_ratio)
-        };
-        this.view.view_aspect = this.view.css_size.width / this.view.css_size.height;
-        this.view.updateBounds();
+        this.view.setViewportSize(width, height);
 
         if (this.canvas) {
-            this.canvas.style.width = this.view.css_size.width + 'px';
-            this.canvas.style.height = this.view.css_size.height + 'px';
-            this.canvas.width = this.view.device_size.width;
-            this.canvas.height = this.view.device_size.height;
+            this.canvas.style.width = this.view.size.css.width + 'px';
+            this.canvas.style.height = this.view.size.css.height + 'px';
+            this.canvas.width = this.view.size.device.width;
+            this.canvas.height = this.view.size.device.height;
 
             if (this.gl) {
                 this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
@@ -449,12 +443,6 @@ export default class Scene {
 
     render() {
         var gl = this.gl;
-
-        // Map transforms
-        // TODO move to view
-        if (!this.view.center_meters) {
-            return;
-        }
 
         // Update styles, camera, lights
         this.camera.update();
@@ -692,8 +680,8 @@ export default class Scene {
 
         // Point scaled to [0..1] range
         var point = {
-            x: pixel.x * Utils.device_pixel_ratio / this.view.device_size.width,
-            y: pixel.y * Utils.device_pixel_ratio / this.view.device_size.height
+            x: pixel.x * Utils.device_pixel_ratio / this.view.size.device.width,
+            y: pixel.y * Utils.device_pixel_ratio / this.view.size.device.height
         };
 
         this.dirty = true; // need to make sure the scene re-renders for these to be processed

--- a/src/scene.js
+++ b/src/scene.js
@@ -474,7 +474,7 @@ export default class Scene {
 
         this.tile_manager.removeTiles(tile => {
             // Ignore visible tiles
-            if (tile.visible) {
+            if (tile.visible || tile.proxy) {
                 return false;
             }
 
@@ -576,8 +576,6 @@ export default class Scene {
     }
 
     update() {
-        this.tile_manager.loadQueuedCoordinates();
-
         // Render on demand
         var will_render = !(
             this.dirty === false ||

--- a/src/scene.js
+++ b/src/scene.js
@@ -947,10 +947,10 @@ export default class Scene {
     createCamera() {
         let active_camera = this._active_camera;
         if (active_camera) {
-            this.camera = Camera.create(active_camera, this, this.config.cameras[this._active_camera]);
+            this.camera = Camera.create(active_camera, this.view, this.config.cameras[this._active_camera]);
 
             // TODO: replace this and move all position info to camera
-            this.camera.updateScene();
+            this.camera.updateView();
         }
     }
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -458,7 +458,7 @@ export default class Scene {
         let coords = [];
         for (let x = sw.x - buffer; x <= ne.x + buffer; x++) {
             for (let y = ne.y - buffer; y <= sw.y + buffer; y++) {
-                coords.push({ x, y, z });
+                coords.push(Tile.coord({ x, y, z }));
             }
         }
         return coords;

--- a/src/scene.js
+++ b/src/scene.js
@@ -85,6 +85,7 @@ export default class Scene {
         this.center = null;
 
         this.zooming = false;
+        this.zoom_direction = 0;
         this.preserve_tiles_within_zoom = 1;
         this.panning = false;
         this.container = options.container;
@@ -375,7 +376,8 @@ export default class Scene {
             zoom = tile_zoom;
         }
 
-        if (tile_zoom !== this.tileZoom(this.last_zoom)) {
+        let last_tile_zoom = this.tileZoom(this.last_zoom);
+        if (tile_zoom !== last_tile_zoom) {
             // Remove tiles outside current zoom that are still loading
             this.tile_manager.removeTiles(tile => {
                 if (tile.loading && this.tileZoom(tile.coords.z) !== tile_zoom) {
@@ -383,6 +385,8 @@ export default class Scene {
                     return true;
                 }
             });
+
+            this.zoom_direction = tile_zoom > last_tile_zoom ? 1 : -1;
         }
 
         this.last_zoom = this.zoom;

--- a/src/scene.js
+++ b/src/scene.js
@@ -921,8 +921,6 @@ export default class Scene {
         let active_camera = this._active_camera;
         if (active_camera) {
             this.camera = Camera.create(active_camera, this.view, this.config.cameras[this._active_camera]);
-
-            // TODO: replace this and move all position info to camera
             this.camera.updateView();
         }
     }

--- a/src/scene.js
+++ b/src/scene.js
@@ -1214,19 +1214,26 @@ export default class Scene {
         this.loadDataSources();
         this.loadTextures();
         this.setBackground();
-        this.updateBounds();
 
         // TODO: detect changes to styles? already (currently) need to recompile anyway when camera or lights change
         this.updateStyles();
         this.syncConfigToWorker();
+
+        // Optionally rebuild geometry
+        let done;
         if (rebuild) {
-            return this.rebuildGeometry().then(() => { this.updating--; this.requestRedraw(); });
+            done = this.rebuildGeometry();
         }
         else {
-            this.updating--;
-            this.requestRedraw();
-            return Promise.resolve();
+            done = Promise.resolve();
         }
+
+        // Finish by updating bounds and re-rendering
+        return done.then(() => {
+            this.updating--;
+            this.updateBounds();
+            this.requestRedraw();
+        });
     }
 
     // Serialize config and send to worker

--- a/src/scene.js
+++ b/src/scene.js
@@ -912,7 +912,7 @@ export default class Scene {
             light.name = i.replace('-', '_'); // light names are injected in shaders, can't have hyphens
             light.visible = (light.visible === false) ? false : true;
             if (light.visible) {
-                this.lights[light.name] = Light.create(this, light);
+                this.lights[light.name] = Light.create(this.view, light);
             }
         }
         Light.inject(this.lights);

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,4 +1,3 @@
-import Geo from './geo';
 import Utils from './utils/utils';
 import WorkerBroker from './utils/worker_broker';
 import subscribeMixin from './utils/subscribe';
@@ -11,11 +10,12 @@ import {StyleParser} from './styles/style_parser';
 import SceneLoader from './scene_loader';
 import View from './view';
 import Light from './light';
-import Tile from './tile';
 import TileManager from './tile_manager';
 import DataSource from './sources/data_source';
 import FeatureSelection from './selection';
 import RenderState from './gl/render_state';
+
+import log from 'loglevel';
 
 import {Polygons} from './styles/polygons/polygons';
 import {Lines} from './styles/lines/lines';
@@ -27,8 +27,6 @@ StyleManager.register(Polygons);
 StyleManager.register(Lines);
 StyleManager.register(Points);
 StyleManager.register(TextStyle);
-
-import log from 'loglevel';
 
 // Load scene definition: pass an object directly, or a URL as string to load remotely
 export default class Scene {

--- a/src/scene.js
+++ b/src/scene.js
@@ -370,7 +370,13 @@ export default class Scene {
     }
 
     setZoom(zoom) {
-        this.zooming = false;
+        if (this.zooming) {
+            this.zooming = false;
+        }
+        else {
+            this.last_zoom = this.zoom;
+        }
+
         let tile_zoom = this.tileZoom(zoom);
 
         if (!this.continuous_zoom) {
@@ -485,8 +491,8 @@ export default class Scene {
             }
 
             // Discard if too far from current zoom
-            let zdiff = tile.style_zoom - style_zoom;
-            if (Math.abs(zdiff) > this.preserve_tiles_within_zoom) {
+            let zdiff = Math.abs(tile.style_zoom - style_zoom);
+            if (zdiff > this.preserve_tiles_within_zoom) {
                 return true;
             }
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -118,6 +118,10 @@ export default class Scene {
         log.setLevel(this.logLevel);
     }
 
+    static create (config, options = {}) {
+        return new Scene(config, options);
+    }
+
     // Load (or reload) scene config
     // Optionally specify new scene file URL
     load(config_source = null, config_path = null) {
@@ -1416,9 +1420,3 @@ export default class Scene {
     }
 
 }
-
-// Static methods/state
-
-Scene.create = function (config, options = {}) {
-    return new Scene(config, options);
-};

--- a/src/scene.js
+++ b/src/scene.js
@@ -144,8 +144,8 @@ export default class Scene {
                     Texture.subscribe(this.texture_listener);
                 }
 
-                // Remove tiles before rebuilding
-                this.tile_manager.removeTiles(tile => !tile.visible);
+                // Reset tile manager visibility before rebuilding
+                this.tile_manager.resetVisibleTiles();
                 return this.updateConfig({ rebuild: true });
             }).then(() => {
                 this.updating--;
@@ -445,6 +445,7 @@ export default class Scene {
         this.dirty = true;
     }
 
+    // TODO: move to a new view manager object
     findVisibleTileCoordinates({ buffer } = {}) {
         if (!this.bounds_meters) {
             return [];

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -177,7 +177,13 @@ Object.assign(self, {
 
     // Load this tile's data source
     loadTileSourceData (tile) {
-        return self.sources.tiles[tile.source].load(tile);
+        if (self.sources.tiles[tile.source]) {
+            return self.sources.tiles[tile.source].load(tile);
+        }
+        else {
+            tile.source_data = { error: `Data source '${tile.source}' not found` };
+            return Promise.resolve(tile);
+        }
     },
 
     // Remove tile

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -37,7 +37,7 @@ export default class DataSource {
         }
 
         // overzoom will apply for zooms higher than this
-        this.max_zoom = config.max_zoom || Geo.default_max_zoom;
+        this.max_zoom = config.max_zoom || Geo.default_source_max_zoom;
     }
 
     // Create a tile source by type, factory-style

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -1,7 +1,7 @@
 uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
-uniform vec3 u_tile_origin;
+uniform vec4 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -62,6 +62,14 @@ void main (void) {
     #endif
 
     #pragma tangram: color
+
+    // Fade out when tile is zooming out, e.g. acting as proxy tiles
+    // NB: this is mostly done to compensate for text label collision happening at the label's 1x zoom. As labels
+    // in proxy tiles are scaled down, they begin to overlap, and the fade is a simple way to ease the transition.
+    #ifdef TANGRAM_FADE_ON_ZOOM_OUT
+        color.a *= clamp(0., 1., 1. - TANGRAM_FADE_ON_ZOOM_OUT_RATE * (u_tile_origin.z - u_map_position.z));
+    #endif
+
     #pragma tangram: filter
 
     gl_FragColor = color;

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -1,7 +1,7 @@
 uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
-uniform vec3 u_tile_origin;
+uniform vec4 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -63,7 +63,8 @@ void main() {
     cameraProjection(position);
 
     #ifdef TANGRAM_LAYER_ORDER
-        applyLayerOrder(SHORT(a_position.w), position);
+        // w coordinates hold feature layer, and additional proxy offset (set to 0 for non-proxy tiles)
+        applyLayerOrder(SHORT(a_position.w) + u_tile_origin.w, position);
     #endif
 
     // Apply pixel offset in screen-space

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -1,7 +1,7 @@
 uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
-uniform vec3 u_tile_origin;
+uniform vec4 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -31,7 +31,7 @@ varying vec4 v_world_position;
 void main (void) {
     // Initialize globals
     #pragma tangram: setup
-    
+
     vec4 color = v_color;
     vec3 normal = TANGRAM_NORMAL;
 

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -1,7 +1,7 @@
 uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
-uniform vec3 u_tile_origin;
+uniform vec4 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -110,7 +110,9 @@ void main() {
 
     // Camera
     cameraProjection(position);
-    applyLayerOrder(SHORT(a_position.w), position);
+
+    // w coordinates hold feature layer, and additional proxy offset (set to 0 for non-proxy tiles)
+    applyLayerOrder(SHORT(a_position.w) + u_tile_origin.w, position);
 
     gl_Position = position;
 }

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -39,6 +39,10 @@ Object.assign(TextStyle, {
         // Manually un-multiply alpha, because Canvas text rasterization is pre-multiplied
         this.defines.TANGRAM_UNMULTIPLY_ALPHA = true;
 
+        // Fade out text when tile is zooming out, e.g. acting as proxy tiles
+        this.defines.TANGRAM_FADE_ON_ZOOM_OUT = true;
+        this.defines.TANGRAM_FADE_ON_ZOOM_OUT_RATE = 2; // fade at 2x, e.g. fully transparent at 0.5 zoom level away
+
         this.reset();
     },
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -408,12 +408,12 @@ export default class Tile {
         log.debug(`Tile: debug for ${this.key}: [  ${JSON.stringify(this.debug)} ]`);
     }
 
-    update(scene) {
+    update(view) {
         let coords = this.coords;
-        if (coords.z !== scene.center_tile.z) {
-            coords = Tile.coordinateAtZoom(coords, scene.center_tile.z);
+        if (coords.z !== view.center_tile.z) {
+            coords = Tile.coordinateAtZoom(coords, view.center_tile.z);
         }
-        this.center_dist = Math.abs(scene.center_tile.x - coords.x) + Math.abs(scene.center_tile.y - coords.y);
+        this.center_dist = Math.abs(view.center_tile.x - coords.x) + Math.abs(view.center_tile.y - coords.y);
     }
 
     // Slice a subset of keys out of a tile

--- a/src/tile.js
+++ b/src/tile.js
@@ -5,7 +5,7 @@ import Collision from './labels/collision';
 import WorkerBroker from './utils/worker_broker';
 import Texture from './gl/texture';
 
-import {mat4, vec3} from 'gl-matrix';
+import {mat4, vec3} from './utils/gl-matrix';
 import log from 'loglevel';
 
 export default class Tile {

--- a/src/tile.js
+++ b/src/tile.js
@@ -38,8 +38,6 @@ export default class Tile {
         this.style_zoom = style_zoom; // zoom level to be used for styling
 
         this.coords = Tile.coordinateWithMaxZoom(coords, this.source.max_zoom);
-        this.parent = this.coords.z && Tile.coordinateAtZoom(this.coords, this.coords.z - 1);
-        this.children = Tile.childrenForCoordinate(this.coords);
         this.key = Tile.key(this.coords, this.source, this.style_zoom);
         this.min = Geo.metersForTile(this.coords);
         this.max = Geo.metersForTile({x: this.coords.x + 1, y: this.coords.y + 1, z: this.coords.z }),

--- a/src/tile.js
+++ b/src/tile.js
@@ -37,8 +37,7 @@ export default class Tile {
         this.source = source;
         this.style_zoom = style_zoom; // zoom level to be used for styling
 
-        this.coords = coords;
-        this.coords = Tile.overZoomedCoordinate(this.coords, this.source.max_zoom);
+        this.coords = Tile.coordinateWithMaxZoom(coords, this.source.max_zoom);
         this.coord_key = Tile.coordKey(this.coords);
         this.parent = this.coords.z && Tile.coordinateAtZoom(this.coords, this.coords.z - 1);
         this.children = Tile.childrenForCoordinate(this.coords);
@@ -70,7 +69,7 @@ export default class Tile {
     }
 
     static key (coords, source, style_zoom) {
-        coords = Tile.overZoomedCoordinate(coords, source.max_zoom);
+        coords = Tile.coordinateWithMaxZoom(coords, source.max_zoom);
         if (coords.y < 0 || coords.y >= (1 << coords.z) || coords.z < 0) {
             return; // cull tiles out of range (x will wrap)
         }
@@ -94,7 +93,7 @@ export default class Tile {
         return false;
     }
 
-    static overZoomedCoordinate({x, y, z}, max_zoom) {
+    static coordinateWithMaxZoom({x, y, z}, max_zoom) {
         if (max_zoom !== undefined && z > max_zoom) {
             return Tile.coordinateAtZoom({x, y, z}, max_zoom);
         }

--- a/src/tile.js
+++ b/src/tile.js
@@ -41,6 +41,7 @@ export default class Tile {
         this.coords = Tile.overZoomedCoordinate(this.coords, this.source.max_zoom);
         this.coord_key = Tile.coordKey(this.coords);
         this.parent = this.coords.z && Tile.coordinateAtZoom(this.coords, this.coords.z - 1);
+        this.children = Tile.childrenForCoordinate(this.coords);
         this.key = Tile.key(this.coords, this.source, this.style_zoom);
         this.min = Geo.metersForTile(this.coords);
         this.max = Geo.metersForTile({x: this.coords.x + 1, y: this.coords.y + 1, z: this.coords.z }),
@@ -98,6 +99,16 @@ export default class Tile {
             return Tile.coordinateAtZoom({x, y, z}, max_zoom);
         }
         return {x, y, z};
+    }
+
+    static childrenForCoordinate({x, y, z}) {
+        z++;
+        x *= 2;
+        y *= 2;
+        return [
+            {x, y,      z}, {x: x+1, y,      z},
+            {x, y: y+1, z}, {x: x+1, y: y+1, z}
+        ];
     }
 
     // Sort a set of tile instances (which already have a distance from center tile computed)

--- a/src/tile.js
+++ b/src/tile.js
@@ -103,9 +103,9 @@ export default class Tile {
         return Tile.coord_children[key];
     }
 
-    static isChild(parent, child) {
-        if (child.z > parent.z) {
-            let {x, y} = Tile.coordinateAtZoom(child, parent.z);
+    static isDescendant(parent, descendant) {
+        if (descendant.z > parent.z) {
+            let {x, y} = Tile.coordinateAtZoom(descendant, parent.z);
             return (parent.x === x && parent.y === y);
         }
         return false;

--- a/src/tile.js
+++ b/src/tile.js
@@ -96,14 +96,17 @@ export default class Tile {
         return Tile.coord({x, y, z});
     }
 
-    static childrenForCoordinate({x, y, z}) {
-        z++;
-        x *= 2;
-        y *= 2;
-        return [
-            Tile.coord({x, y,      z}), Tile.coord({x: x+1, y,      z}),
-            Tile.coord({x, y: y+1, z}), Tile.coord({x: x+1, y: y+1, z})
-        ];
+    static childrenForCoordinate({x, y, z, key}) {
+        if (!Tile.coord_children[key]) {
+            z++;
+            x *= 2;
+            y *= 2;
+            Tile.coord_children[key] = [
+                Tile.coord({x, y,      z}), Tile.coord({x: x+1, y,      z}),
+                Tile.coord({x, y: y+1, z}), Tile.coord({x: x+1, y: y+1, z})
+            ];
+        }
+        return Tile.coord_children[key];
     }
 
     static isChild(parent, child) {
@@ -466,3 +469,5 @@ export default class Tile {
     }
 
 }
+
+Tile.coord_children = {}; // only allocate children coordinates once per coordinate

--- a/src/tile.js
+++ b/src/tile.js
@@ -18,33 +18,26 @@ export default class Tile {
         worker: web worker to handle tile construction
     */
     constructor({ coords, style_zoom, source, worker, view }) {
-        Object.assign(this, {
-            coords: {
-                x: null,
-                y: null,
-                z: null
-            },
-            debug: {},
-            loading: false,
-            loaded: false,
-            error: null,
-            worker: null,
-            generation: null,
-            visible: false,
-            center_dist: 0
-        });
-
         this.worker = worker;
         this.view = view;
         this.source = source;
-        this.style_zoom = style_zoom; // zoom level to be used for styling
+        this.generation = null;
+
+        this.visible = false;
+        this.proxy = null;
+        this.loading = false;
+        this.loaded = false;
+        this.error = null;
+        this.debug = {};
 
         this.coords = Tile.coordinateWithMaxZoom(coords, this.source.max_zoom);
+        this.style_zoom = style_zoom; // zoom level to be used for styling
         this.key = Tile.key(this.coords, this.source, this.style_zoom);
         this.min = Geo.metersForTile(this.coords);
         this.max = Geo.metersForTile({x: this.coords.x + 1, y: this.coords.y + 1, z: this.coords.z }),
         this.span = { x: (this.max.x - this.min.x), y: (this.max.y - this.min.y) };
         this.bounds = { sw: { x: this.min.x, y: this.max.y }, ne: { x: this.max.x, y: this.min.y } };
+        this.center_dist = 0;
 
         // Units per pixel needs to account for over-zooming
         this.units_per_pixel = Geo.units_per_pixel;

--- a/src/tile.js
+++ b/src/tile.js
@@ -40,6 +40,7 @@ export default class Tile {
         this.coords = coords;
         this.coords = Tile.overZoomedCoordinate(this.coords, this.source.max_zoom);
         this.coord_key = Tile.coordKey(this.coords);
+        this.parent = this.coords.z && Tile.coordinateAtZoom(this.coords, this.coords.z - 1);
         this.key = Tile.key(this.coords, this.source, this.style_zoom);
         this.min = Geo.metersForTile(this.coords);
         this.max = Geo.metersForTile({x: this.coords.x + 1, y: this.coords.y + 1, z: this.coords.z }),
@@ -140,6 +141,7 @@ export default class Tile {
             coord_key: this.coord_key,
             source: this.source.name,
             coords: this.coords,
+            parent: this.parent,
             min: this.min,
             max: this.max,
             units_per_pixel: this.units_per_pixel,

--- a/src/tile.js
+++ b/src/tile.js
@@ -384,16 +384,16 @@ export default class Tile {
     }
 
     // Update model matrix and tile uniforms
-    setupProgram (matrix, program) {
+    setupProgram ({ model, model32 }, program) {
         // Tile origin
         program.uniform('3f', 'u_tile_origin', this.min.x, this.min.y, this.style_zoom);
 
-        // Model matrix - transform tile space into world space (meters, absolute mercator position)
-        mat4.identity(matrix.model);
-        mat4.translate(matrix.model, matrix.model, vec3.fromValues(this.min.x, this.min.y, 0));
-        mat4.scale(matrix.model, matrix.model, vec3.fromValues(this.span.x / Geo.tile_scale, -1 * this.span.y / Geo.tile_scale, 1)); // scale tile local coords to meters
-        mat4.copy(matrix.model32, matrix.model);
-        program.uniform('Matrix4fv', 'u_model', false, matrix.model32);
+        // Model - transform tile space into world space (meters, absolute mercator position)
+        mat4.identity(model);
+        mat4.translate(model, model, vec3.fromValues(this.min.x, this.min.y, 0));
+        mat4.scale(model, model, vec3.fromValues(this.span.x / Geo.tile_scale, -1 * this.span.y / Geo.tile_scale, 1)); // scale tile local coords to meters
+        mat4.copy(model32, model);
+        program.uniform('Matrix4fv', 'u_model', false, model32);
     }
 
     /**

--- a/src/tile.js
+++ b/src/tile.js
@@ -410,10 +410,10 @@ export default class Tile {
 
     update(view) {
         let coords = this.coords;
-        if (coords.z !== view.center_tile.z) {
-            coords = Tile.coordinateAtZoom(coords, view.center_tile.z);
+        if (coords.z !== view.center.tile.z) {
+            coords = Tile.coordinateAtZoom(coords, view.center.tile.z);
         }
-        this.center_dist = Math.abs(view.center_tile.x - coords.x) + Math.abs(view.center_tile.y - coords.y);
+        this.center_dist = Math.abs(view.center.tile.x - coords.x) + Math.abs(view.center.tile.y - coords.y);
     }
 
     // Slice a subset of keys out of a tile

--- a/src/tile.js
+++ b/src/tile.js
@@ -25,6 +25,7 @@ export default class Tile {
 
         this.visible = false;
         this.proxy = null;
+        this.proxy_depth = 0;
         this.loading = false;
         this.loaded = false;
         this.error = null;
@@ -433,14 +434,18 @@ export default class Tile {
         this.proxy = tile;
         if (tile) {
             this.visible = true;
+            this.proxy_depth = Math.abs(this.style_zoom - this.proxy.style_zoom); // draw all proxies behind
             this.update();
+        }
+        else {
+            this.proxy_depth = 0;
         }
     }
 
     // Update model matrix and tile uniforms
     setupProgram ({ model, model32 }, program) {
         // Tile origin
-        program.uniform('3f', 'u_tile_origin', this.min.x, this.min.y, this.style_zoom);
+        program.uniform('4f', 'u_tile_origin', this.min.x, this.min.y, this.style_zoom, this.proxy_depth);
 
         // Model - transform tile space into world space (meters, absolute mercator position)
         mat4.identity(model);

--- a/src/tile.js
+++ b/src/tile.js
@@ -155,7 +155,6 @@ export default class Tile {
             key: this.key,
             source: this.source.name,
             coords: this.coords,
-            parent: this.parent,
             min: this.min,
             max: this.max,
             units_per_pixel: this.units_per_pixel,

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -252,7 +252,7 @@ const TileManager = {
                     source,
                     coords,
                     worker: this.scene.nextWorker(),
-                    style_zoom: this.view.styleZoom(coords.z) // TODO: replace?
+                    style_zoom: this.view.styleZoom(coords.z)
                 });
 
                 this.keepTile(tile);

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -25,7 +25,7 @@ const TileManager = {
         this.visible_coords = {};
         this.queued_coords = [];
         this.scene = null;
-        // this.view
+        this.view = null;
     },
 
     keepTile(tile) {
@@ -225,8 +225,8 @@ const TileManager = {
 
         // Sort queued tiles from center tile
         this.queued_coords.sort((a, b) => {
-            let ad = Math.abs(this.view.center_tile.x - a.x) + Math.abs(this.view.center_tile.y - a.y);
-            let bd = Math.abs(this.view.center_tile.x - b.x) + Math.abs(this.view.center_tile.y - b.y);
+            let ad = Math.abs(this.view.center.tile.x - a.x) + Math.abs(this.view.center.tile.y - a.y);
+            let bd = Math.abs(this.view.center.tile.x - b.x) + Math.abs(this.view.center.tile.y - b.y);
             return (bd > ad ? -1 : (bd === ad ? 0 : 1));
         });
         this.queued_coords.forEach(coords => this.loadCoordinate(coords));
@@ -236,7 +236,7 @@ const TileManager = {
     // Load all tiles to cover a given logical tile coordinate
     loadCoordinate(coords) {
         // Skip if not at current scene zoom
-        if (coords.z !== this.view.center_tile.z) {
+        if (coords.z !== this.view.center.tile.z) {
             return;
         }
 

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -40,6 +40,9 @@ export default TileManager = {
             let tile = this.tiles[key];
             if (this.coord_tiles[tile.coords.key]) {
                 this.coord_tiles[tile.coords.key].delete(tile);
+                if (this.coord_tiles[tile.coords.key].size === 0) {
+                    delete this.coord_tiles[tile.coords.key];
+                }
             }
         }
 

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -135,7 +135,7 @@ const TileManager = {
         }
 
         // Clear previous proxies
-        this.forEachTile(tile => tile.proxy = false);
+        this.forEachTile(tile => tile.setProxyFor(null));
 
         let proxy = false;
         this.forEachTile(tile => {
@@ -143,10 +143,8 @@ const TileManager = {
                 if (tile.visible && tile.loading && tile.coords.z > 0) {
                     let p = this.pyramid.getAncestor(tile);
                     if (p) {
+                        p.setProxyFor(tile);
                         proxy = true;
-                        p.proxy = true;
-                        p.visible = true;
-                        p.update();
                     }
                 }
             }
@@ -154,10 +152,8 @@ const TileManager = {
                 if (tile.visible && tile.loading) {
                     let d = this.pyramid.getDescendants(tile);
                     for (let t of d) {
+                        t.setProxyFor(tile);
                         proxy = true;
-                        t.proxy = true;
-                        t.visible = true;
-                        t.update();
                     }
                 }
             }

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -1,4 +1,5 @@
 import Tile from './tile';
+import Geo from './geo';
 import Utils from './utils/utils';
 
 import log from 'loglevel';
@@ -167,8 +168,8 @@ export default TileManager = {
         // First check overzoomed tiles at same coordinate zoom
         if (style_zoom >= source.max_zoom) {
             if (this.coord_tiles[coord.key]) {
-                // TODO: don't hardcode max view zoom
-                for (let z = style_zoom + 1; z <= 20; z++) {
+                let search_max_zoom = Math.max(Geo.default_view_max_zoom, style_zoom + this.max_proxy_descendant_depth);
+                for (let z = style_zoom + 1; z <= search_max_zoom; z++) {
                     for (let descendant of this.coord_tiles[coord.key]) {
                         if (descendant.style_zoom === z && descendant.source.name === source.name) {
                             descendants.push(descendant);

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -99,6 +99,11 @@ export default TileManager = {
                     proxyable.push(Tile.coordKey(tile.parent));
                 }
             }
+            else if (this.scene.zoom_direction === -1) {
+                if (tile.visible && tile.loading && tile.children) {
+                    proxyable.push(...tile.children.map(Tile.coordKey));
+                }
+            }
         });
 
         if (proxyable.length > 0) {

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -94,8 +94,10 @@ export default TileManager = {
     updateProxyTiles () {
         let proxyable = [];
         this.forEachTile(tile => {
-            if (tile.visible && tile.loading && tile.parent) {
-                proxyable.push(Tile.coordKey(tile.parent));
+            if (this.scene.zoom_direction === 1) {
+                if (tile.visible && tile.loading && tile.parent) {
+                    proxyable.push(Tile.coordKey(tile.parent));
+                }
             }
         });
 

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -27,8 +27,8 @@ export default TileManager = {
 
     keepTile(tile) {
         this.tiles[tile.key] = tile;
-        this.coord_tiles[tile.coord_key] = this.coord_tiles[tile.coord_key] || new Set();
-        this.coord_tiles[tile.coord_key].add(tile);
+        this.coord_tiles[tile.coords.key] = this.coord_tiles[tile.coords.key] || new Set();
+        this.coord_tiles[tile.coords.key].add(tile);
     },
 
     hasTile(key) {
@@ -38,8 +38,8 @@ export default TileManager = {
     forgetTile(key) {
         if (this.hasTile(key)) {
             let tile = this.tiles[key];
-            if (this.coord_tiles[tile.coord_key]) {
-                this.coord_tiles[tile.coord_key].delete(tile);
+            if (this.coord_tiles[tile.coords.key]) {
+                this.coord_tiles[tile.coords.key].delete(tile);
             }
         }
 
@@ -89,7 +89,7 @@ export default TileManager = {
         let tile_coords = this.scene.findVisibleTileCoordinates();
         for (let coords of tile_coords) {
             this.queueCoordinate(coords);
-            this.visible_coords[Tile.coordKey(coords)] = coords;
+            this.visible_coords[coords.key] = coords;
         }
 
         this.forEachTile(tile => {
@@ -103,14 +103,11 @@ export default TileManager = {
     },
 
     getAncestorTile (coord, source, style_zoom) {
-        let key;
-
         // First check overzoomed tiles at same coordinate zoom
         if (style_zoom > coord.z) {
-            key = Tile.coordKey(coord);
-            if (this.coord_tiles[key]) {
+            if (this.coord_tiles[coord.key]) {
                 for (let z = style_zoom - 1; z >= coord.z; z--) {
-                    for (let ancestor of this.coord_tiles[key]) {
+                    for (let ancestor of this.coord_tiles[coord.key]) {
                         if (ancestor.style_zoom === z && ancestor.source.name === source.name) {
                             return ancestor;
                         }
@@ -120,9 +117,9 @@ export default TileManager = {
         }
 
         // Check tiles at next zoom up
-        key = Tile.coordKey(Tile.coordinateAtZoom(coord, coord.z - 1));
-        if (this.coord_tiles[key]) {
-            for (let ancestor of this.coord_tiles[key]) {
+        let parent = Tile.coordinateAtZoom(coord, coord.z - 1);
+        if (this.coord_tiles[parent.key]) {
+            for (let ancestor of this.coord_tiles[parent.key]) {
                 if (ancestor.source.name === source.name) {
                     return ancestor; // found ancestor
                 }
@@ -136,8 +133,6 @@ export default TileManager = {
     },
 
     getDescendantTiles (coord, source, style_zoom, level = 0) {
-        let key;
-
         // First check overzoomed tiles at same coordinate zoom
         // TODO
 
@@ -145,9 +140,8 @@ export default TileManager = {
         let descendants = [];
         for (let child of Tile.childrenForCoordinate(coord)) {
             let found = false;
-            key = Tile.coordKey(child);
-            if (this.coord_tiles[key]) {
-                for (let descendant of this.coord_tiles[key]) {
+            if (this.coord_tiles[child.key]) {
+                for (let descendant of this.coord_tiles[child.key]) {
                     if (descendant.source.name === source.name) {
                         descendants.push(descendant);
                         found = true;
@@ -212,7 +206,7 @@ export default TileManager = {
             return;
         }
 
-        if (this.visible_coords[tile.coord_key]) {
+        if (this.visible_coords[tile.coords.key]) {
             tile.visible = true;
         }
         else {

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -15,6 +15,7 @@ export default TileManager = {
         this.queued_coords = [];
         this.building_tiles = null;
         this.reset_visible_tiles = true;
+        this.max_proxy_descendant_depth = 3; // # of levels deep to search for descendant proxy tiles
     },
 
     destroy() {
@@ -160,7 +161,7 @@ export default TileManager = {
         }
     },
 
-    getDescendantTiles (coord, source, style_zoom, level = 0) {
+    getDescendantTiles (coord, source, style_zoom, level = 1) {
         // First check overzoomed tiles at same coordinate zoom
         // TODO
 
@@ -180,7 +181,7 @@ export default TileManager = {
 
             // didn't find child, try next level
             // TODO: fix for true max view zoom
-            if (!found && level < 3) { //&& child.z < 20) {
+            if (!found && level <= this.max_proxy_descendant_depth && child.z < 20) {
                 descendants.push(...this.getDescendantTiles(child, source, style_zoom, level + 1));
             }
         }

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -396,7 +396,8 @@ export default TileManager = {
         tile.update(this.scene);
         tile.build(this.scene.generation)
             .then(message => this.buildTileCompleted(message))
-            .catch(() => {
+            .catch(e => {
+                log.error(`Error building tile ${tile.key}:`, e);
                 this.forgetTile(tile.key);
                 Tile.abortBuild(tile);
             });

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -1,6 +1,5 @@
 import Tile from './tile';
 import TilePyramid from './tile_pyramid';
-import Geo from './geo';
 import Utils from './utils/utils';
 
 import log from 'loglevel';

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -176,7 +176,7 @@ const TileManager = {
         else {
             // brute force
             for (let key in this.visible_coords) {
-                if (Tile.isChild(tile.coords, this.visible_coords[key])) {
+                if (Tile.isDescendant(tile.coords, this.visible_coords[key])) {
                     tile.visible = true;
                     return;
                 }

--- a/src/tile_pyramid.js
+++ b/src/tile_pyramid.js
@@ -1,0 +1,149 @@
+import Geo from './geo';
+import Tile from './tile';
+
+const TilePyramid = {
+
+    coords: {},
+    max_proxy_descendant_depth: 3, // # of levels deep to search for descendant proxy tiles
+
+    reset() {
+        this.coords = {};
+    },
+
+    sourceTiles(coord, source) {
+        return (
+            this.coords[coord.key] &&
+            this.coords[coord.key].sources &&
+            this.coords[coord.key].sources.get(source.name));
+    },
+
+    addTile(tile) {
+        // Add target tile
+        let key = tile.coords.key;
+        let coord = this.coords[key];
+        if (!coord) {
+            coord = this.coords[key] = { descendants: 0 };
+        }
+
+        if (!coord.sources) {
+            coord.sources = new Map();
+        }
+
+        if (!coord.sources.get(tile.source.name)) {
+            coord.sources.set(tile.source.name, new Map());
+        }
+        coord.sources.get(tile.source.name).set(tile.style_zoom, tile);
+
+        // Increment reference count up the tile pyramid
+        for (let z = tile.coords.z - 1; z >= 0; z--) {
+            let up = Tile.coordinateAtZoom(tile.coords, z);
+            if (!this.coords[up.key]) {
+                this.coords[up.key] = { descendants: 0 };
+            }
+            this.coords[up.key].descendants++;
+        }
+    },
+
+    removeTile(tile) {
+        // Remove target tile
+        let key = tile.coords.key;
+        let source_tiles =
+            this.coords[key] &&
+            this.coords[key].sources &&
+            this.coords[key].sources.get(tile.source.name);
+
+        if (source_tiles) {
+            source_tiles.delete(tile.style_zoom);
+            if (source_tiles.size === 0) {
+                // remove source
+                this.coords[key].sources.delete(tile.source.name);
+                if (this.coords[key].sources.size === 0) {
+                    delete this.coords[key].sources;
+                }
+
+                if (this.coords[key].descendants === 0) {
+                    // remove whole coord
+                    delete this.coords[key];
+                }
+            }
+        }
+
+        // Decrement reference count up the tile pyramid
+        for (let z = tile.coords.z - 1; z >= 0; z--) {
+            let down = Tile.coordinateAtZoom(tile.coords, z);
+            if (this.coords[down.key] && this.coords[down.key].descendants > 0) {
+                this.coords[down.key].descendants--;
+                if (this.coords[down.key].descendants === 0 && !this.coords[down.key].sources) {
+                    delete this.coords[down.key];
+                }
+            }
+        }
+    },
+
+    getAncestor ({ coords, style_zoom, source }) {
+        // First check overzoomed tiles at same coordinate zoom
+        if (style_zoom > source.max_zoom) {
+            let source_tiles = this.sourceTiles(coords, source);
+            if (source_tiles) {
+                for (let z = style_zoom - 1; z >= source.max_zoom; z--) {
+                    if (source_tiles.has(z)) {
+                        return source_tiles.get(z);
+                    }
+                }
+            }
+            style_zoom = source.max_zoom;
+        }
+
+        // Check tiles at next zoom up
+        style_zoom--;
+        let parent = Tile.coordinateAtZoom(coords, coords.z - 1);
+        let parent_tiles = this.sourceTiles(parent, source);
+        if (parent_tiles && parent_tiles.has(style_zoom)) {
+            return parent_tiles.get(style_zoom);
+        }
+        // didn't find ancestor, try next level
+        // TODO: max depth levels to check
+        if (parent.z > 0) {
+            return this.getAncestor({ coords: parent, style_zoom, source });
+        }
+    },
+
+    getDescendants ({ coords, style_zoom, source }, level = 1) {
+        let descendants = [];
+
+        // First check overzoomed tiles at same coordinate zoom
+        if (style_zoom >= source.max_zoom) {
+            let source_tiles = this.sourceTiles(coords, source);
+            if (source_tiles) {
+                let search_max_zoom = Math.max(Geo.default_view_max_zoom, style_zoom + this.max_proxy_descendant_depth);
+                for (let z = style_zoom + 1; z <= search_max_zoom; z++) {
+                    if (source_tiles.has(z)) {
+                        descendants.push(source_tiles.get(z));
+                        return descendants;
+                    }
+                }
+            }
+            return descendants;
+        }
+
+        // Check tiles at next zoom down
+        if (this.coords[coords.key] && this.coords[coords.key].descendants > 0) {
+            style_zoom++;
+            for (let child of Tile.childrenForCoordinate(coords)) {
+                let child_tiles = this.sourceTiles(child, source);
+                if (child_tiles && child_tiles.has(style_zoom)) {
+                    descendants.push(child_tiles.get(style_zoom));
+                }
+                // didn't find child, try next level
+                else if (level <= this.max_proxy_descendant_depth && child.z <= source.max_zoom) {
+                    descendants.push(...this.getDescendants({ coords: child, source, style_zoom }, level + 1));
+                }
+            }
+        }
+
+        return descendants;
+    }
+
+};
+
+export default TilePyramid;

--- a/src/utils/gl-matrix.js
+++ b/src/utils/gl-matrix.js
@@ -1,0 +1,52 @@
+// Partial import of gl-matrix via modularized stack-gl forks
+// https://github.com/toji/gl-matrix
+// https://github.com/stackgl
+
+// vec3
+
+// Substitute 64-bit version
+// We need the extra precision when multiplying matrices w/mercator projected values
+const vec3 = {
+    fromValues (x, y, z) {
+        var out = new Float64Array(3);
+        out[0] = x;
+        out[1] = y;
+        out[2] = z;
+        return out;
+    }
+};
+
+
+// mat3
+
+import {default as mat3_normalFromMat4} from 'gl-mat3/normal-from-mat4';
+import {default as mat3_invert} from 'gl-mat3/invert';
+
+const mat3 = {
+    normalFromMat4: mat3_normalFromMat4,
+    invert: mat3_invert
+};
+
+
+// mat4
+
+import {default as mat4_multiply} from 'gl-mat4/multiply';
+import {default as mat4_translate} from 'gl-mat4/translate';
+import {default as mat4_scale} from 'gl-mat4/scale';
+import {default as mat4_perspective} from 'gl-mat4/perspective';
+import {default as mat4_lookAt} from 'gl-mat4/lookAt';
+import {default as mat4_identity} from 'gl-mat4/identity';
+import {default as mat4_copy} from 'gl-mat4/copy';
+
+const mat4 = {
+    multiply: mat4_multiply,
+    translate: mat4_translate,
+    scale: mat4_scale,
+    perspective: mat4_perspective,
+    lookAt: mat4_lookAt,
+    identity: mat4_identity,
+    copy: mat4_copy
+};
+
+
+export {vec3, mat3, mat4};

--- a/src/view.js
+++ b/src/view.js
@@ -1,0 +1,229 @@
+import Geo from './geo';
+import Tile from './tile';
+import Utils from './utils/utils';
+import subscribeMixin from './utils/subscribe';
+
+import log from 'loglevel';
+
+export default class View {
+
+    constructor(scene, options) {
+        subscribeMixin(this);
+
+        this.scene = scene;
+
+        this.zoom = null;
+        this.center = null;
+
+        this.zooming = false;
+        this.zoom_direction = 0;
+        this.preserve_tiles_within_zoom = 1;
+        this.panning = false;
+
+        // this.meters_per_pixel
+        // this.css_size
+        // this.device_size
+        // this.view_aspect
+        // this.viewport_meters
+        // this.center_meters
+        // this.center_tile
+        // this.bounds_meters
+
+        this.buffer = 0;
+        this.continuous_zoom = (typeof options.continuousZoom === 'boolean') ? options.continuousZoom : true;
+        this.tile_simplification_level = 0; // level-of-detail downsampling to apply to tile loading
+        this.preserve_tiles_within_zoom = 1;
+    }
+
+    // Set the map view, can be passed an object with lat/lng and/or zoom
+    setView({ lng, lat, zoom } = {}) {
+        var changed = false;
+
+        // Set center
+        if (typeof lng === 'number' && typeof lat === 'number') {
+            if (!this.center || lng !== this.center.lng || lat !== this.center.lat) {
+                changed = true;
+                this.center = { lng: Geo.wrapLng(lng), lat };
+            }
+        }
+
+        // Set zoom
+        if (typeof zoom === 'number' && zoom !== this.zoom) {
+            changed = true;
+            this.setZoom(zoom);
+        }
+
+        if (changed) {
+            this.updateBounds();
+        }
+        return changed;
+    }
+
+    setZoom(zoom) {
+        if (this.zooming) {
+            this.zooming = false;
+        }
+        else {
+            this.last_zoom = this.zoom;
+        }
+
+        let last_tile_zoom = this.tile_zoom;
+        let tile_zoom = this.tileZoom(zoom);
+        if (!this.continuous_zoom) {
+            zoom = tile_zoom;
+        }
+
+        if (tile_zoom !== last_tile_zoom) {
+            // Remove tiles outside current zoom that are still loading
+            this.scene.tile_manager.removeTiles(tile => {
+                if (tile.loading && this.tileZoom(tile.coords.z) !== tile_zoom) {
+                    log.trace(`removed ${tile.key} (was loading, but outside current zoom)`);
+                    return true;
+                }
+            });
+
+            this.zoom_direction = tile_zoom > last_tile_zoom ? 1 : -1;
+        }
+
+        this.last_zoom = this.zoom;
+        this.zoom = zoom;
+        this.tile_zoom = tile_zoom;
+
+        this.updateBounds();
+        this.scene.requestRedraw();
+    }
+
+    startZoom() {
+        this.last_zoom = this.zoom;
+        this.zooming = true;
+    }
+
+    // Choose the base zoom level to use for a given fractional zoom
+    baseZoom(zoom) {
+        return Math.floor(zoom);
+    }
+
+    // For a given view zoom, what tile zoom should be loaded?
+    tileZoom(view_zoom) {
+        return this.baseZoom(view_zoom) - this.tile_simplification_level;
+    }
+
+    // For a given tile zoom, what style zoom should be used?
+    styleZoom(tile_zoom) {
+        return this.baseZoom(tile_zoom) + this.tile_simplification_level;
+    }
+
+    ready() {
+        // TODO: better concept of "readiness" state?
+        if (this.css_size == null || this.center == null || this.zoom == null) {
+             return false;
+        }
+        return true;
+    }
+
+    // Calculate viewport bounds based on current center and zoom
+    updateBounds() {
+        if (!this.ready()) {
+            return;
+        }
+
+        this.meters_per_pixel = Geo.metersPerPixel(this.zoom);
+
+        // Size of the half-viewport in meters at current zoom
+        this.viewport_meters = {
+            x: this.css_size.width * this.meters_per_pixel,
+            y: this.css_size.height * this.meters_per_pixel
+        };
+
+        // Center of viewport in meters, and tile
+        let [x, y] = Geo.latLngToMeters([this.center.lng, this.center.lat]);
+        this.center_meters = { x, y };
+
+        this.center_tile = Geo.tileForMeters([this.center_meters.x, this.center_meters.y], this.tile_zoom);
+
+        this.bounds_meters = {
+            sw: {
+                x: this.center_meters.x - this.viewport_meters.x / 2,
+                y: this.center_meters.y - this.viewport_meters.y / 2
+            },
+            ne: {
+                x: this.center_meters.x + this.viewport_meters.x / 2,
+                y: this.center_meters.y + this.viewport_meters.y / 2
+            }
+        };
+
+        this.scene.tile_manager.updateTilesForView(this.view);
+
+        this.trigger('move');
+        this.scene.requestRedraw(); // TODO automate via move event?
+    }
+
+    // TODO: move to a new view manager object
+    findVisibleTileCoordinates() {
+        if (!this.bounds_meters) {
+            return [];
+        }
+
+        let z = this.tile_zoom;
+        let sw = Geo.tileForMeters([this.bounds_meters.sw.x, this.bounds_meters.sw.y], z);
+        let ne = Geo.tileForMeters([this.bounds_meters.ne.x, this.bounds_meters.ne.y], z);
+
+        let coords = [];
+        for (let x = sw.x - this.buffer; x <= ne.x + this.buffer; x++) {
+            for (let y = ne.y - this.buffer; y <= sw.y + this.buffer; y++) {
+                coords.push(Tile.coord({ x, y, z }));
+            }
+        }
+        return coords;
+    }
+
+    // Remove tiles too far outside of view
+    pruneTileCoordinatesForView() {
+        // TODO: will this function ever be called when view isn't ready?
+        if (!this.ready()) {
+            return;
+        }
+
+        // Remove tiles that are a specified # of tiles outside of the viewport border
+        let border_tiles = [
+            Math.ceil((Math.floor(this.css_size.width / Geo.tile_size) + 2) / 2),
+            Math.ceil((Math.floor(this.css_size.height / Geo.tile_size) + 2) / 2)
+        ];
+        let style_zoom = this.tileZoom(this.zoom);
+
+        this.scene.tile_manager.removeTiles(tile => {
+            // Ignore visible tiles
+            if (tile.visible || tile.proxy) {
+                return false;
+            }
+
+            // Discard if too far from current zoom
+            let zdiff = Math.abs(tile.style_zoom - style_zoom);
+            if (zdiff > this.preserve_tiles_within_zoom) {
+                return true;
+            }
+
+            // Handle tiles at different zooms
+            let coords = Tile.coordinateAtZoom(tile.coords, style_zoom);
+
+            // Discard tiles outside an area surrounding the viewport
+            if (Math.abs(coords.x - this.center_tile.x) - border_tiles[0] > this.buffer) {
+                log.trace(`View: remove tile ${tile.key} (as ${coords.x}/${coords.y}/${style_zoom}) for being too far out of visible area ***`);
+                return true;
+            }
+            else if (Math.abs(coords.y - this.center_tile.y) - border_tiles[1] > this.buffer) {
+                log.trace(`View: remove tile ${tile.key} (as ${coords.x}/${coords.y}/${style_zoom}) for being too far out of visible area ***`);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    setupProgram (program) {
+        program.uniform('2f', 'u_resolution', this.device_size.width, this.device_size.height);
+        program.uniform('3f', 'u_map_position', this.center_meters.x, this.center_meters.y, this.zoom);
+        program.uniform('1f', 'u_meters_per_pixel', this.meters_per_pixel);
+        program.uniform('1f', 'u_device_pixel_ratio', Utils.device_pixel_ratio);
+    }
+
+}

--- a/src/view.js
+++ b/src/view.js
@@ -170,7 +170,6 @@ export default class View {
         this.scene.requestRedraw(); // TODO automate via move event?
     }
 
-    // TODO: move to a new view manager object
     findVisibleTileCoordinates() {
         if (!this.bounds) {
             return [];

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -12,8 +12,8 @@ describe('Scene', function () {
 
     beforeEach(() => {
         subject = makeScene({});
-        sinon.stub(subject, 'findVisibleTileCoordinates').returns([]);
-        subject.setView(nycLatLng);
+        sinon.stub(subject.view, 'findVisibleTileCoordinates').returns([]);
+        subject.view.setView(nycLatLng);
     });
 
     afterEach(() => {
@@ -116,7 +116,7 @@ describe('Scene', function () {
         });
 
         it('sets the device size property', () => {
-            assert.deepEqual(subject.size.device, {
+            assert.deepEqual(subject.view.size.device, {
                 height: computedHeight,
                 width: computedWidth
             });
@@ -153,19 +153,20 @@ describe('Scene', function () {
 
     });
 
-    describe('.setView(lng, lat)', () => {
+    describe('.view.setView(lng, lat)', () => {
         let {lng, lat, zoom} = nycLatLng;
 
         beforeEach(() => {
-            subject.setView(nycLatLng);
+            subject.view.setView(nycLatLng);
         });
 
-        it('sets the scene center', () => {
-            assert.deepEqual(subject.center, {lng, lat});
+        it('sets the view center', () => {
+            assert.equal(subject.view.center.lng, lng);
+            assert.equal(subject.view.center.lat, lat);
         });
 
-        it('sets the scene zoom', () => {
-            assert.equal(subject.zoom, zoom);
+        it('sets the view zoom', () => {
+            assert.equal(subject.view.zoom, zoom);
         });
 
         it('marks the scene as dirty', () => {
@@ -173,27 +174,27 @@ describe('Scene', function () {
         });
     });
 
-    describe('.startZoom()', () => {
+    describe('.view.startZoom()', () => {
 
         beforeEach(() => {
-            subject.startZoom();
+            subject.view.startZoom();
         });
 
         it('sets the last zoom property with the value of the current zoom', () => {
-            assert.equal(subject.last_zoom, subject.zoom);
+            assert.equal(subject.view.last_zoom, subject.view.zoom);
         });
 
-        it('marks the scene as zooming', () => {
-            assert.isTrue(subject.zooming);
+        it('marks the view as zooming', () => {
+            assert.isTrue(subject.view.zooming);
         });
 
     });
 
     // TODO this method does a lot of stuff
-    describe('.setZoom(zoom)', () => {
+    describe('.view.setZoom(zoom)', () => {
 
         beforeEach(() => {
-            subject.setZoom(10);
+            subject.view.setZoom(10);
         });
 
         it('marks the scene as dirty', () => {
@@ -201,7 +202,7 @@ describe('Scene', function () {
         });
 
         it('updates the zoom level', () => {
-            assert.equal(subject.zoom, 10);
+            assert.equal(subject.view.zoom, 10);
         });
 
     });
@@ -211,7 +212,7 @@ describe('Scene', function () {
         beforeEach(() => {
             sinon.spy(subject, 'render');
 
-            subject.setView(nycLatLng);
+            subject.view.setView(nycLatLng);
             return subject.load();
         });
 

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -116,7 +116,7 @@ describe('Scene', function () {
         });
 
         it('sets the device size property', () => {
-            assert.deepEqual(subject.device_size, {
+            assert.deepEqual(subject.size.device, {
                 height: computedHeight,
                 width: computedWidth
             });

--- a/test/tile_manager_spec.js
+++ b/test/tile_manager_spec.js
@@ -11,13 +11,14 @@ let midtownTileKey = `${midtownTile.x}/${midtownTile.y}/${midtownTile.z}`;
 
 describe('TileManager', function () {
 
-    let scene;
+    let scene, view;
 
     beforeEach(() => {
         scene = makeScene({});
-        TileManager.init(scene);
-        sinon.stub(scene, 'findVisibleTileCoordinates').returns([]);
-        scene.setView(nycLatLng);
+        view = scene.view;
+        TileManager.init({ scene, view });
+        sinon.stub(view, 'findVisibleTileCoordinates').returns([]);
+        view.setView(nycLatLng);
     });
 
     afterEach(() => {

--- a/test/tile_spec.js
+++ b/test/tile_spec.js
@@ -37,9 +37,11 @@ describe('Tile', function() {
             let unzoomed_coords = { x: Math.floor(coords.x*2), y: Math.floor(coords.y*2), z: 18 };
             let overzoomed_coords = { x: Math.floor(coords.x/4), y: Math.floor(coords.y/4), z: 15 };
 
-            let overzoomed = Tile.overZoomedCoordinate(unzoomed_coords, 15);
+            let overzoomed = Tile.coordinateWithMaxZoom(unzoomed_coords, 15);
 
-            assert.deepEqual(overzoomed, overzoomed_coords);
+            assert.deepEqual(overzoomed.x, overzoomed_coords.x);
+            assert.deepEqual(overzoomed.y, overzoomed_coords.y);
+            assert.deepEqual(overzoomed.z, overzoomed_coords.z);
         });
 
     });

--- a/test/tile_spec.js
+++ b/test/tile_spec.js
@@ -9,15 +9,23 @@ describe('Tile', function() {
 
     let subject,
         scene,
+        view,
         coords = { x: 38603, y: 49255, z: 17 };
 
     beforeEach(() => {
         scene = makeScene({});
-        TileManager.init(scene);
-        sinon.stub(scene, 'findVisibleTileCoordinates').returns([]);
-        scene.setView(nycLatLng);
+        view = scene.view;
+        TileManager.init({ scene, view });
+        sinon.stub(view, 'findVisibleTileCoordinates').returns([]);
+        view.setView(nycLatLng);
         return scene.load().then(() => {
-            subject = Tile.create({coords, style_zoom: coords.z, source: scene.sources.osm, worker: scene.nextWorker()});
+            subject = Tile.create({
+                coords,
+                style_zoom: coords.z,
+                source: scene.sources.osm,
+                worker: scene.nextWorker(),
+                view: view
+            });
         });
     });
 
@@ -70,8 +78,8 @@ describe('Tile', function() {
     describe('sets visibility', () => {
 
         beforeEach(() => {
-            scene.findVisibleTileCoordinates.restore();
-            scene.updateBounds();
+            view.findVisibleTileCoordinates.restore();
+            view.updateBounds();
         });
 
         describe('without a source max_zoom', () => {
@@ -82,13 +90,13 @@ describe('Tile', function() {
             });
 
             it('is NOT visible when scene is lower than tile zoom', () => {
-                scene.setZoom(16);
+                view.setZoom(16);
                 TileManager.updateVisibility(subject);
                 assert.isFalse(subject.visible);
             });
 
             it('is NOT visible when scene is higher than tile zoom', () => {
-                scene.setZoom(18);
+                view.setZoom(18);
                 TileManager.updateVisibility(subject);
                 assert.isFalse(subject.visible);
             });
@@ -106,15 +114,15 @@ describe('Tile', function() {
             });
 
             it('is visible when scene is higher than tile zoom and tile is at its max zoom', () => {
-                scene.setZoom(18);
-                subject = Tile.create({coords, style_zoom: scene.zoom, source: scene.sources.osm, worker: scene.nextWorker()});
+                view.setZoom(18);
+                subject = Tile.create({coords, view: view, style_zoom: view.zoom, source: scene.sources.osm, worker: scene.nextWorker()});
                 TileManager.updateVisibility(subject);
                 assert.isTrue(subject.visible);
             });
 
             it('is NOT visible when scene is higher than tile zoom and tile is NOT at its max zoom', () => {
-                scene.setZoom(14);
-                subject = Tile.create({coords, style_zoom: scene.zoom, source: scene.sources.osm, worker: scene.nextWorker()});
+                view.setZoom(14);
+                subject = Tile.create({coords, view: view, style_zoom: scene.zoom, source: scene.sources.osm, worker: scene.nextWorker()});
                 TileManager.updateVisibility(subject);
                 assert.isFalse(subject.visible);
             });


### PR DESCRIPTION
Adds "proxy tile" support: while tiles are loading, previously loaded tiles from higher or lower zooms will be shown in their place, providing more visual continuity and reducing "breaks" or "flashes" between tile zooms.

- Proxy retrieval: To speed up retrieval of proxy tiles, a new `TilePyramid` object tracks ancestor/descendant relationships across zoom levels.
  - `getAncestor()` and `getDescendants()` methods recursively find available proxy tiles above or below a given tile (for descendants, the max level to descend can be set, since there is up to 4x increase in number of potential proxy tiles for each level; current max depth default is 3 zooms).
 - There is special handling for over-zooming in `TilePyramid` that could be simplified, and in the future should be generalized to support over-zooming *between* intermediate zooms, in addition to past a max zoom (allow data sources to specify partial zoom range coverage, e.g. load tiles for z6, over-zoom them and skip z7, then load new tiles at z8). There is also some redundancy in tile indexing between `TilePyramid` and `TileManager` that could be improved.
- Labels:
  - Because labels are placed/collided once at tile load time, assuming a 1x view size, labels will overlap in undesirable ways when zoomed out for display as descendant proxy tiles. The current solution to this is to [fade out](https://github.com/tangrams/tangram/compare/proxy-view?expand=1#diff-60e93cbad892a92b22ab3f8baaf17594R66) labels on zoom out; currently, labels will become fully transparent when zoomed out 50%, as this appears to be a decent compromise.
  - Zoom-fade could also be applied to sprites/POIs, though this has not been done yet, as icon overlap (subjectively) appears both less problematic and can help retain visual consistency when icons would otherwise fade out and then back into the same place (Tangram ES addresses this with custom logic to prevent immediate fade-out-in, but this is not easily implementable in JS due to the current one-time label build pattern).
- Depth:
  - Similar to Tangram ES, proxy tiles are drawn behind the tiles they are proxying for, e.g. as the new tiles load, they are drawn in front of and appear to replace the proxy tiles. Because proxy tiles can be drawn at multiple mixed zooms (if zooming across several levels), each proxy tile is offset one additional `order` value for each zoom level away from the tile it is proxying.
  - For example, a z15 tile proxying a z16 one would be drawn 1 additional order behind, while a z14 tile proxying the same z16 tile would be drawn 2 orders behind.
- Scene/View refactor:
  - This PR also includes a significant reorganization, pulling much of the view logic into a new `View` object (which also holds the `Camera` and GL model/view matrices).
  - Related model matrix calculation is moved into `Tile`.
  - There is much remaining room for improvement of logic / data flow / separation of concerns between `Scene`, `TileManager`, and `View`, but this refactor provides a better basis for future work, and is closer to the Tangram ES architecture.

![greenlake-zoom](https://cloud.githubusercontent.com/assets/16733/13386535/7891e088-de7b-11e5-9751-49fecee9204a.gif)

![uw-zoom](https://cloud.githubusercontent.com/assets/16733/13386536/78935468-de7b-11e5-818f-ffc6c798e97b.gif)


