### PR TITLE
Global property substitution

### DIFF
--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -152,7 +152,7 @@ export default SceneLoader = {
     // Normalize some scene-wide settings that apply to the final, merged scene
     finalize(config) {
         // Replace scene properties
-        config = StyleParser.applySceneProperties(config);
+        config = StyleParser.applyGlobalProperties(config);
 
         // Assign ids to data sources
         let source_id = 0;

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -151,7 +151,7 @@ export default SceneLoader = {
 
     // Normalize some scene-wide settings that apply to the final, merged scene
     finalize(config) {
-        // Replace scene properties
+        // Replace global scene properties
         config = StyleParser.applyGlobalProperties(config);
 
         // Assign ids to data sources

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -2,6 +2,7 @@ import Utils from './utils/utils';
 import GLSL from './gl/glsl';
 // import mergeObjects from './utils/merge';
 import {StyleManager} from './styles/style_manager';
+import {StyleParser} from './styles/style_parser';
 
 var SceneLoader;
 
@@ -150,6 +151,9 @@ export default SceneLoader = {
 
     // Normalize some scene-wide settings that apply to the final, merged scene
     finalize(config) {
+        // Replace scene properties
+        config = StyleParser.applySceneProperties(config);
+
         // Assign ids to data sources
         let source_id = 0;
         for (let source in config.sources) {

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -96,6 +96,9 @@ Object.assign(self, {
             self.tiles = {};
         }
 
+        // Replace scene properties
+        config = StyleParser.applySceneProperties(config, config.scene);
+
         // Expand styles
         config = Utils.stringsToFunctions(config, StyleParser.wrapFunction);
         self.styles = StyleManager.build(config.styles, { generation: self.generation });

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -96,9 +96,6 @@ Object.assign(self, {
             self.tiles = {};
         }
 
-        // Replace scene properties
-        config = StyleParser.applySceneProperties(config);
-
         // Expand styles
         config = Utils.stringsToFunctions(config, StyleParser.wrapFunction);
         self.styles = StyleManager.build(config.styles, { generation: self.generation });

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -97,7 +97,7 @@ Object.assign(self, {
         }
 
         // Replace scene properties
-        config = StyleParser.applySceneProperties(config, config.scene);
+        config = StyleParser.applySceneProperties(config);
 
         // Expand styles
         config = Utils.stringsToFunctions(config, StyleParser.wrapFunction);

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -104,8 +104,7 @@ Object.assign(self, {
         self.styles = StyleManager.build(config.styles, { generation: self.generation });
 
         // Parse each top-level layer as a separate rule tree
-        self.layers = config.layers;
-        self.rules = parseRules(self.layers);
+        self.rules = parseRules(config.layers);
 
         // Sync tetxure info from main thread
         self.syncing_textures = self.syncTextures(config.textures);
@@ -153,7 +152,7 @@ Object.assign(self, {
 
                         tile.loading = false;
                         tile.loaded = true;
-                        Tile.buildGeometry(tile, self.layers, self.rules, self.styles).then(keys => {
+                        Tile.buildGeometry(tile, self.config, self.rules, self.styles).then(keys => {
                             resolve({ tile: Tile.slice(tile, keys) });
                         });
                     }).catch((error) => {
@@ -171,7 +170,7 @@ Object.assign(self, {
                 Utils.log('trace', `used worker cache for tile ${tile.key}`);
 
                 // Build geometry
-                return Tile.buildGeometry(tile, self.layers, self.rules, self.styles).then(keys => {
+                return Tile.buildGeometry(tile, self.config, self.rules, self.styles).then(keys => {
                     return { tile: Tile.slice(tile, keys) };
                 });
             }

--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -3,7 +3,7 @@ import mergeObjects from '../utils/merge';
 import {match} from 'match-feature';
 import log from 'loglevel';
 
-export const whiteList = ['filter', 'draw', 'visible', 'data', 'properties'];
+export const whiteList = ['filter', 'draw', 'visible', 'data'];
 
 export let ruleCache = {};
 
@@ -70,7 +70,7 @@ export function mergeTrees(matchingTrees, group) {
 
 class Rule {
 
-    constructor({name, parent, draw, visible, filter, properties}) {
+    constructor({name, parent, draw, visible, filter}) {
         this.id = Rule.id++;
         this.parent = parent;
         this.name = name;
@@ -78,17 +78,12 @@ class Rule {
         this.draw = draw;
         this.filter = filter;
         this.visible = visible !== undefined ? visible : (this.parent && this.parent.visible);
-        this.properties = properties !== undefined ? properties : (this.parent && this.parent.properties);
 
-        // Denormalize layer name & properties to draw groups
+        // Denormalize layer name to draw groups
         if (this.draw) {
             for (let group in this.draw) {
                 this.draw[group] = this.draw[group] || {};
                 this.draw[group].layer_name = this.full_name;
-
-                if (this.properties !== undefined) {
-                    this.draw[group].properties = this.properties;
-                }
             }
         }
 
@@ -162,15 +157,15 @@ Rule.id = 0;
 
 
 export class RuleLeaf extends Rule {
-    constructor({name, parent, draw, visible, filter, properties}) {
-        super({name, parent, draw, visible, filter, properties});
+    constructor({name, parent, draw, visible, filter}) {
+        super({name, parent, draw, visible, filter});
     }
 
 }
 
 export class RuleTree extends Rule {
-    constructor({name, parent, draw, visible, rules, filter, properties}) {
-        super({name, parent, draw, visible, filter, properties});
+    constructor({name, parent, draw, visible, rules, filter}) {
+        super({name, parent, draw, visible, filter});
         this.rules = rules || [];
     }
 
@@ -364,7 +359,6 @@ export function matchFeature(context, rules, collectedRules, collectedRulesIds) 
 
     for (let r=0; r < rules.length; r++) {
         let current = rules[r];
-        context.properties = current.properties;
 
         if (current instanceof RuleLeaf) {
 
@@ -391,8 +385,6 @@ export function matchFeature(context, rules, collectedRules, collectedRulesIds) 
                 }
             }
         }
-
-        context.properties = null;
     }
 
     return matched;

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -403,6 +403,10 @@ StyleParser.evalProp = function(prop, context) {
 // of the form `scene.`, for example `color: scene.park_color` would be replaced with the value (if any)
 // defined for the `park_color` property in `config.scene.park_color`.
 StyleParser.applySceneProperties = function (config) {
+    if (!config.scene || Object.keys(config.scene).length === 0) {
+        return config; // no scene properties to transform
+    }
+
     const separator = '_$_';
     const props = flattenProperties(config.scene, separator);
 

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -396,3 +396,40 @@ StyleParser.evalProp = function(prop, context) {
     }
     return prop;
 };
+
+// Substitutes scene properties (those defined in the `config.scene` object) for any style values
+// of the form `scene.`, for example `color: scene.park_color` would be replaced with the value (if any)
+// defined for the `park_color` property in `config.scene.park_color`.
+StyleParser.applySceneProperties = function (obj, scene) {
+    // Convert string
+    if (typeof obj === 'string') {
+        var key = (obj.slice(0, 6) === 'scene.') && obj.slice(6);
+        var val;
+        if (key) {
+            var dot = key.split('.');
+            if (dot.length > 0) { // nested props, e.g. 'scene.roads.color'
+                var src = scene;
+                for (var k=0; k < dot.length; k++) {
+                    val = src[dot[k]];
+                    if (val) {
+                        src = val;
+                    }
+                }
+            }
+            else {
+                val = scene[key]; // top-level prop, e.g. 'scene.color'
+            }
+        }
+
+        if (val) {
+            obj = val; // replace property value if scene property found
+        }
+    }
+    // Loop through object properties
+    else if (typeof obj === 'object') {
+        for (let p in obj) {
+            obj[p] = StyleParser.applySceneProperties(obj[p], scene);
+        }
+    }
+    return obj;
+};

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -7,10 +7,10 @@ export var StyleParser = {};
 
 // Wraps style functions and provides a scope of commonly accessible data:
 // - feature: the 'properties' of the feature, e.g. accessed as 'feature.name'
+// - global: user-defined properties on the `global` object in the scene file
 // - $zoom: the current map zoom level
 // - $geometry: the type of geometry, 'point', 'line', or 'polygon'
 // - $meters_per_pixel: conversion for meters/pixels at current map zoom
-// - properties: user-defined properties on the style-rule object in the stylesheet
 StyleParser.wrapFunction = function (func) {
     var f = `function(context) {
                 var feature = context.feature.properties;
@@ -19,7 +19,6 @@ StyleParser.wrapFunction = function (func) {
                 var $layer = context.layer;
                 var $geometry = context.geometry;
                 var $meters_per_pixel = context.meters_per_pixel;
-                var properties = context.properties;
 
                 var val = (${func}());
 

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -14,7 +14,7 @@ export var StyleParser = {};
 StyleParser.wrapFunction = function (func) {
     var f = `function(context) {
                 var feature = context.feature.properties;
-                var scene = context.scene;
+                var global = context.global;
                 var $zoom = context.zoom;
                 var $layer = context.layer;
                 var $geometry = context.geometry;
@@ -76,7 +76,7 @@ StyleParser.getFeatureParseContext = function (feature, tile, config) {
     return {
         feature,
         tile,
-        scene: config.scene,
+        global: config.global,
         zoom: tile.style_zoom,
         geometry: Geo.geometryType(feature.geometry.type),
         meters_per_pixel: tile.meters_per_pixel,
@@ -399,21 +399,21 @@ StyleParser.evalProp = function(prop, context) {
     return prop;
 };
 
-// Substitutes scene properties (those defined in the `config.scene` object) for any style values
-// of the form `scene.`, for example `color: scene.park_color` would be replaced with the value (if any)
-// defined for the `park_color` property in `config.scene.park_color`.
-StyleParser.applySceneProperties = function (config) {
-    if (!config.scene || Object.keys(config.scene).length === 0) {
-        return config; // no scene properties to transform
+// Substitutes global scene properties (those defined in the `config.global` object) for any style values
+// of the form `global.`, for example `color: global.park_color` would be replaced with the value (if any)
+// defined for the `park_color` property in `config.global.park_color`.
+StyleParser.applyGlobalProperties = function (config) {
+    if (!config.global || Object.keys(config.global).length === 0) {
+        return config; // no global properties to transform
     }
 
     const separator = '_$_';
-    const props = flattenProperties(config.scene, separator);
+    const props = flattenProperties(config.global, separator);
 
     function applyProps (obj) {
         // Convert string
         if (typeof obj === 'string') {
-            let key = (obj.slice(0, 6) === 'scene.') && (obj.slice(6).replace(/\./g, separator));
+            let key = (obj.slice(0, 7) === 'global.') && (obj.slice(7).replace(/\./g, separator));
             if (key && props[key]) {
                 obj = props[key];
             }
@@ -431,7 +431,7 @@ StyleParser.applySceneProperties = function (config) {
 };
 
 // Flatten nested properties for simpler string look-ups
-// e.g. scene.background.color -> scene_$_background_$_color
+// e.g. global.background.color -> global_$_background_$_color
 function flattenProperties (obj, separator = '_$_', prefix = null, props = {}) {
     prefix = prefix ? (prefix + separator) : '';
 

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -14,6 +14,7 @@ export var StyleParser = {};
 StyleParser.wrapFunction = function (func) {
     var f = `function(context) {
                 var feature = context.feature.properties;
+                var scene = context.scene;
                 var $zoom = context.zoom;
                 var $layer = context.layer;
                 var $geometry = context.geometry;
@@ -71,10 +72,11 @@ StyleParser.macros = {
 };
 
 // A context object that is passed to style parsing functions to provide a scope of commonly used values
-StyleParser.getFeatureParseContext = function (feature, tile) {
+StyleParser.getFeatureParseContext = function (feature, tile, config) {
     return {
         feature,
         tile,
+        scene: config.scene,
         zoom: tile.style_zoom,
         geometry: Geo.geometryType(feature.geometry.type),
         meters_per_pixel: tile.meters_per_pixel,

--- a/src/tile.js
+++ b/src/tile.js
@@ -194,7 +194,8 @@ export default class Tile {
 
     // Process geometry for tile - called by web worker
     // Returns a set of tile keys that should be sent to the main thread (so that we can minimize data exchange between worker and main thread)
-    static buildGeometry (tile, layers, rules, styles) {
+    static buildGeometry (tile, config, rules, styles) {
+        let layers = config.layers;
         tile.debug.rendering = +new Date();
         tile.debug.features = 0;
 
@@ -233,7 +234,7 @@ export default class Tile {
                         continue; // skip features w/o geometry (valid GeoJSON)
                     }
 
-                    let context = StyleParser.getFeatureParseContext(feature, tile);
+                    let context = StyleParser.getFeatureParseContext(feature, tile, config);
                     context.winding = tile.default_winding;
                     context.layer = source_layer.layer; // add data source layer name
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -261,11 +261,7 @@ export default class Tile {
                             continue;
                         }
 
-                        context.properties = group.properties; // add rule-specific properties to context
-
                         style.addFeature(feature, group, context);
-
-                        context.properties = null; // clear group-specific properties
                     }
 
                     tile.debug.features++;


### PR DESCRIPTION
This PR adds a concept of **global properties**, which are user-defined properties in the scene file that can be substituted for values elsewhere in the file. This is useful for values that are referenced in multiple places in the scene file, and would benefit from a centralized definition for easier editing. Examples include common colors, language preferences, or visibility flags used to tweak styles.

Global properties are scoped as everything under the top-level `global` block of the scene file, including nested properties:

```
global:
   labels: true # label visibility flag
   language: name:en # preferred language for label display
   colors: # group common colors together
      color1: red
      color2: green
      color3: blue
```

These properties can then be substituted elsewhere in the scene file with `global.` syntax (included nested dot notation, `global.group.property`), and are also available in JS function filters and properties under the same syntax:

```
layers:
   road-labels:
      data: { ... }
      visible: global.labels
      draw:
         text:
            text_source: [global.language, name] # display labels in preferred language, fallback to default name
            ...

   point-labels:
      data: { ... }
      draw:
         text:
            text_source: |
               function() {
                  // Make a compound label with "Preferred Name (Local Name)"
                  var preferred = feature[global.language];
                  if (preferred && preferred !== feature.name) {
                     return preferred + '\n(' + feature.name + ')';
                  }
                  return feature.name;
               }

   landuse:
      data: { ... }
      draw:
         polygons:
            color: global.colors.color2 # nested property
            ...
```

Global properties are similar to YAML's native anchor/reference capability, with the most significant difference being that they are applied *after* YAML parsing but *before* other Tangram parsing. This means we can:

- Alter them programmatically and rebuild geometry. For example, this enables a dynamic language preference setting. In the example above, the `global.language` property could be hook up to a language selector dropdown or app preference.
- Import and optionally override scene properties once we have scene `import` functionality (e.g. a base scene `A` could define properties which are then referenced by a scene `B` that has an `import: A`). This is outside the scope of current Tangram functionality, but coming soon.

