### PR TITLE
Revise lighting blocks: always include `color` and `normal`

### DIFF
--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -41,6 +41,10 @@ varying vec4 v_world_position;
     varying vec2 v_texcoord;
 #endif
 
+#if defined(TANGRAM_LIGHTING_VERTEX)
+    varying vec4 v_lighting;
+#endif
+
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting
@@ -92,21 +96,13 @@ void main() {
 
     #if defined(TANGRAM_LIGHTING_VERTEX)
         // Vertex lighting
-        vec4 color = a_color;
-        vec3 normal = TANGRAM_NORMAL;
+        vec3 normal = v_normal;
 
         // Modify normal before lighting
         #pragma tangram: normal
 
-        // Modify color and material properties before lighting
-        #pragma tangram: color
-
-        v_color = calculateLighting(position.xyz, normal, color);
-    #elif !defined(TANGRAM_LIGHTING_FRAGMENT) // lighting: false
-        // No lighting
-        vec4 color = a_color;
-        #pragma tangram: color
-        v_color = color;
+        // Pass lighting intensity to fragment shader
+        v_lighting = calculateLighting(position.xyz - u_eye, normal, vec4(1.));
     #endif
 
     // Camera


### PR DESCRIPTION
This is yet another revision of shader block application, after the v0.6.0 changes revealed compatibility issues with existing styles and limitations on procedurally generated textures and custom lighting setups.

With this new logic, the `color` and `normal` blocks are always injected, regardless of the `lighting` mode:

- `lighting: fragment`:
  - `normal` and `color` blocks executed in the fragment shader.
- `lighting: vertex`:
  - `normal` block is executed in the vertex shader
  - Lighting intensity (e.g. lighting if applied to a pure white surface) is calculated in the vertex shader, and interpolated in the fragment shader.
  - `color` block is executed in the fragment shader, and the result is multiplied by the interpolated lighting intensity. This allows for `color` to create procedural textures that are still properly lit when `lighting: vertex` is applied.
- `lighting: false`:
  - `normal` and `color` blocks executed in the fragment shader. No Tangram lighting is applied, but the user can create alternate shading models in these blocks if desired.

In all cases, the `filter` block is executed last in the fragment shader, as a final color pre-processing step.