### PR TITLE
Build with read-only fork of jsyaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gl-mat3": "1.0.0",
     "gl-mat4": "1.1.4",
     "gl-shader-errors": "1.0.3",
-    "js-yaml": "3.4.6",
+    "js-yaml": "tangrams/js-yaml#read-only",
     "loglevel": "1.2.0",
     "match-feature": "tangrams/match-feature#v1.0.0",
     "pbf": "1.3.2",

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -130,7 +130,11 @@ Utils.io = function (url, timeout = 60000, responseType = 'text', method = 'GET'
 Utils.parseResource = function (body) {
     var data;
     try {
-        data = yaml.safeLoad(body);
+        // jsyaml 'json' option allows duplicate keys
+        // Keeping this for backwards compatibility, but should consider migrating to requiring
+        // unique keys, as this is YAML spec. But Tangram ES currently accepts dupe keys as well,
+        // so should consider how best to unify.
+        data = yaml.safeLoad(body, { json: true });
     } catch (e) {
         throw e;
     }


### PR DESCRIPTION
Builds with a tangram fork of js-yaml that only has YAML read support: https://github.com/nodeca/js-yaml/compare/master...tangrams:read-only

Reduces minified output from 509k to 426k (**-83k**), and gzipped output from 137k to 114k (**-23k**).

Closes #254.