### PR TITLE
Add support for GeoJSON polygon centroid labeling

### DIFF
--- a/src/geo.js
+++ b/src/geo.js
@@ -178,18 +178,22 @@ Geo.geometryType = function(type) {
 };
 
 Geo.centroid = function (polygon) {
-    let n = polygon.length;
-    let centroid = [0, 0];
+    // Adapted from https://github.com/Leaflet/Leaflet/blob/c10f405a112142b19785967ce0e142132a6095ad/src/layer/vector/Polygon.js#L57
+    let p0, p1, f;
+    let x = 0, y = 0, area = 0;
+    let len = polygon.length;
 
-    for (let p=0; p < polygon.length; p++) {
-        centroid[0] += polygon[p][0];
-        centroid[1] += polygon[p][1];
+    for (let i = 0, j = len - 1; i < len; j = i, i++) {
+        let p0 = polygon[i];
+        let p1 = polygon[j];
+        let f = p0[1] * p1[0] - p1[1] * p0[0];
+
+        x += (p0[0] + p1[0]) * f;
+        y += (p0[1] + p1[1]) * f;
+        area += f * 3;
     }
 
-    centroid[0] /= n;
-    centroid[1] /= n;
-
-    return centroid;
+    return [x / area, y / area];
 };
 
 Geo.multiCentroid = function (polygons) {

--- a/src/geo.js
+++ b/src/geo.js
@@ -179,7 +179,6 @@ Geo.geometryType = function(type) {
 
 Geo.centroid = function (polygon) {
     // Adapted from https://github.com/Leaflet/Leaflet/blob/c10f405a112142b19785967ce0e142132a6095ad/src/layer/vector/Polygon.js#L57
-    let p0, p1, f;
     let x = 0, y = 0, area = 0;
     let ring = polygon[0]; // only use first ring for now
     let len = ring.length;

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -131,11 +131,19 @@ export class GeoJSONSource extends NetworkSource {
                         features_centroid.push(centroid_feature);
                         break;
                     case 'MultiPolygon':
+                        // Add centroid feature for largest polygon
                         coordinates = feature.geometry.coordinates;
-                        for (let i = 0; i < coordinates.length; i++) {
-                            centroid_feature = getCentroidFeatureForPolygon(coordinates[i], feature.properties, centroid_properties);
-                            features_centroid.push(centroid_feature);
+                        let max_area = -Infinity;
+                        let max_area_index = 0;
+                        for (let index = 0; index < coordinates.length; index++) {
+                            let area = Geo.polygonArea(coordinates[index]);
+                            if (area > max_area) {
+                                max_area = area;
+                                max_area_index = index;
+                            }
                         }
+                        centroid_feature = getCentroidFeatureForPolygon(coordinates[max_area_index], feature.properties, centroid_properties);
+                        features_centroid.push(centroid_feature);
                         break;
                 }
             });

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -102,8 +102,16 @@ export class GeoJSONSource extends NetworkSource {
 
     parseSourceData (tile, source, response) {
         let parsed_response = JSON.parse(response);
-        this.preprocessFeatures(parsed_response.features);
-        source.layers = this.getLayers(parsed_response);
+        let layers = this.getLayers(parsed_response);
+        this.preprocessLayers(layers);
+        source.layers = layers;
+    }
+
+    preprocessLayers (layers){
+        for (let key in layers) {
+            let layer = layers[key];
+            this.preprocessFeatures(layer.features);
+        }
     }
 
     // Preprocess features. Currently used to add a new "centroid" feature for polygon labeling

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -111,7 +111,7 @@ export class GeoJSONSource extends NetworkSource {
         // Define centroids for polygons for centroid label placement
         // Avoids redundant label placement for each generated tile at higher zoom levels
         let features_centroid = [];
-        let label_key = 'label_centroid';
+        let label_key = 'label_placement';
 
         features.forEach(feature => {
             let coordinates;

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -110,8 +110,8 @@ export class GeoJSONSource extends NetworkSource {
     preprocessFeatures (features){
         // Define centroids for polygons for centroid label placement
         // Avoids redundant label placement for each generated tile at higher zoom levels
-        var features_centroid = [];
-        var label_key = 'label_centroid';
+        let features_centroid = [];
+        let label_key = 'label_centroid';
 
         features.forEach(feature => {
             let coordinates;

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -221,7 +221,7 @@ DataSource.register(GeoJSONTileSource, 'GeoJSONTiles'); // for backwards-compati
 
 // Helper function to create centroid point feature from polygon coordinates and provided feature meta-data
 function getCentroidFeatureForPolygon (coordinates, properties, newProperties) {
-    let centroid = Geo.centroid(coordinates[0]);
+    let centroid = Geo.centroid(coordinates);
 
     // clone properties and mixix newProperties
     let centroid_properties = {};

--- a/src/sources/topojson.js
+++ b/src/sources/topojson.js
@@ -24,13 +24,13 @@ export class TopoJSONSource extends GeoJSONSource {
         if (data.objects &&
             Object.keys(data.objects).length === 1) {
             let layer = Object.keys(data.objects)[0];
-            data = topojson.feature(data, data.objects[layer]);
+            data = getTopoJSONFeature(data, data.objects[layer]);
         }
         // Multiple layers
         else {
             let layers = {};
             for (let key in data.objects) {
-                layers[key] = topojson.feature(data, data.objects[key]);
+                layers[key] = getTopoJSONFeature(data, data.objects[key]);
             }
             data = layers;
         }
@@ -38,6 +38,20 @@ export class TopoJSONSource extends GeoJSONSource {
     }
 
 }
+
+function getTopoJSONFeature (topology, object) {
+    let feature = topojson.feature(topology, object);
+
+    // Convert single feature to a feature collection
+    if (feature.type === 'Feature') {
+        feature = {
+            type: 'FeatureCollection',
+            features: [feature]
+        };
+    }
+    return feature;
+}
+
 
 /**
  Mapzen/OSM.US-style TopoJSON vector tiles

--- a/src/sources/topojson.js
+++ b/src/sources/topojson.js
@@ -13,6 +13,7 @@ export class TopoJSONSource extends GeoJSONSource {
     parseSourceData (tile, source, response) {
         let data = JSON.parse(response);
         data = this.toGeoJSON(data);
+        super.preprocessFeatures(data.features);
         source.layers = this.getLayers(data);
     }
 

--- a/src/sources/topojson.js
+++ b/src/sources/topojson.js
@@ -13,8 +13,10 @@ export class TopoJSONSource extends GeoJSONSource {
     parseSourceData (tile, source, response) {
         let data = JSON.parse(response);
         data = this.toGeoJSON(data);
-        super.preprocessFeatures(data.features);
-        source.layers = this.getLayers(data);
+
+        let layers = this.getLayers(data);
+        super.preprocessLayers(layers);
+        source.layers = layers;
     }
 
     toGeoJSON (data) {

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -296,7 +296,7 @@ Object.assign(Points, {
         else if (geometry.type === "Polygon") {
             // Point at polygon centroid (of outer ring)
             if (options.centroid) {
-                let centroid = Geo.centroid(geometry.coordinates[0]);
+                let centroid = Geo.centroid(geometry.coordinates);
                 labels.push(new LabelPoint(centroid, size, options));
             }
             // Point at each polygon vertex (all rings)

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -396,7 +396,7 @@ Object.assign(TextStyle, {
                 labels.push(new LabelPoint(points[i], size, options));
             }
         } else if (geometry.type === "Polygon") {
-            let centroid = Geo.centroid(geometry.coordinates[0]);
+            let centroid = Geo.centroid(geometry.coordinates);
             labels.push(new LabelPoint(centroid, size, options));
         } else if (geometry.type === "MultiPolygon") {
             let centroid = Geo.multiCentroid(geometry.coordinates);


### PR DESCRIPTION
This PR is a fix for #243 

It defines a new feature in the GeoJSON pipeline to calculate the centroids of polygons for labeling so that when the polygon is tiled, multiple redundant labels are not calculated for each tile.

<img width="1091" alt="screen shot 2016-04-22 at 4 02 49 pm" src="https://cloud.githubusercontent.com/assets/796394/14753513/e22b6d46-08a3-11e6-930c-8151c1850560.png">

In the photo above, the centroid labels are in blue, and the tiled labels are in yellow. We only want the centroid labels to appear. The expectation is for the user to not draw the text for the polygons in the data-source, but to filter the data based on points with the property `label_centroid` (this name can easily be changed) and to draw labels for only those points instead. Resulting in a rendering like the one below

<img width="1084" alt="screen shot 2016-04-22 at 4 09 08 pm" src="https://cloud.githubusercontent.com/assets/796394/14753637/9605a566-08a4-11e6-8a4a-80b8e2ae05b5.png">

This PR also supports MultiPolygons (creating a label for each one at its centroid), but doesn't currently support nested polygons (to create annulus-like shapes), whose "centroid" is a less well-defined (but possible, if we would like to add support for it).

@burritojustice @nvkelso @bcamper