### PR TITLE
Increase line width precision for overzoomed tiles

### DIFF
--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -86,9 +86,9 @@ Object.assign(Lines, {
 
         // convert to units and relative change from previous zoom
         // NB: multiply by 2 because a given width is twice as big in screen space at the next zoom
-        style.width = width * context.units_per_meter;
+        style.width = width * context.units_per_meter_overzoom;
         style.next_width = (next_width * 2) - width;
-        style.next_width *= context.units_per_meter;
+        style.next_width *= context.units_per_meter_overzoom;
         style.next_width /= 2; // NB: divide by 2 because extrusion width is halved in builder - remove?
 
         style.color = this.parseColor(rule_style.color, context);

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -86,7 +86,8 @@ void main() {
         width += dwdz * dz;
 
         // Scale pixel dimensions to be consistent in screen space
-        width *= exp2(-dz);
+        // Scale from style zoom units back to tile zoom
+        width *= exp2(-dz - (u_tile_origin.z - u_tile_origin.w));
 
         // Modify line width before extrusion
         #pragma tangram: width

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -79,7 +79,7 @@ StyleParser.getFeatureParseContext = function (feature, tile, global) {
         zoom: tile.style_zoom,
         geometry: Geo.geometryType(feature.geometry.type),
         meters_per_pixel: tile.meters_per_pixel,
-        units_per_meter: tile.units_per_meter
+        units_per_meter_overzoom: tile.units_per_meter_overzoom
     };
 };
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -42,11 +42,9 @@ export default class Tile {
         this.bounds = { sw: { x: this.min.x, y: this.max.y }, ne: { x: this.max.x, y: this.min.y } };
         this.center_dist = 0;
 
-        // Units per pixel needs to account for over-zooming
-        this.units_per_pixel = Geo.units_per_pixel / this.overzoom2;
-
         this.meters_per_pixel = Geo.metersPerPixel(this.coords.z);
-        this.units_per_meter = Geo.unitsPerMeter(this.coords.z);
+        this.units_per_pixel = Geo.units_per_pixel / this.overzoom2; // adjusted for overzoom
+        this.units_per_meter_overzoom = Geo.unitsPerMeter(this.coords.z) * this.overzoom2; // adjusted for overzoom
 
         this.meshes = {}; // renderable VBO meshes keyed by style
         this.textures = []; // textures that the tile owns (labels, etc.)
@@ -152,7 +150,7 @@ export default class Tile {
             max: this.max,
             units_per_pixel: this.units_per_pixel,
             meters_per_pixel: this.meters_per_pixel,
-            units_per_meter: this.units_per_meter,
+            units_per_meter_overzoom: this.units_per_meter_overzoom,
             style_zoom: this.style_zoom,
             overzoom: this.overzoom,
             overzoom2: this.overzoom2,


### PR DESCRIPTION
Line width is stored in a signed short GL attribute. Previously, the units used were the tile's coordinates, which (in Tangram JS) have a scale of 0-4096. When tiles are overzoomed, those units cover more and more screenspace. This causes precision loss and eventually lines disappear entirely, as their width collapses to zero. In Bubble Wrap, for example, this causes 1px building outlines to disappear at z20 (when overzoomed from z16 tiles). See #267 for more info.

This PR adjust the units for line width to multiply by the number of overzoom levels squared, e.g. units for z16 tiles shown at z20 are multipled by 4^2, or 16x. This ensures that the same level of precision is maintained for line widths at all zooms, regardless of overzooming.

Verified this in Differ, and added a z20 test case with building outlines:

![0la oekasrqaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/16733/15337044/8bb4ec0a-1c47-11e6-8a60-6f3a25fd5552.png)

