### PR TITLE
Cache Canvas text sizes and line layouts

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -32,6 +32,7 @@ import {StyleManager} from './styles/style_manager';
 import {StyleParser} from './styles/style_parser';
 import Collision from './labels/collision';
 import FeatureSelection from './selection';
+import CanvasText from './styles/text/canvas_text';
 
 import yaml from 'js-yaml';
 
@@ -56,7 +57,8 @@ var debug = {
     StyleManager,
     StyleParser,
     Collision,
-    FeatureSelection
+    FeatureSelection,
+    CanvasText
 };
 
 if (Utils.isMainThread) {

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -37,12 +37,17 @@ export default class CanvasText {
     textSizes (texts) {
         for (let style in texts) {
             let text_infos = texts[style];
+            let first = true;
 
             for (let text in text_infos) {
                 // Use cached size, or compute via canvas
                 if (!CanvasText.text_cache[style] || !CanvasText.text_cache[style][text]) {
                     let text_settings = text_infos[text].text_settings;
-                    this.setFont(text_settings); // TODO: only set once above
+                    if (first) {
+                        this.setFont(text_settings);
+                        first = false;
+                    }
+
                     CanvasText.text_cache[style] = CanvasText.text_cache[style] || {};
                     CanvasText.text_cache[style][text] =
                         this.textSize(text, text_settings.transform, text_settings.text_wrap);
@@ -182,16 +187,22 @@ export default class CanvasText {
     rasterize (texts, texture_size) {
         for (let style in texts) {
             let text_infos = texts[style];
+            let first = true;
 
             for (let text in text_infos) {
                 let info = text_infos[text];
+                let text_settings = info.text_settings;
                 let lines = CanvasText.text_cache[style][text].lines; // get previously computed lines of text
 
-                this.setFont(info.text_settings); // TODO: only set once above
+                if (first) {
+                    this.setFont(text_settings);
+                    first = false;
+                }
+
                 this.drawText(lines, info.position, info.size, {
-                    stroke: info.text_settings.stroke,
-                    transform: info.text_settings.transform,
-                    align: info.text_settings.align
+                    stroke: text_settings.stroke,
+                    transform: text_settings.transform,
+                    align: text_settings.align
                 });
 
                 info.texcoords = Texture.getTexcoordsForSprite(

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -19,7 +19,8 @@ export default TextSettings = {
             settings.stroke_width,
             settings.transform,
             settings.text_wrap,
-            settings.align
+            settings.align,
+            Utils.device_pixel_ratio
         ].join('/');
     },
 


### PR DESCRIPTION
A few optimizations to Canvas text rendering:

- Cache results of unique style/text string combinations, so we can avoid computing them more than once.
  - This typically leads to anywhere between 40%-60% cache hit rate, reducing potentially expensive Canvas text `measureText()` calls (especially observed as slow for non-Latin characters) by about half.
- Keep the computed text lines (from applying word-wrapping) on the main thread (they don't need to be sent to the worker because they can be retrieved later during the text rasterization call).
- Only set the Canvas context text style once per text group.