### PR TITLE
Use GL_LESS for depth func

### DIFF
--- a/src/gl/render_state.js
+++ b/src/gl/render_state.js
@@ -15,7 +15,7 @@ export default class RenderState {
     }
 
     static initialize (gl) {
-        RenderState.defaults = {}
+        RenderState.defaults = {};
         // Culling
         RenderState.defaults.culling = true;
         RenderState.defaults.culling_face = gl.BACK;

--- a/src/gl/render_state.js
+++ b/src/gl/render_state.js
@@ -15,9 +15,26 @@ export default class RenderState {
     }
 
     static initialize (gl) {
+        RenderState.defaults = {}
+        // Culling
+        RenderState.defaults.culling = true;
+        RenderState.defaults.culling_face = gl.BACK;
+
+        // Blending
+        RenderState.defaults.blending = false;
+        RenderState.defaults.blending_src = gl.ONE_MINUS_SRC_ALPHA;
+        RenderState.defaults.blending_dst = gl.ONE_MINUS_SRC_ALPHA;
+        RenderState.defaults.blending_src_alpha = gl.ONE;
+        RenderState.defaults.blending_dst_alpha = gl.ONE_MINUS_SRC_ALPHA;
+
+        // Depth test/write
+        RenderState.defaults.depth_write = true;
+        RenderState.defaults.depth_test = true;
+        RenderState.defaults.depth_func = gl.LESS;
+
     	// Culling
     	RenderState.culling = new RenderState(
-    		{ cull: true, face: gl.BACK },
+    		{ cull: RenderState.defaults.culling, face: RenderState.defaults.culling_face },
     		(value) => {
     			if (value.cull) {
     				gl.enable(gl.CULL_FACE);
@@ -29,8 +46,13 @@ export default class RenderState {
     	);
 
     	// Blending mode
-    	RenderState.blending = new RenderState(
-            { blend: false, src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA, src_alpha: gl.ONE, dst_alpha: gl.ONE_MINUS_SRC_ALPHA },
+    	RenderState.blending = new RenderState({
+                blend: RenderState.defaults.blending,
+                src: RenderState.defaults.blending_src,
+                dst: RenderState.defaults.blending_dst,
+                src_alpha: RenderState.defaults.blending_src_alpha,
+                dst_alpha: RenderState.defaults.blending_dst_alpha
+            },
             (value) => {
     			if (value.blend) {
             		gl.enable(gl.BLEND);
@@ -49,7 +71,7 @@ export default class RenderState {
 
     	// Depth write
     	RenderState.depth_write = new RenderState(
-    		{ depth_write: true },
+    		{ depth_write: RenderState.defaults.depth_write },
     		(value) => {
         		gl.depthMask(value.depth_write);
     		}
@@ -57,7 +79,7 @@ export default class RenderState {
 
     	// Depth test
     	RenderState.depth_test = new RenderState(
-    		{ depth_test: true, depth_func: gl.LEQUAL },
+    		{ depth_test: RenderState.defaults.depth_test, depth_func: RenderState.defaults.depth_func },
     		(value) => {
     			if (value.depth_test) {
             		gl.enable(gl.DEPTH_TEST);

--- a/src/scene.js
+++ b/src/scene.js
@@ -587,7 +587,7 @@ export default class Scene {
         // Reset frame state
         let gl = this.gl;
 
-        RenderState.depth_test.set({ depth_test: depth_test, depth_func: gl.LEQUAL });
+        RenderState.depth_test.set({ depth_test: depth_test, depth_func: gl.LESS });
         RenderState.depth_write.set({ depth_write: depth_write });
         RenderState.culling.set({ cull: cull_face, face: gl.BACK });
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -579,17 +579,17 @@ export default class Scene {
 
         // Defaults
         // TODO: when we abstract out support for multiple render passes, these can be per-pass config options
-        depth_test = (depth_test === false) ? false : true;     // default true
-        depth_write = (depth_write === false) ? false : true;   // default true
-        cull_face = (cull_face === false) ? false : true;       // default true
-        blend = (blend != null) ? blend : false;                // default false
+        depth_test = (depth_test === false) ? false : RenderState.defaults.depth_test;      // default true
+        depth_write = (depth_write === false) ? false : RenderState.defaults.depth_write;   // default true
+        cull_face = (cull_face === false) ? false : RenderState.defaults.culling;           // default true
+        blend = (blend != null) ? blend : RenderState.defaults.blending;                    // default false
 
         // Reset frame state
         let gl = this.gl;
 
-        RenderState.depth_test.set({ depth_test: depth_test, depth_func: gl.LESS });
+        RenderState.depth_test.set({ depth_test: depth_test, depth_func: RenderState.defaults.depth_func });
         RenderState.depth_write.set({ depth_write: depth_write });
-        RenderState.culling.set({ cull: cull_face, face: gl.BACK });
+        RenderState.culling.set({ cull: cull_face, face: RenderState.defaults.culling_face });
 
         // Blending of alpha channel is modified to account for WebGL alpha behavior, see:
         // http://webglfundamentals.org/webgl/lessons/webgl-and-alpha.html


### PR DESCRIPTION
#260 

Consistent behavior between -es and -js with several styles including while using alpha blending on. 
No specific improvement on render time noticed nor overdrawing improvements, profiled on mobile and browser.