### PR TITLE
Subdivide line labels by segment on overzoomed tiles

### DIFF
--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -7,8 +7,12 @@ export default class LabelLine extends Label {
     constructor (size, lines, options) {
         super(size, options);
 
-        this.segment_index = 0;
         this.lines = lines;
+
+        // optionally limit the line segments that the label may be placed in, by specifying a segment index range
+        // used as a coarse subdivide for placing multiple labels per line geometry
+        this.segment_index = options.segment_start || 0;
+        this.segment_max = options.segment_end || this.lines.length;
         this.update();
     }
 
@@ -20,7 +24,7 @@ export default class LabelLine extends Label {
     }
 
     moveNextSegment () {
-        if (this.segment_index + 1 >= this.lines.length - 1) {
+        if (this.segment_index + 1 >= this.segment_max - 1) {
             return false;
         }
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -418,7 +418,7 @@ Object.assign(TextStyle, {
 
     // Build one or more labels for a line geometry
     buildLineLabels (size, line, options, labels) {
-        let subdiv = Math.min(options.subdiv, line.length);
+        let subdiv = Math.min(options.subdiv, line.length - 1);
         if (subdiv > 1) {
             // Create multiple labels for line, with each allotted a range of segments
             // in which it will attempt to place

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -380,6 +380,9 @@ Object.assign(TextStyle, {
         }
         layout.repeat_group += '/' + text;
 
+        // Max number of subdivisions to try
+        layout.subdiv = tile.overzoom2;
+
         return layout;
     },
 
@@ -388,15 +391,11 @@ Object.assign(TextStyle, {
         let labels = [];
 
         if (geometry.type === "LineString") {
-            let lines = geometry.coordinates;
-
-            labels.push(new LabelLine(size, lines, options));
+            this.buildLineLabels(size, geometry.coordinates, options, labels);
         } else if (geometry.type === "MultiLineString") {
             let lines = geometry.coordinates;
-
             for (let i = 0; i < lines.length; ++i) {
-                let line = lines[i];
-                labels.push(new LabelLine(size, line, options));
+                this.buildLineLabels(size, lines[i], options, labels);
             }
         } else if (geometry.type === "Point") {
             labels.push(new LabelPoint(geometry.coordinates, size, options));
@@ -404,8 +403,7 @@ Object.assign(TextStyle, {
             let points = geometry.coordinates;
 
             for (let i = 0; i < points.length; ++i) {
-                let point = points[i];
-                labels.push(new LabelPoint(point, size, options));
+                labels.push(new LabelPoint(points[i], size, options));
             }
         } else if (geometry.type === "Polygon") {
             let centroid = Geo.centroid(geometry.coordinates[0]);
@@ -416,6 +414,26 @@ Object.assign(TextStyle, {
         }
 
         return labels;
+    },
+
+    // Build one or more labels for a line geometry
+    buildLineLabels (size, line, options, labels) {
+        let subdiv = Math.min(options.subdiv, line.length);
+        if (subdiv > 1) {
+            // Create multiple labels for line, with each allotted a range of segments
+            // in which it will attempt to place
+            let seg_per_div = (line.length - 1) / subdiv;
+            for (let i=0; i < subdiv; i++) {
+                options.segment_start = Math.floor(i * seg_per_div);
+                options.segment_end = Math.floor((i+1) * seg_per_div);
+                labels.push(new LabelLine(size, line, options));
+            }
+            options.segment_start = null;
+            options.segment_end = null;
+        }
+        else {
+            labels.push(new LabelLine(size, line, options));
+        }
     }
 
 });

--- a/src/tile.js
+++ b/src/tile.js
@@ -34,6 +34,8 @@ export default class Tile {
 
         this.coords = Tile.coordinateWithMaxZoom(coords, this.source.max_zoom);
         this.style_zoom = style_zoom; // zoom level to be used for styling
+        this.overzoom = Math.max(this.style_zoom - this.coords.z, 0); // number of levels of overzooming
+        this.overzoom2 = Math.pow(2, this.overzoom);
         this.key = Tile.key(this.coords, this.source, this.style_zoom);
         this.min = Geo.metersForTile(this.coords);
         this.max = Geo.metersForTile({x: this.coords.x + 1, y: this.coords.y + 1, z: this.coords.z }),
@@ -42,10 +44,7 @@ export default class Tile {
         this.center_dist = 0;
 
         // Units per pixel needs to account for over-zooming
-        this.units_per_pixel = Geo.units_per_pixel;
-        if (this.style_zoom > this.coords.z) {
-            this.units_per_pixel /= Math.pow(2, this.style_zoom - this.coords.z);
-        }
+        this.units_per_pixel = Geo.units_per_pixel / this.overzoom2;
 
         this.meters_per_pixel = Geo.metersPerPixel(this.coords.z);
         this.units_per_meter = Geo.unitsPerMeter(this.coords.z);
@@ -162,6 +161,8 @@ export default class Tile {
             meters_per_pixel: this.meters_per_pixel,
             units_per_meter: this.units_per_meter,
             style_zoom: this.style_zoom,
+            overzoom: this.overzoom,
+            overzoom2: this.overzoom2,
             generation: this.generation,
             debug: this.debug
         };


### PR DESCRIPTION
We've found that our line labelling logic is insufficient for overzoomed tiles, because it only places one label per line, which often provides enough density at each tile's "native" zoom, but is too sparse (sometimes dramatically so) when tiles are overzoomed multiple levels. See #273.

This PR increases line label density by attempting to place multiple labels per line. For each line, up to `2^dz` tiles are placed, where `dz` is the number of levels of overzooming being applied. For example, a z16 tile would still place 1 (2^0) label at z16, but when displayed at z18 the same line would place up to 4 (2^2) labels. This is done with a "coarse subdivide", splitting the line by segment. Each label placement is assigned a range of segments in which it can place.

Examples with and without subdivide:

![output_cm5gxy](https://cloud.githubusercontent.com/assets/16733/13879645/e2f694ec-ecee-11e5-9ccd-0e06639b0191.gif)

![output_hrxole](https://cloud.githubusercontent.com/assets/16733/13879644/e2f57d50-ecee-11e5-9ec9-ecb4a6ad059f.gif)

This could likely be improved further, either with more precise (fractional segment) subdivide, and/or by inverting the pattern so that instead of creating multiple `LineLabel` instances per feature, we have one `LineLabel` instance that can emit multiple labels. But this approach was a straightforward and significant near-term improvement, and fits well with the current architecture (we already generate multiple label instances for `Multi` geometries). We could also adjust the heuristic to place more labels, but in my testing I found that label repeat distance was usually the limiting factor (we could adjust that default repeat value to increase density if desired).

@karimnaaji and I discussed this, some more investigation should be done on the ES side. He thought the same issues might apply, but from a quick glance I am not seeing the same magnitude of label sparsity on device.