### PR TITLE
Add 'introspection' mode to enable interactivity for all features

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -65,6 +65,7 @@ function extendLeaflet(options) {
                         continuousZoom: (LeafletLayer.leafletVersion === '1.x'),
                         highDensityDisplay: this.options.highDensityDisplay,
                         logLevel: this.options.logLevel,
+                        introspection: this.options.introspection,
                         // advanced option, app will have to manually called scene.update() per frame
                         disableRenderLoop: this.options.disableRenderLoop,
                         // advanced option, will require library to be served as same host as page

--- a/src/scene.js
+++ b/src/scene.js
@@ -946,7 +946,7 @@ export default class Scene {
     // Turn introspection mode on/off
     setIntrospection (val) {
         this.introspection = val || false;
-        this.updateConfig({ rebuild: true });
+        this.updateConfig();
     }
 
     // Update scene config, and optionally rebuild geometry

--- a/src/scene.js
+++ b/src/scene.js
@@ -76,6 +76,7 @@ export default class Scene {
         this.frame = 0;
         this.queue_screenshot = null;
         this.selection = null;
+        this.introspection = false;
         this.resetTime();
 
         this.container = options.container;
@@ -942,6 +943,12 @@ export default class Scene {
         }
     }
 
+    // Turn introspection mode on/off
+    setIntrospection (val) {
+        this.introspection = val || false;
+        this.updateConfig({ rebuild: true });
+    }
+
     // Update scene config, and optionally rebuild geometry
     // rebuild can be boolean, or an object containing rebuild options to passthrough
     updateConfig({ rebuild } = {}) {
@@ -978,7 +985,8 @@ export default class Scene {
         this.config_serialized = Utils.serializeWithFunctions(this.config);
         return WorkerBroker.postMessage(this.workers, 'self.updateConfig', {
             config: this.config_serialized,
-            generation: this.generation
+            generation: this.generation,
+            introspection: this.introspection
         });
     }
 

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -40,12 +40,13 @@ Object.assign(self, {
     },
 
     // Starts a config refresh
-    updateConfig ({ config, generation }) {
+    updateConfig ({ config, generation, introspection }) {
         config = JSON.parse(config);
 
         self.last_config = mergeObjects({}, self.config);
         self.config = mergeObjects({}, config);
         self.generation = generation;
+        self.introspection = introspection;
 
         // Data block functions are not context wrapped like the rest of the style functions are
         // TODO: probably want a cleaner way to exclude these
@@ -101,7 +102,11 @@ Object.assign(self, {
 
         // Expand styles
         config.styles = Utils.stringsToFunctions(config.styles, StyleParser.wrapFunction);
-        self.styles = StyleManager.build(config.styles, { generation: self.generation, sources: self.sources.tiles });
+        self.styles = StyleManager.build(config.styles, {
+            generation: self.generation,
+            sources: self.sources.tiles,
+            introspection: self.introspection
+        });
 
         // Parse each top-level layer as a separate rule tree
         self.layers = Utils.stringsToFunctions(config.layers, StyleParser.wrapFunction);

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -17,7 +17,7 @@ import log from 'loglevel';
 // Base class
 
 export var Style = {
-    init ({ generation, sources = {} } = {}) {
+    init ({ generation, sources = {}, introspection } = {}) {
         if (!this.isBuiltIn()) {
             this.built_in = false; // explicitly set to false to avoid any confusion
         }
@@ -26,7 +26,8 @@ export var Style = {
         this.sources = sources;                     // data sources for scene
         this.defines = (this.hasOwnProperty('defines') && this.defines) || {}; // #defines to be injected into the shaders
         this.shaders = (this.hasOwnProperty('shaders') && this.shaders) || {}; // shader customization (uniforms, defines, blocks, etc.)
-        this.selection = this.selection || false;   // flag indicating if this style supports feature selection
+        this.introspection = introspection || false;
+        this.selection = this.selection || this.introspection || false;   // flag indicating if this style supports feature selection
         this.compiling = false;                     // programs are currently compiling
         this.compiled = false;                      // programs are finished compiling
         this.program = null;                        // GL program reference (for main render pass)
@@ -202,7 +203,7 @@ export var Style = {
 
             // Feature selection (only if style supports it)
             var selectable = false;
-            style.interactive = rule_style.interactive;
+            style.interactive = this.introspection || rule_style.interactive;
             if (this.selection) {
                 selectable = StyleParser.evalProp(style.interactive, context);
             }


### PR DESCRIPTION
By default, feature selection is only available for features where it is has been explicitly enabled via the `interactive` flag. For authoring environments like Tangram Play, or debugging, it's useful to have feature interactivity enabled for **all** features in the scene.

This PR introduces an 'introspection' mode for this purpose. When enabled, feature selection is on for all features, regardless of their `interactive` setting in the scene file.

Introspection is off by default, but can be enabled when the Tangram Leaflet layer is initialized with:

```
layer = Tangram.leafletLayer({
   scene: '...',
   introspection: true,
   ...
};
```

Or enabled at run-time with:

`scene.setIntrospection(true);`

Enabling or disabling introspection at run-time will cause the scene to rebuild automatically to reflect the new setting.