### PR TITLE
Scale modelPosition() to account for tile overzooming

### DIFF
--- a/src/gl/shaders/accessors.glsl
+++ b/src/gl/shaders/accessors.glsl
@@ -1,9 +1,17 @@
-// Vertex position in model space: [0, 1] range over the local tile
-// Note positions can be outside that range due to unclipped geometry, geometry higher than a unit cube, etc.
 #ifdef TANGRAM_VERTEX_SHADER
 
+// Vertex position in model space: [0, 1] range over the local tile
+// Note positions can be outside that range due to unclipped geometry, geometry higher than a unit cube, etc.
 vec4 modelPosition() {
-    return vec4(SHORT(a_position.xyz) / TANGRAM_TILE_SCALE, 1.) + vec4(0., 1., 0., 0.);
+    return
+        vec4(
+            SHORT(a_position.xyz)                       // scale normalized short to full range
+            / TANGRAM_TILE_SCALE                        // scale coords to ~0-1 range
+            * exp2(u_tile_origin.z - u_tile_origin.w),  // adjust for tile overzooming
+        1.)
+        + vec4(0., 1., 0., 0.);
+        // NB: additional offset to account for unusual Tangram JS y coords,
+        // should be refactored to remove
 }
 
 #endif

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -2,6 +2,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
+uniform float u_tile_proxy_depth;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -63,9 +64,8 @@ void main() {
     cameraProjection(position);
 
     #ifdef TANGRAM_LAYER_ORDER
-        // w coordinates hold feature layer, and additional proxy offset (set to 0 for non-proxy tiles)
         // +1 is to keep all layers including proxies > 0
-        applyLayerOrder(SHORT(a_position.w) + u_tile_origin.w + 1., position);
+        applyLayerOrder(SHORT(a_position.w) + u_tile_proxy_depth + 1., position);
     #endif
 
     // Apply pixel offset in screen-space

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -2,6 +2,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
+uniform float u_tile_proxy_depth;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -111,9 +112,8 @@ void main() {
     // Camera
     cameraProjection(position);
 
-    // w coordinates hold feature layer, and additional proxy offset (set to 0 for non-proxy tiles)
     // +1 is to keep all layers including proxies > 0
-    applyLayerOrder(SHORT(a_position.w) + u_tile_origin.w + 1., position);
+    applyLayerOrder(SHORT(a_position.w) + u_tile_proxy_depth + 1., position);
 
     gl_Position = position;
 }

--- a/src/tile.js
+++ b/src/tile.js
@@ -445,7 +445,8 @@ export default class Tile {
     // Update model matrix and tile uniforms
     setupProgram ({ model, model32 }, program) {
         // Tile origin
-        program.uniform('4f', 'u_tile_origin', this.min.x, this.min.y, this.style_zoom, this.proxy_depth);
+        program.uniform('4f', 'u_tile_origin', this.min.x, this.min.y, this.style_zoom, this.coords.z);
+        program.uniform('1f', 'u_tile_proxy_depth', this.proxy_depth);
 
         // Model - transform tile space into world space (meters, absolute mercator position)
         mat4.identity(model);


### PR DESCRIPTION
We concluded in https://github.com/tangrams/tangram/issues/259 that we should scale the `modelPosition()` accessor to account for tile overzooming, providing a consistent scale for shader-based patterns. 

This is done by adding an additional scaling factor of `2^(tile style zoom - tile coord zoom)` to the `modelPosition()`.

Implementation notes:
- `u_tile_origin.z` was already set to the tile's *style zoom* (the zoom at which the tile is being displayed) in JS, but to the *coordinate zoom* (e.g. the zoom at which the tile was loaded) in ES. We concluded that it should be set to the **style zoom** on both platforms.
- However we also need access to the tile coordinate zoom, which is now provided as `u_tile_origin.w`.
- Previously, JS was using `u_tile_origin.w` as the depth offset for proxy tiles. This was moved to a new uniform `u_tile_proxy_depth`, however this will not be documented/exposed as a public "API" uniform (unlike `u_tile_origin`, which is available to users).
- `modelPosition()` has never really been in a true `[0, 1]` range, because geometry can go outside the tile bounds. This means it cannot safely have a modulus or `fract` applied. Instead we've opted to simply scale it, meaning the scale of its values is consistent with what the user would expect for a given zoom level, but the actual values cover a greater range.

