### PR TITLE
Add matching layers to feature selection info

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -215,8 +215,15 @@ export default class FeatureSelection {
         selector.feature = {
             id: feature.id,
             properties: feature.properties,
-            tile: tile.key,
-            layers: context.layers
+            layers: context.layers,
+            tile: {
+                key: tile.key,
+                coords: tile.coords,
+                style_zoom: tile.style_zoom,
+                source: tile.source,
+                generation: tile.generation
+
+            }
         };
 
         return selector.color;

--- a/src/selection.js
+++ b/src/selection.js
@@ -210,12 +210,13 @@ export default class FeatureSelection {
         return this.map[key];
     }
 
-    static makeColor(feature, tile) {
+    static makeColor(feature, tile, context) {
         var selector = this.makeEntry(tile);
         selector.feature = {
             id: feature.id,
             properties: feature.properties,
-            tile: tile.key
+            tile: tile.key,
+            layers: context.layers
         };
 
         return selector.color;

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -199,7 +199,7 @@ export var Style = {
 
             // If feature is marked as selectable
             if (selectable) {
-                style.selection_color = FeatureSelection.makeColor(feature, context.tile);
+                style.selection_color = FeatureSelection.makeColor(feature, context.tile, context);
             }
             else {
                 style.selection_color = FeatureSelection.defaultColor;

--- a/src/tile.js
+++ b/src/tile.js
@@ -267,6 +267,7 @@ export default class Tile {
                             continue;
                         }
 
+                        context.layers = group.layers;  // add matching draw layers
                         context.properties = group.properties; // add rule-specific properties to context
 
                         style.addFeature(feature, group, context);


### PR DESCRIPTION
This adds the fully qualified names of the `layers` that matched a feature to the selection object returned for it, as `feature.layers`. For example:

```
scene.getFeatureAt(pixel).then(function(selection) {
   if (selection.feature) {
      console.log(selection.feature.layers);
   }
});

=> ["roads:major_road:trunk_primary:early", 
"roads:major_road:trunk_primary:routes:early", 
"roads:major_road:trunk_primary:labels-trunk_primary-z13"]