### PR TITLE
Selection event handlers

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -408,14 +408,6 @@ Enjoy!
     selection_info.style.display = 'block';
 
     function onFeatureHover (selection) {
-        // Don't show labels while panning
-        if (scene.panning == true) {
-            if (selection_info.parentNode != null) {
-                selection_info.parentNode.removeChild(selection_info);
-            }
-            return;
-        }
-
         // Show selection info
         var feature = selection.feature;
         if (feature != null) {
@@ -429,7 +421,9 @@ Enjoy!
                 selection_info.style.left = (selection.pixel.x + 5) + 'px';
                 selection_info.style.top = (selection.pixel.y + 15) + 'px';
                 selection_info.innerHTML = '<span class="labelInner">' + label + '</span>';
-                map.getContainer().appendChild(selection_info);
+                if (selection_info.parentNode == null) {
+                    map.getContainer().appendChild(selection_info);
+                }
             }
             else if (selection_info.parentNode != null) {
                 selection_info.parentNode.removeChild(selection_info);

--- a/demos/main.js
+++ b/demos/main.js
@@ -36,6 +36,9 @@ Enjoy!
 
         layer = Tangram.leafletLayer({
             scene: scene_url,
+            events: {
+                hover: onFeatureHover
+            },
             preUpdate: preUpdate,
             postUpdate: postUpdate,
             // highDensityDisplay: false,
@@ -400,58 +403,41 @@ Enjoy!
     }
 
     // Feature selection
-    function initFeatureSelection () {
-        // Selection info shown on hover
-        var selection_info = document.createElement('div');
-        selection_info.setAttribute('class', 'label');
-        selection_info.style.display = 'block';
+    var selection_info = document.createElement('div'); // shown on hover
+    selection_info.setAttribute('class', 'label');
+    selection_info.style.display = 'block';
 
-        // Show selected feature on hover
-        map.getContainer().addEventListener('mousemove', function (event) {
-            if (gui['feature info'] == false) {
-                if (selection_info.parentNode != null) {
-                    selection_info.parentNode.removeChild(selection_info);
-                }
-
-                return;
+    function onFeatureHover (selection) {
+        // Don't show labels while panning
+        if (scene.panning == true) {
+            if (selection_info.parentNode != null) {
+                selection_info.parentNode.removeChild(selection_info);
             }
+            return;
+        }
 
-            var pixel = { x: event.clientX, y: event.clientY };
-
-            scene.getFeatureAt(pixel).then(function(selection) {
-                if (!selection) {
-                    return;
-                }
-                var feature = selection.feature;
-                if (feature != null) {
-                    var label = '';
-                    if (feature.properties.name != null) {
-                        label = feature.properties.name;
-                    }
-                    // Object.keys(feature.properties).forEach(p => label += `<b>${p}:</b> ${feature.properties[p]}<br>`);
-
-                    if (label != '') {
-                        selection_info.style.left = (pixel.x + 5) + 'px';
-                        selection_info.style.top = (pixel.y + 15) + 'px';
-                        selection_info.innerHTML = '<span class="labelInner">' + label + '</span>';
-                        map.getContainer().appendChild(selection_info);
-                    }
-                    else if (selection_info.parentNode != null) {
-                        selection_info.parentNode.removeChild(selection_info);
-                    }
-                }
-                else if (selection_info.parentNode != null) {
-                    selection_info.parentNode.removeChild(selection_info);
-                }
-            });
-
-            // Don't show labels while panning
-            if (scene.panning == true) {
-                if (selection_info.parentNode != null) {
-                    selection_info.parentNode.removeChild(selection_info);
-                }
+        // Show selection info
+        var feature = selection.feature;
+        if (feature != null) {
+            var label = '';
+            if (feature.properties.name != null) {
+                label = feature.properties.name;
             }
-        });
+            // Object.keys(feature.properties).forEach(p => label += `<b>${p}:</b> ${feature.properties[p]}<br>`);
+
+            if (label != '') {
+                selection_info.style.left = (selection.pixel.x + 5) + 'px';
+                selection_info.style.top = (selection.pixel.y + 15) + 'px';
+                selection_info.innerHTML = '<span class="labelInner">' + label + '</span>';
+                map.getContainer().appendChild(selection_info);
+            }
+            else if (selection_info.parentNode != null) {
+                selection_info.parentNode.removeChild(selection_info);
+            }
+        }
+        else if (selection_info.parentNode != null) {
+            selection_info.parentNode.removeChild(selection_info);
+        }
     }
 
     // Pre-render hook
@@ -499,8 +485,6 @@ Enjoy!
                 style_options.setup(url_style);
             }
             updateURL();
-
-            initFeatureSelection();
         });
         layer.addTo(map);
 

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -171,6 +171,7 @@ function extendLeaflet(options) {
                 map.off('dragend', this.hooks.dragend);
                 map.off('click', this.hooks.click);
                 map.off('mousemove', this.hooks.mousemove);
+                map.off('mouseout', this.hooks.mouseout);
                 this.hooks = {};
 
                 if (this.scene) {
@@ -324,6 +325,14 @@ function extendLeaflet(options) {
                     }
                 };
                 map.on('mousemove', this.hooks.mousemove);
+
+                this.hooks.mouseout = (event) => {
+                    // When mouse leaves map, send an additional selection event to indicate no feature is selected
+                    if (typeof this._selection_events.hover === 'function') {
+                        this._selection_events.hover({ changed: true, leaflet_event: event });
+                    }
+                };
+                map.on('mouseout', this.hooks.mouseout);
             },
 
             // Set user-defined handlers for feature selection events

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -130,6 +130,10 @@ function extendLeaflet(options) {
                 // Modify default leaflet scroll wheel behavior
                 this.modifyScrollWheelBehavior(map);
 
+                // Setup feature selection
+                this.setupSelectionEventHandlers(map);
+                this.setSelectionEvents(this.options.events);
+
                 // Add GL canvas to layer container
                 this.scene.container = this.getContainer();
 
@@ -165,6 +169,8 @@ function extendLeaflet(options) {
                 map.off('zoomstart', this.hooks.zoomstart);
                 map.off('dragstart', this.hooks.dragstart);
                 map.off('dragend', this.hooks.dragend);
+                map.off('click', this.hooks.click);
+                map.off('mousemove', this.hooks.mousemove);
                 this.hooks = {};
 
                 if (this.scene) {
@@ -291,6 +297,40 @@ function extendLeaflet(options) {
 
                 var top_left = this._map.containerPointToLayerPoint([0, 0]);
                 L.DomUtil.setPosition(this.scene.container, top_left);
+            },
+
+            // Tie Leaflet event handlers to Tangram feature selection
+            setupSelectionEventHandlers: function (map) {
+                this._selection_events = {};
+
+                this.hooks.click = (event) => {
+                    if (typeof this._selection_events.click === 'function') {
+                        this.scene.getFeatureAt(event.containerPoint).
+                            then(selection => {
+                                let results = Object.assign({}, selection, { leaflet_event: event });
+                                this._selection_events.click(results);
+                            });
+                    }
+                };
+                map.on('click', this.hooks.click);
+
+                this.hooks.mousemove = (event) => {
+                    if (typeof this._selection_events.hover === 'function') {
+                        this.scene.getFeatureAt(event.containerPoint).
+                            then(selection => {
+                                let results = Object.assign({}, selection, { leaflet_event: event });
+                                this._selection_events.hover(results);
+                            });
+                    }
+                };
+                map.on('mousemove', this.hooks.mousemove);
+            },
+
+            // Set user-defined handlers for feature selection events
+            // Currently only one handler can be defined for each event type
+            // Event types are: `click`, `hover` (leaflet `mousemove`)
+            setSelectionEvents: function (events) {
+                this._selection_events = Object.assign(this._selection_events, events);
             }
 
         });

--- a/src/scene.js
+++ b/src/scene.js
@@ -646,7 +646,9 @@ export default class Scene {
         };
 
         this.dirty = true; // need to make sure the scene re-renders for these to be processed
-        return this.selection.getFeatureAt(point).catch(r => Promise.resolve(r));
+        return this.selection.getFeatureAt(point).
+            then(selection => Object.assign(selection, { pixel })).
+            catch(error => Promise.resolve({ error }));
     }
 
     // Rebuild geometry, without re-parsing the config or re-compiling styles

--- a/src/scene.js
+++ b/src/scene.js
@@ -440,7 +440,7 @@ export default class Scene {
 
         // Render selection pass (if needed)
         if (this.selection.pendingRequests()) {
-            if (this.view.panning) {
+            if (this.view.panning || this.view.zooming) {
                 this.selection.clearPendingRequests();
                 return;
             }


### PR DESCRIPTION
This PR simplifies the process of setting up Tangram feature selection callbacks (such as on hover or click), removing the need for boilerplate code for DOM events by tying into Leaflet's existing event handlers.

A new concept of *selection event handlers* has been added to Tangram, currently with two events supported:
- `hover`
- `click`

Selection event handlers will be passed the same `selection` object returned by direct calls to `scene.getFeatureAt()` (which is still supported and available for custom input/event needs).

Two additional properties have also been added to the returned `selection` object:
- `pixel`: the XY location within the map container where the event occurred, in the form `{ x, y }` (this wasn't previously necessary since the user already needed to pass it explicitly to `getFeatureAt(pixel)`)
- `leaflet_event`: the Leaflet event that triggered the selection is also passed through (it contains information that may be useful for deeper or existing Leaflet integrations)

Handlers for these events can be configured in two ways:

**When creating the Leaflet layer:**

An `events` object can be passed with other leaflet layer options. `hover` and/or `click` properties can be set to a callback function:

```
var layer = Tangram.leafletLayer({
   scene: 'scene.yaml',
   events: {
      hover: function(selection) { console.log('Hover!', selection); },
      click: function(selection) { console.log('Click!', selection); }
   }
};
```

**Updated after Leaflet layer creation:**

Selection events can be added, changed, or removed after layer creation with a call to `layer.setSelectionEvents(events)`. It takes the same `events` object as above:

```
layer.setSelectionEvents({
   hover: onTangramHover,
   click: onTangramClick
});
```

Or, to remove an event, `layer.setSelectionEvents({ click: null });`.