### PR TITLE
Optimize worker message pipeline

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -1067,11 +1067,12 @@ export default class Scene {
 
     // Log messages pass through from web workers
     workerLogMessage(event) {
-        if (event.data.type !== 'log') {
+        let data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data; // optional un-stringify
+        if (data.type !== 'log') {
             return;
         }
 
-        var { worker_id, level, msg } = event.data;
+        var { worker_id, level, msg } = data;
 
         if (log[level]) {
             log[level](`worker ${worker_id}:`,  ...msg);

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -151,7 +151,7 @@ Object.assign(self, {
                         tile.loading = false;
                         tile.loaded = true;
                         Tile.buildGeometry(tile, self.layers, self.rules, self.styles).then(keys => {
-                            resolve({ tile: Tile.slice(tile, keys) });
+                            resolve(WorkerBroker.returnWithTransferables({ tile: Tile.slice(tile, keys) }));
                         });
                     }).catch((error) => {
                         tile.loading = false;
@@ -169,7 +169,7 @@ Object.assign(self, {
 
                 // Build geometry
                 return Tile.buildGeometry(tile, self.layers, self.rules, self.styles).then(keys => {
-                    return { tile: Tile.slice(tile, keys) };
+                    return WorkerBroker.returnWithTransferables({ tile: Tile.slice(tile, keys) });
                 });
             }
         });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -231,12 +231,12 @@ Utils.stringToFunction = function(val, wrap) {
 Utils.log = function (level, ...msg) {
     level = level || 'info';
     if (Utils.isWorkerThread) {
-        self.postMessage({
+        self.postMessage(JSON.stringify({
             type: 'log',
             level: level,
             worker_id: self._worker_id,
             msg: msg
-        });
+        }));
     }
     else if (typeof log[level] === 'function') {
         log[level](...msg);

--- a/src/utils/worker_broker.js
+++ b/src/utils/worker_broker.js
@@ -151,12 +151,12 @@ function setupMainThread () {
             messages[message_id] = { method, message, resolve, reject };
         });
 
-        worker.postMessage({
+        worker.postMessage(JSON.stringify({
             type: 'main_send',      // mark message as method invocation from main thread
             message_id,             // unique id for this message, for life of program
             method,                 // will dispatch to a function of this name within the worker
             message                 // message payload
-        });
+        }));
 
         message_id++;
         return promise;
@@ -173,18 +173,19 @@ function setupMainThread () {
 
         // Listen for messages coming back from the worker, and fulfill that message's promise
         worker.addEventListener('message', (event) => {
-            if (event.data.type !== 'worker_reply') {
+            let data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data; // optional un-stringify
+            if (data.type !== 'worker_reply') {
                 return;
             }
 
             // Pass the result to the promise
-            var id = event.data.message_id;
+            var id = data.message_id;
             if (messages[id]) {
-                if (event.data.error) {
-                    messages[id].reject(event.data.error);
+                if (data.error) {
+                    messages[id].reject(data.error);
                 }
                 else {
-                    messages[id].resolve(event.data.message);
+                    messages[id].resolve(data.message);
                 }
                 delete messages[id];
             }
@@ -193,27 +194,29 @@ function setupMainThread () {
         // Listen for messages initiating a call from the worker, dispatch them,
         // and send any return value back to the worker
         worker.addEventListener('message', (event) => {
+            let data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data; // optional un-stringify
+
             // Unique id for this message & return call to main thread
-            var id = event.data.message_id;
-            if (event.data.type !== 'worker_send' || id == null) {
+            var id = data.message_id;
+            if (data.type !== 'worker_send' || id == null) {
                 return;
             }
 
             // Call the requested method and save the return value
-            // var target = targets[event.data.target];
-            var [method_name, target] = findTarget(event.data.method);
+            // var target = targets[data.target];
+            var [method_name, target] = findTarget(data.method);
             if (!target) {
-                throw Error(`Worker broker could not dispatch message type ${event.data.method} on target ${event.data.target} because no object with that name is registered on main thread`);
+                throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because no object with that name is registered on main thread`);
             }
 
             var method = (typeof target[method_name] === 'function') && target[method_name];
             if (!method) {
-                throw Error(`Worker broker could not dispatch message type ${event.data.method} on target ${event.data.target} because object has no method with that name`);
+                throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because object has no method with that name`);
             }
 
             var result, error;
             try {
-                result = method.apply(target, event.data.message);
+                result = method.apply(target, data.message);
             }
             catch(e) {
                 // Thrown errors will be passed back (in string form) to worker
@@ -221,17 +224,22 @@ function setupMainThread () {
             }
 
             // Send return value to worker
-            let transferables;
+            let payload, transferables;
             // Async result
             if (result instanceof Promise) {
                 result.then((value) => {
-                    transferables = findTransferables(value);
-
-                    worker.postMessage({
+                    payload = {
                         type: 'main_reply',
                         message_id: id,
                         message: value
-                    }, transferables.map(t => t.object));
+                    };
+
+                    transferables = findTransferables(value);
+                    if (transferables.length === 0) {
+                        payload = JSON.stringify(payload); // can stringify if not sending transferable objects
+                    }
+
+                    worker.postMessage(payload, transferables.map(t => t.object));
 
                     freeTransferables(transferables);
                     // if (transferables.length > 0) {
@@ -248,14 +256,19 @@ function setupMainThread () {
             }
             // Immediate result
             else {
-                transferables = findTransferables(result);
-
-                worker.postMessage({
+                payload = {
                     type: 'main_reply',
                     message_id: id,
                     message: result,
                     error: (error instanceof Error ? `${error.message}: ${error.stack}` : error)
-                }, transferables.map(t => t.object));
+                };
+
+                transferables = findTransferables(result);
+                if (transferables.length === 0) {
+                    payload = JSON.stringify(payload); // can stringify if not sending transferable objects
+                }
+
+                worker.postMessage(payload, transferables.map(t => t.object));
 
                 freeTransferables(transferables);
                 // if (transferables.length > 0) {
@@ -308,18 +321,19 @@ function setupWorkerThread () {
 
     // Listen for messages coming back from the main thread, and fulfill that message's promise
     self.addEventListener('message', (event) => {
-        if (event.data.type !== 'main_reply') {
+        let data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data; // optional un-stringify
+        if (data.type !== 'main_reply') {
             return;
         }
 
         // Pass the result to the promise
-        var id = event.data.message_id;
+        var id = data.message_id;
         if (messages[id]) {
-            if (event.data.error) {
-                messages[id].reject(event.data.error);
+            if (data.error) {
+                messages[id].reject(data.error);
             }
             else {
-                messages[id].resolve(event.data.message);
+                messages[id].resolve(data.message);
             }
             delete messages[id];
         }
@@ -327,27 +341,29 @@ function setupWorkerThread () {
 
     // Receive messages from main thread, dispatch them, and send back a reply
     self.addEventListener('message', (event) => {
+        let data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data; // optional un-stringify
+
         // Unique id for this message & return call to main thread
-        var id = event.data.message_id;
-        if (event.data.type !== 'main_send' || id == null) {
+        var id = data.message_id;
+        if (data.type !== 'main_send' || id == null) {
             return;
         }
 
         // Call the requested worker method and save the return value
-        var [method_name, target] = findTarget(event.data.method);
+        var [method_name, target] = findTarget(data.method);
         if (!target) {
-            throw Error(`Worker broker could not dispatch message type ${event.data.method} on target ${event.data.target} because no object with that name is registered on main thread`);
+            throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because no object with that name is registered on main thread`);
         }
 
         var method = (typeof target[method_name] === 'function') && target[method_name];
 
         if (!method) {
-            throw Error(`Worker broker could not dispatch message type ${event.data.method} because worker has no method with that name`);
+            throw Error(`Worker broker could not dispatch message type ${data.method} because worker has no method with that name`);
         }
 
         var result, error;
         try {
-            result = method.apply(target, event.data.message);
+            result = method.apply(target, data.message);
         }
         catch(e) {
             // Thrown errors will be passed back (in string form) to main thread
@@ -355,17 +371,22 @@ function setupWorkerThread () {
         }
 
         // Send return value to main thread
-        let transferables;
+        let payload, transferables;
         // Async result
         if (result instanceof Promise) {
             result.then((value) => {
-                transferables = findTransferables(value);
-
-                self.postMessage({
+                payload = {
                     type: 'worker_reply',
                     message_id: id,
                     message: value
-                }, transferables.map(t => t.object));
+                };
+
+                transferables = findTransferables(value);
+                if (transferables.length === 0) {
+                    payload = JSON.stringify(payload); // can stringify if not sending transferable objects
+                }
+
+                self.postMessage(payload, transferables.map(t => t.object));
 
                 freeTransferables(transferables);
                 // if (transferables.length > 0) {
@@ -381,14 +402,19 @@ function setupWorkerThread () {
         }
         // Immediate result
         else {
-            transferables = findTransferables(result);
-
-            self.postMessage({
+            payload = {
                 type: 'worker_reply',
                 message_id: id,
                 message: result,
                 error: (error instanceof Error ? `${error.message}: ${error.stack}` : error)
-            }, transferables.map(t => t.object));
+            };
+
+            transferables = findTransferables(result);
+            if (transferables.length === 0) {
+                payload = JSON.stringify(payload); // can stringify if not sending transferable objects
+            }
+
+            self.postMessage(payload, transferables.map(t => t.object));
 
             freeTransferables(transferables);
             // if (transferables.length > 0) {


### PR DESCRIPTION
Optimize the worker message-passing pipeline:

1. It's been found that because native browser serialization of Web Worker messages is slow, it is generally faster to stringify them before sending, and then parse on reception. See http://nolanlawson.com/2016/02/29/high-performance-web-worker-messages/ for details.

  Stringifying is not an option in cases where [transferable objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable) are included in the message payload.

  This PR automatically stringifies worker messages when possible, through the `WorkerBroker`. `JSON.stringify` is applied before the message is sent, and `JSON.parse` when it is received. When transferable objects are found in the payload, the message is left in its original object form.

  For Tangram, this change is most likely to help with label-related messages, where potentially large nested objects with text strings and text metrics are exchanged, as the `Canvas` context is only available on the main thread. Tile-building results in large messages, but these include the transfer of `ArrayBuffer` objects for VBOs, so they cannot be stringified (but are already simple objects and the VBO binary memory already transfers instantly).

2. Transferable objects are relatively rare but important for VBO memory transfer. Previously, we were recursively examining each message for transferable objects, and building a list to pass to `postMessage`. We can reduce that overhead by requiring the caller to explicitly indicate the desire to transfer objects from the response. A special `WorkerBroker.returnWithTransferables` object is provided that wraps regular function return values. When this object is passed to `WorkerBroker`, it automatically searches the return value for transferable objects; if a regular return value is passed, it is assumed to not contain transferables. This puts more responsibility on the caller, but also makes the transfer of objects more explicit and intentional and less prone to error.

