### PR TITLE
Remove duplicate consecutive points during line building

### DIFF
--- a/src/styles/builders.js
+++ b/src/styles/builders.js
@@ -236,7 +236,12 @@ Builders.buildPolylines = function (
     };
 
     for (var ln = 0; ln < lines.length; ln++) {
-        var line = lines[ln];
+        // Remove dupe points from lines
+        var line = dedupeLine(lines[ln], closed_polygon);
+        if (!line) {
+            continue; // skip if no valid line remaining
+        }
+
         var lineSize = line.length;
 
         // Ignore non-lines
@@ -379,6 +384,31 @@ Builders.buildPolylines = function (
         }
     }
 };
+
+// Remove duplicate points from a line, creating a new line only when points must be removed
+function dedupeLine (line, closed) {
+    let i, dupes;
+
+    // Collect dupe points
+    for (i=0; i < line.length - 1; i++) {
+        if (line[i][0] === line[i+1][0] && line[i][1] === line[i+1][1]) {
+            dupes = dupes || [];
+            dupes.push(i);
+        }
+    }
+
+    // Remove dupe points
+    if (dupes) {
+        line = line.slice(0);
+        dupes.forEach(d => line.splice(d, 1));
+    }
+
+    // Line needs at least 2 points, polygon needs at least 3 (+1 to close)
+    if (!closed && line.length < 2 || closed && line.length < 4) {
+        return;
+    }
+    return line;
+}
 
 // Add to equidistant pairs of vertices (internal method for polyline builder)
 function addVertex(coord, normal, uv, { halfWidth, vertices, scalingVecs, texcoords }) {


### PR DESCRIPTION
We've found several cases where tiles (either Mapzen-served or user-provided) can contain degenerate geometries, particularly lines with duplicate consecutive points (this can happen when quantizing for specific output formats, or during re-projection, etc.).

In Tangram JS, these are manifested as "fat arrowheads". This is because the line builder attempts to find an extrusion vector between two coincident points, resulting in a vector of `[NaN, NaN]`. These `NaN` values get set in the VBO as signed short ints, where they are converted to some unexpected non-zero value, sending the line careening outwards:

![tangram-mon mar 07 2016 16-58-08 gmt-0500 est](https://cloud.githubusercontent.com/assets/16733/13584844/4e1f4d5c-e486-11e5-83ab-52bac33e13b6.png)

The complete solution is probably a combination of server-side and client-side resiliency checks. See https://github.com/mapzen/vector-datasource/issues/569 for further background. 

For now, this PR adds a check for duplicate consecutive points during line building. When duplicates are found, it copies the line to a new instance and removes them, to avoid meddling with the underlying data. A more robust solution would cover more cases, and alter that data once (right now, the dupe check will happen each time the line is built, which could be multiple times either for outlines or other style applications).


