### PR TITLE
Add textured lines w/support for dash array patterns

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -333,6 +333,7 @@ layers:
             filter: { kind: ferry }
             draw:
                 lines:
+                    style: dashed
                     color: '#8db3ce'
                     width: [[14, 1px], [18, 2px]]
                     outline:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -140,6 +140,9 @@ styles:
                     // Just visualize the grid lines directly
                     color = vec4(vec3(1.0 - min(line, 1.0)), 1.0);
 
+    dash:
+        base: lines
+        dasharray: [2, 1]
 
 sources:
     mapzen:
@@ -321,8 +324,9 @@ layers:
             filter: { kind: path }
             draw:
                 lines:
-                    color: '#bbb'
-                    width: [[15, 0px], [18, 2px]]
+                    style: dash
+                    color: white
+                    width: [[15, 0px], [18, 3px]]
                     outline:
                         width: 0
         ferry:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -140,9 +140,9 @@ styles:
                     // Just visualize the grid lines directly
                     color = vec4(vec3(1.0 - min(line, 1.0)), 1.0);
 
-    dash:
+    dashed:
         base: lines
-        dasharray: [2, 1]
+        dash: [2, 1]
 
 sources:
     mapzen:
@@ -324,7 +324,7 @@ layers:
             filter: { kind: path }
             draw:
                 lines:
-                    style: dash
+                    style: dashed
                     color: white
                     width: [[15, 0px], [18, 3px]]
                     outline:

--- a/src/builders/polylines.js
+++ b/src/builders/polylines.js
@@ -32,8 +32,9 @@ export function buildPolylines (
         tile_edge_tolerance,
         texcoord_index,
         texcoord_scale,
-        texcoord_normalize,
+        texcoord_width,
         texcoord_ratio,
+        texcoord_normalize,
         scaling_index,
         scaling_normalize,
         join, cap,
@@ -69,7 +70,7 @@ export function buildPolylines (
         texcoords: texcoord_index && [],
         texcoord_normalize,
         min_u, min_v, max_u, max_v,
-        v_scale: 1 / ((width * texcoord_ratio) * v_scale_adjust), // scales line texture as a ratio of the line's width
+        v_scale: 1 / ((texcoord_width * texcoord_ratio) * v_scale_adjust), // scales line texture as a ratio of the line's width
         total_dist: 0,
         num_pairs: 0
     };

--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -170,6 +170,11 @@ export default class Texture {
         this.source = data;
         this.source_type = 'data';
 
+        // Convert regular array to typed array
+        if (Array.isArray(this.source)) {
+            this.source = new Uint8Array(this.source);
+        }
+
         this.update(options);
         this.setFiltering(options);
 

--- a/src/styles/lines/dasharray.js
+++ b/src/styles/lines/dasharray.js
@@ -13,7 +13,7 @@
 const default_dash_color = [255, 255, 255, 255];
 const default_background_color = [0, 0, 0, 0];
 
-export default function renderDashArray (pattern, options) {
+export default function renderDashArray (pattern, options = {}) {
     const dash_pixel = options.dash_color || default_dash_color;
     const background_color = options.background_color || default_background_color;
     const dashes = pattern;

--- a/src/styles/lines/dasharray.js
+++ b/src/styles/lines/dasharray.js
@@ -9,9 +9,13 @@
 // https://www.w3.org/TR/SVG/painting.html#StrokeDasharrayProperty
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray
 
-const dash_pixel = [255, 255, 255, 255];
+const default_dash_color = [255, 255, 255, 255];
+const default_space_color = [0, 0, 0, 0];
 
-export default function renderDasharray (dasharray, space_pixel = [0, 0, 0, 0]) {
+export default function renderDasharray (dasharray, options) {
+    const dash_pixel = options.dash_color || default_dash_color;
+    const space_color = options.space_color || default_space_color;
+
     let dashes = dasharray;
 
     // If pattern is odd, repeat it to make it even (see SVG spec)
@@ -24,7 +28,7 @@ export default function renderDasharray (dasharray, space_pixel = [0, 0, 0, 0]) 
     for (let i=0; i < dashes.length; i++) {
         let segment = dashes[i];
         for (let s=0; s < segment; s++) {
-            Array.prototype.push.apply(pixels, dash ? dash_pixel : space_pixel);
+            Array.prototype.push.apply(pixels, dash ? dash_pixel : space_color);
         }
         dash = !dash; // alternate between dashes and spaces
     }

--- a/src/styles/lines/dasharray.js
+++ b/src/styles/lines/dasharray.js
@@ -10,11 +10,11 @@
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray
 
 const default_dash_color = [255, 255, 255, 255];
-const default_space_color = [0, 0, 0, 0];
+const default_background_color = [0, 0, 0, 0];
 
 export default function renderDasharray (dasharray, options) {
     const dash_pixel = options.dash_color || default_dash_color;
-    const space_color = options.space_color || default_space_color;
+    const background_color = options.background_color || default_background_color;
 
     let dashes = dasharray;
 
@@ -28,7 +28,7 @@ export default function renderDasharray (dasharray, options) {
     for (let i=0; i < dashes.length; i++) {
         let segment = dashes[i];
         for (let s=0; s < segment; s++) {
-            Array.prototype.push.apply(pixels, dash ? dash_pixel : space_color);
+            Array.prototype.push.apply(pixels, dash ? dash_pixel : background_color);
         }
         dash = !dash; // alternate between dashes and spaces
     }

--- a/src/styles/lines/dasharray.js
+++ b/src/styles/lines/dasharray.js
@@ -1,4 +1,4 @@
-// Renders an array specifying a line pattern of alternating dashes and gaps,
+// Renders an array specifying a line pattern of alternating dashes and spaces,
 // similar to an SVG `dasharray`, into a byte array of RGBA pixels
 // Returns:
 // {
@@ -10,9 +10,8 @@
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray
 
 const dash_pixel = [255, 255, 255, 255];
-const gap_pixel = [0, 0, 0, 0];
 
-export default function renderDasharray (dasharray) {
+export default function renderDasharray (dasharray, space_pixel = [0, 0, 0, 0]) {
     let dashes = dasharray;
 
     // If pattern is odd, repeat it to make it even (see SVG spec)
@@ -25,9 +24,9 @@ export default function renderDasharray (dasharray) {
     for (let i=0; i < dashes.length; i++) {
         let segment = dashes[i];
         for (let s=0; s < segment; s++) {
-            Array.prototype.push.apply(pixels, dash ? dash_pixel : gap_pixel);
+            Array.prototype.push.apply(pixels, dash ? dash_pixel : space_pixel);
         }
-        dash = !dash; // alternate between dashes and gaps
+        dash = !dash; // alternate between dashes and spaces
     }
 
     pixels = new Uint8Array(pixels); // convert to typed array

--- a/src/styles/lines/dasharray.js
+++ b/src/styles/lines/dasharray.js
@@ -1,0 +1,37 @@
+// Renders an array specifying a line pattern of alternating dashes and gaps,
+// similar to an SVG `dasharray`, into a byte array of RGBA pixels
+// Returns:
+// {
+//    pixel: rendered image in Uint8Array buffer
+//    length: pixel length of rendered dasharray pattern (sum of all dashes and spaces)
+// }
+//
+// https://www.w3.org/TR/SVG/painting.html#StrokeDasharrayProperty
+// https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray
+
+const dash_pixel = [255, 255, 255, 255];
+const gap_pixel = [0, 0, 0, 0];
+
+export default function renderDasharray (dasharray) {
+    let dashes = dasharray;
+
+    // If pattern is odd, repeat it to make it even (see SVG spec)
+    if (dashes.length % 2 === 1) {
+        Array.prototype.push.apply(dashes, dashes);
+    }
+
+    let dash = true;
+    let pixels = [];
+    for (let i=0; i < dashes.length; i++) {
+        let segment = dashes[i];
+        for (let s=0; s < segment; s++) {
+            Array.prototype.push.apply(pixels, dash ? dash_pixel : gap_pixel);
+        }
+        dash = !dash; // alternate between dashes and gaps
+    }
+
+    pixels = new Uint8Array(pixels); // convert to typed array
+    const length = pixels.length / 4; // one RGBA byte sequences to one pixel
+
+    return { pixels, length };
+}

--- a/src/styles/lines/dasharray.js
+++ b/src/styles/lines/dasharray.js
@@ -1,22 +1,22 @@
 // Renders an array specifying a line pattern of alternating dashes and spaces,
-// similar to an SVG `dasharray`, into a byte array of RGBA pixels
+// similar to an SVG `dasharray` or Canvas setLineDash(), into a byte array of RGBA pixels
 // Returns:
 // {
 //    pixel: rendered image in Uint8Array buffer
-//    length: pixel length of rendered dasharray pattern (sum of all dashes and spaces)
+//    length: pixel length of rendered dash pattern (sum of all dashes and spaces)
 // }
 //
 // https://www.w3.org/TR/SVG/painting.html#StrokeDasharrayProperty
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray
+// https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash
 
 const default_dash_color = [255, 255, 255, 255];
 const default_background_color = [0, 0, 0, 0];
 
-export default function renderDasharray (dasharray, options) {
+export default function renderDashArray (pattern, options) {
     const dash_pixel = options.dash_color || default_dash_color;
     const background_color = options.background_color || default_background_color;
-
-    let dashes = dasharray;
+    const dashes = pattern;
 
     // If pattern is odd, repeat it to make it even (see SVG spec)
     if (dashes.length % 2 === 1) {

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -81,7 +81,8 @@ Object.assign(Lines, {
                 this.dash_space_color[3] = 0; // alpha value is used to test if pixel is dash or space
             }
 
-            let dasharray = renderDasharray(this.dasharray, this.dash_space_color);
+            // Render line pattern
+            let dasharray = renderDasharray(this.dasharray, { space_color: this.dash_space_color });
             let texname = this.name + '_dasharray';
             Texture.create(this.gl, texname, {
                 data: dasharray.pixels,

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -83,23 +83,19 @@ Object.assign(Lines, {
 
             // Render line pattern
             let dash = renderDashArray(this.dash, { background_color: this.dash_background_color });
-            let texname = this.name + '_dasharray';
-            Texture.create(this.gl, texname, {
+            this.texture = '_' + this.name + '_dasharray';
+            Texture.create(this.gl, this.texture, {
                 data: dash.pixels,
                 height: dash.length,
                 width: 1,
                 filtering: 'nearest'
             });
 
-            this.defines.TANGRAM_LINE_TEXTURE = true;
             this.defines.TANGRAM_LINE_BACKGROUND_COLOR = (this.dash_background_color != null);
-            this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are line "spaces"
-            this.shaders.uniforms = this.shaders.uniforms || {};
-            this.shaders.uniforms.u_texture = texname;
-            this.shaders.uniforms.u_texture_ratio = dash.length;
         }
-        // Specify a texture directly
-        else if (this.texture) {
+
+        // Specify a line texture (either directly, or rendered dash pattern from above)
+        if (this.texture) {
             this.defines.TANGRAM_LINE_TEXTURE = true;
             this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are transparent
             this.shaders.uniforms = this.shaders.uniforms || {};

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -86,18 +86,24 @@ Object.assign(Lines, {
             });
 
             this.defines.TANGRAM_LINE_TEXTURE = true;
-            this.defines.TANGRAM_LINE_TEXTURE_RATIO = dasharray.length;
             this.defines.TANGRAM_ALPHA_DISCARD = 0.5;
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = texname;
+            this.shaders.uniforms.u_texture_ratio = dasharray.length;
         }
         // Specify a texture directly
         else if (this.texture) {
             this.defines.TANGRAM_LINE_TEXTURE = true;
-            // TODO: set ratio based on texture size (must wait for texture to load)
-            this.defines.TANGRAM_LINE_TEXTURE_RATIO = this.defines.TANGRAM_LINE_TEXTURE_RATIO || 1;
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = this.texture;
+            this.shaders.uniforms.u_texture_ratio = 1;
+
+            // update line pattern aspect ratio after texture loads
+            Texture.getInfo(this.texture).then(texture => {
+                if (texture) {
+                    this.shaders.uniforms.u_texture_ratio = texture.height / texture.width;
+                }
+            });
         }
     },
 

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -75,8 +75,13 @@ Object.assign(Lines, {
     parseLineTexture () {
         // Specify a line pattern
         if (this.dasharray) {
+            // Optional color for spaces in dahs pattern (defaults transparent)
+            if (this.dash_space_color) {
+                this.dash_space_color = StyleParser.parseColor(this.dash_space_color).map(c => c * 255);
+            }
+
             // TODO: add dasharray to style mixing
-            let dasharray = renderDasharray(this.dasharray);
+            let dasharray = renderDasharray(this.dasharray, this.dash_space_color);
             let texname = this.name + '_dasharray';
             Texture.create(this.gl, texname, {
                 data: dasharray.pixels,
@@ -86,7 +91,9 @@ Object.assign(Lines, {
             });
 
             this.defines.TANGRAM_LINE_TEXTURE = true;
-            this.defines.TANGRAM_ALPHA_DISCARD = 0.5;
+            if (!this.dash_space_color || this.dash_space_color[3] === 0) {
+                this.defines.TANGRAM_ALPHA_DISCARD = 0.5; // discard is on when spaces are transparent
+            }
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = texname;
             this.shaders.uniforms.u_texture_ratio = dasharray.length;

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -80,7 +80,6 @@ Object.assign(Lines, {
                 this.dash_space_color = StyleParser.parseColor(this.dash_space_color).map(c => c * 255);
             }
 
-            // TODO: add dasharray to style mixing
             let dasharray = renderDasharray(this.dasharray, this.dash_space_color);
             let texname = this.name + '_dasharray';
             Texture.create(this.gl, texname, {

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -79,6 +79,7 @@ Object.assign(Lines, {
             if (this.dash_background_color) {
                 this.dash_background_color = StyleParser.parseColor(this.dash_background_color).map(c => c * 255);
                 this.dash_background_color[3] = 0; // alpha value is used to test if pixel is dash or space
+                this.defines.TANGRAM_LINE_BACKGROUND_COLOR = true;
             }
 
             // Render line pattern
@@ -90,8 +91,6 @@ Object.assign(Lines, {
                 width: 1,
                 filtering: 'nearest'
             });
-
-            this.defines.TANGRAM_LINE_BACKGROUND_COLOR = (this.dash_background_color != null);
         }
 
         // Specify a line texture (either directly, or rendered dash pattern from above)

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -314,7 +314,7 @@ Object.assign(Lines, {
                 scaling_index: this.vertex_layout.index.a_extrude,
                 scaling_normalize: 256, // values have an 8-bit fraction
                 texcoord_index: this.vertex_layout.index.a_texcoord,
-                texcoord_width: style.width || style.next_width, // UVs can't calc for zero-width, use next zoom width in that case
+                texcoord_width: (style.width || style.next_width) / context.tile.overzoom2, // UVs can't calc for zero-width, use next zoom width in that case
                 texcoord_normalize: 65535, // scale UVs to unsigned shorts
                 closed_polygon: options && options.closed_polygon,
                 remove_tile_edges: !style.tile_edges && options && options.remove_tile_edges,

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -7,7 +7,7 @@ import gl from '../../gl/constants'; // web workers don't have access to GL cont
 import Texture from '../../gl/texture';
 import VertexLayout from '../../gl/vertex_layout';
 import {buildPolylines} from '../../builders/polylines';
-import renderDasharray from './dasharray';
+import renderDashArray from './dasharray';
 import Geo from '../../geo';
 import {shaderSrc_polygonsVertex, shaderSrc_polygonsFragment} from '../polygons/polygons';
 
@@ -39,9 +39,9 @@ Object.assign(Lines, {
             attribs.push({ name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true });
         }
 
-        // Optional line texture or dasharray
+        // Optional line texture or dash array
         // (latter will be rendered at compile-time, when GL context available)
-        if (this.texture || this.dasharray) {
+        if (this.texture || this.dash) {
             this.texcoords = true;
         }
 
@@ -71,10 +71,10 @@ Object.assign(Lines, {
         return Style.compile.apply(this, arguments);
     },
 
-    // Optionally apply a dasharray pattern to this line
+    // Optionally apply a dash array pattern to this line
     parseLineTexture () {
         // Specify a line pattern
-        if (this.dasharray) {
+        if (this.dash) {
             // Optional background color for dash pattern (defaults transparent)
             if (this.dash_background_color) {
                 this.dash_background_color = StyleParser.parseColor(this.dash_background_color).map(c => c * 255);
@@ -82,11 +82,11 @@ Object.assign(Lines, {
             }
 
             // Render line pattern
-            let dasharray = renderDasharray(this.dasharray, { background_color: this.dash_background_color });
+            let dash = renderDashArray(this.dash, { background_color: this.dash_background_color });
             let texname = this.name + '_dasharray';
             Texture.create(this.gl, texname, {
-                data: dasharray.pixels,
-                height: dasharray.length,
+                data: dash.pixels,
+                height: dash.length,
                 width: 1,
                 filtering: 'nearest'
             });
@@ -96,7 +96,7 @@ Object.assign(Lines, {
             this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are line "spaces"
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = texname;
-            this.shaders.uniforms.u_texture_ratio = dasharray.length;
+            this.shaders.uniforms.u_texture_ratio = dash.length;
         }
         // Specify a texture directly
         else if (this.texture) {

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -75,14 +75,14 @@ Object.assign(Lines, {
     parseLineTexture () {
         // Specify a line pattern
         if (this.dasharray) {
-            // Optional color for spaces in dahs pattern (defaults transparent)
-            if (this.dash_space_color) {
-                this.dash_space_color = StyleParser.parseColor(this.dash_space_color).map(c => c * 255);
-                this.dash_space_color[3] = 0; // alpha value is used to test if pixel is dash or space
+            // Optional background color for dash pattern (defaults transparent)
+            if (this.dash_background_color) {
+                this.dash_background_color = StyleParser.parseColor(this.dash_background_color).map(c => c * 255);
+                this.dash_background_color[3] = 0; // alpha value is used to test if pixel is dash or space
             }
 
             // Render line pattern
-            let dasharray = renderDasharray(this.dasharray, { space_color: this.dash_space_color });
+            let dasharray = renderDasharray(this.dasharray, { background_color: this.dash_background_color });
             let texname = this.name + '_dasharray';
             Texture.create(this.gl, texname, {
                 data: dasharray.pixels,
@@ -92,7 +92,7 @@ Object.assign(Lines, {
             });
 
             this.defines.TANGRAM_LINE_TEXTURE = true;
-            this.defines.TANGRAM_LINE_SPACE_COLOR = (this.dash_space_color != null);
+            this.defines.TANGRAM_LINE_BACKGROUND_COLOR = (this.dash_background_color != null);
             this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are line "spaces"
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = texname;

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -77,13 +77,13 @@ Object.assign(Lines, {
         if (this.dash) {
             // Optional background color for dash pattern (defaults transparent)
             if (this.dash_background_color) {
-                this.dash_background_color = StyleParser.parseColor(this.dash_background_color).map(c => c * 255);
-                this.dash_background_color[3] = 0; // alpha value is used to test if pixel is dash or space
-                this.defines.TANGRAM_LINE_BACKGROUND_COLOR = true;
+                this.dash_background_color = StyleParser.parseColor(this.dash_background_color);
+                this.defines.TANGRAM_LINE_BACKGROUND_COLOR =
+                    `vec3(${this.dash_background_color.slice(0, 3).join(', ')})`;
             }
 
             // Render line pattern
-            let dash = renderDashArray(this.dash, { background_color: this.dash_background_color });
+            let dash = renderDashArray(this.dash);
             this.texture = '_' + this.name + '_dasharray';
             Texture.create(this.gl, this.texture, {
                 data: dash.pixels,

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -313,7 +313,7 @@ Object.assign(Lines, {
                 scaling_index: this.vertex_layout.index.a_extrude,
                 scaling_normalize: 256, // values have an 8-bit fraction
                 texcoord_index: this.vertex_layout.index.a_texcoord,
-                texcoord_scale: this.texcoord_scale,
+                texcoord_width: style.width || style.next_width, // UVs can't calc for zero-width, use next zoom width in that case
                 texcoord_normalize: 65535, // scale UVs to unsigned shorts
                 closed_polygon: options && options.closed_polygon,
                 remove_tile_edges: !style.tile_edges && options && options.remove_tile_edges,

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -78,6 +78,7 @@ Object.assign(Lines, {
             // Optional color for spaces in dahs pattern (defaults transparent)
             if (this.dash_space_color) {
                 this.dash_space_color = StyleParser.parseColor(this.dash_space_color).map(c => c * 255);
+                this.dash_space_color[3] = 0; // alpha value is used to test if pixel is dash or space
             }
 
             let dasharray = renderDasharray(this.dasharray, this.dash_space_color);
@@ -90,9 +91,8 @@ Object.assign(Lines, {
             });
 
             this.defines.TANGRAM_LINE_TEXTURE = true;
-            if (!this.dash_space_color || this.dash_space_color[3] === 0) {
-                this.defines.TANGRAM_ALPHA_DISCARD = 0.5; // discard is on when spaces are transparent
-            }
+            this.defines.TANGRAM_LINE_SPACE_COLOR = (this.dash_space_color != null);
+            this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are line "spaces"
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = texname;
             this.shaders.uniforms.u_texture_ratio = dasharray.length;
@@ -100,6 +100,7 @@ Object.assign(Lines, {
         // Specify a texture directly
         else if (this.texture) {
             this.defines.TANGRAM_LINE_TEXTURE = true;
+            this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are transparent
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = this.texture;
             this.shaders.uniforms.u_texture_ratio = 1;

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -493,7 +493,7 @@ Object.assign(Points, {
                 offset,
                 angle: angle * 4096,    // values have a 12-bit fraction
                 shape_w: sampler,
-                texcoord_scale: texcoord_scale,
+                texcoord_scale,
                 texcoord_normalize: 65535
             }
         );

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -22,8 +22,8 @@ varying vec4 v_world_position;
 #define TANGRAM_NORMAL vec3(0., 0., 1.)
 
 // Alpha discard threshold (substitute for alpha blending)
-#ifndef TANGRAM_ALPHA_DISCARD
-#define TANGRAM_ALPHA_DISCARD 0.5
+#ifndef TANGRAM_ALPHA_TEST
+#define TANGRAM_ALPHA_TEST 0.5
 #endif
 
 // Alpha fade range for edges of points
@@ -71,7 +71,7 @@ void main (void) {
 
     // If blending is off, use alpha discard as a lower-quality substitute
     #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
-        if (color.a < TANGRAM_ALPHA_DISCARD) {
+        if (color.a < TANGRAM_ALPHA_TEST) {
             discard;
         }
     #endif

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -151,7 +151,6 @@ Object.assign(Polygons, {
         let vertex_template = this.makeVertexTemplate(style);
         let options = {
             texcoord_index: this.vertex_layout.index.a_texcoord,
-            texcoord_scale: this.texcoord_scale,
             texcoord_normalize: 65535, // scale UVs to unsigned shorts
             remove_tile_edges: !style.tile_edges,
             tile_edge_tolerance: Geo.tile_scale * context.tile.pad_scale * 4,

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -48,7 +48,26 @@ void main (void) {
     // Apply line texture
     #ifdef TANGRAM_LINE_TEXTURE
         vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / u_texture_ratio));
-        color *= texture2D(u_texture, _line_st);
+        vec4 _line_color = texture2D(u_texture, _line_st);
+
+        #ifdef TANGRAM_ALPHA_TEST
+            if (_line_color.a < TANGRAM_ALPHA_TEST) {
+                #ifdef TANGRAM_LINE_SPACE_COLOR
+                    color.rgb = _line_color.rgb;
+                #else
+                    #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
+                        discard;
+                    #else
+                        color.a = 0.;
+                    #endif
+                #endif
+            }
+            else {
+                color *= _line_color;
+            }
+        #else
+            color *= _line_color;
+        #endif
     #endif
 
     // First, get normal from raster tile (if applicable)
@@ -80,11 +99,6 @@ void main (void) {
 
     // Post-processing effects (modify color after lighting)
     #pragma tangram: filter
-
-    // Alpha discard used instead of transparency
-    #if defined(TANGRAM_ALPHA_DISCARD) && !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
-        if (color.a < TANGRAM_ALPHA_DISCARD) discard;
-    #endif
 
     gl_FragColor = color;
 }

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -45,6 +45,12 @@ void main (void) {
         color *= sampleRaster(0); // multiplied to tint texture color
     #endif
 
+    // Apply line texture
+    #ifdef TANGRAM_LINE_TEXTURE
+        vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / TANGRAM_LINE_TEXTURE_RATIO));
+        color *= texture2D(u_texture, _line_st);
+    #endif
+
     // First, get normal from raster tile (if applicable)
     #ifdef TANGRAM_RASTER_TEXTURE_NORMAL
         normal = normalize(sampleRaster(0).rgb * 2. - 1.);
@@ -74,6 +80,11 @@ void main (void) {
 
     // Post-processing effects (modify color after lighting)
     #pragma tangram: filter
+
+    // Alpha discard used instead of transparency
+    #if defined(TANGRAM_ALPHA_DISCARD) && !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
+        if (color.a < TANGRAM_ALPHA_DISCARD) discard;
+    #endif
 
     gl_FragColor = color;
 }

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -53,12 +53,10 @@ void main (void) {
         if (_line_color.a < TANGRAM_ALPHA_TEST) {
             #ifdef TANGRAM_LINE_BACKGROUND_COLOR
                 color.rgb = _line_color.rgb;
+            #elif !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
+                discard; // use discard when alpha blending is unavailable
             #else
-                #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
-                    discard; // use discard when alpha blending is unavailable
-                #else
-                    color.a = 0.; // use alpha channel when blending is available
-                #endif
+                color.a = 0.; // use alpha channel when blending is available
             #endif
         }
         else {

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -52,7 +52,7 @@ void main (void) {
 
         if (_line_color.a < TANGRAM_ALPHA_TEST) {
             #ifdef TANGRAM_LINE_BACKGROUND_COLOR
-                color.rgb = _line_color.rgb;
+                color.rgb = TANGRAM_LINE_BACKGROUND_COLOR;
             #elif !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
                 discard; // use discard when alpha blending is unavailable
             #else

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -50,24 +50,20 @@ void main (void) {
         vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / u_texture_ratio));
         vec4 _line_color = texture2D(u_texture, _line_st);
 
-        #ifdef TANGRAM_ALPHA_TEST
-            if (_line_color.a < TANGRAM_ALPHA_TEST) {
-                #ifdef TANGRAM_LINE_BACKGROUND_COLOR
-                    color.rgb = _line_color.rgb;
+        if (_line_color.a < TANGRAM_ALPHA_TEST) {
+            #ifdef TANGRAM_LINE_BACKGROUND_COLOR
+                color.rgb = _line_color.rgb;
+            #else
+                #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
+                    discard; // use discard when alpha blending is unavailable
                 #else
-                    #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
-                        discard;
-                    #else
-                        color.a = 0.;
-                    #endif
+                    color.a = 0.; // use alpha channel when blending is available
                 #endif
-            }
-            else {
-                color *= _line_color;
-            }
-        #else
+            #endif
+        }
+        else {
             color *= _line_color;
-        #endif
+        }
     #endif
 
     // First, get normal from raster tile (if applicable)

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -47,7 +47,7 @@ void main (void) {
 
     // Apply line texture
     #ifdef TANGRAM_LINE_TEXTURE
-        vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / TANGRAM_LINE_TEXTURE_RATIO));
+        vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / u_texture_ratio));
         color *= texture2D(u_texture, _line_st);
     #endif
 

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -52,7 +52,7 @@ void main (void) {
 
         #ifdef TANGRAM_ALPHA_TEST
             if (_line_color.a < TANGRAM_ALPHA_TEST) {
-                #ifdef TANGRAM_LINE_SPACE_COLOR
+                #ifdef TANGRAM_LINE_BACKGROUND_COLOR
                     color.rgb = _line_color.rgb;
                 #else
                     #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -110,6 +110,8 @@ StyleManager.mix = function (style, styles) {
     style.lighting = sources.map(x => x.lighting).filter(x => x != null).pop();
     style.texture = sources.map(x => x.texture).filter(x => x).pop();
     style.raster = sources.map(x => x.raster).filter(x => x != null).pop();
+    style.dasharray = sources.map(x => x.dasharray).filter(x => x != null).pop();
+    style.dash_space_color = sources.map(x => x.dash_space_color).filter(x => x != null).pop();
     if (sources.some(x => x.hasOwnProperty('blend') && x.blend)) {
         // only mix blend if explicitly set, otherwise let base style choose blending mode
         // hasOwnProperty check gives preference to base style prototype

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -111,7 +111,7 @@ StyleManager.mix = function (style, styles) {
     style.texture = sources.map(x => x.texture).filter(x => x).pop();
     style.raster = sources.map(x => x.raster).filter(x => x != null).pop();
     style.dasharray = sources.map(x => x.dasharray).filter(x => x != null).pop();
-    style.dash_space_color = sources.map(x => x.dash_space_color).filter(x => x != null).pop();
+    style.dash_background_color = sources.map(x => x.dash_background_color).filter(x => x != null).pop();
     if (sources.some(x => x.hasOwnProperty('blend') && x.blend)) {
         // only mix blend if explicitly set, otherwise let base style choose blending mode
         // hasOwnProperty check gives preference to base style prototype

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -110,7 +110,7 @@ StyleManager.mix = function (style, styles) {
     style.lighting = sources.map(x => x.lighting).filter(x => x != null).pop();
     style.texture = sources.map(x => x.texture).filter(x => x).pop();
     style.raster = sources.map(x => x.raster).filter(x => x != null).pop();
-    style.dasharray = sources.map(x => x.dasharray).filter(x => x != null).pop();
+    style.dash = sources.map(x => x.dash).filter(x => x != null).pop();
     style.dash_background_color = sources.map(x => x.dash_background_color).filter(x => x != null).pop();
     if (sources.some(x => x.hasOwnProperty('blend') && x.blend)) {
         // only mix blend if explicitly set, otherwise let base style choose blending mode


### PR DESCRIPTION
This PR adds support for textured lines, with additional support for line dash patterns built in (using syntax similar to SVG/Canvas-style "dash array"). This is commonly used for features such as paths, administrative boundaries, stairs, or railway lines.

**Dash Patterns**
The simplest (and likely most common way) to create line patterns is through a dash pattern. This is done with a new `dash` parameter, as part of a style definition.

- The syntax of `dash` is an array defining a pattern of alternating dashes and spaces, e.g. `[2, 1]` creates a pattern of dashes that are each 2 units long, separated by spaces that are 1 unit long.
- The unit of the dash pattern is the *width* of its line, e.g. a value of `[1, 1]` creates a series of square dashes (separated by square spaces).
- If the dash pattern contains an *odd* number of entries, it is *repeated* to form an even pattern ([as in SVG](https://www.w3.org/TR/SVG/painting.html#StrokeDasharrayProperty)). This means that the `[1, 1]` example above is equivalent to just `[1]`. Similarly, `[3, 1, 1]` would become `[3, 1, 1, 3, 1, 1]`.
- Example of a simple dash pattern, applied to park paths:
```
styles:
   dashed:
      base: lines
      dash: [2, 1]
```
![tangram-1464027788197](https://cloud.githubusercontent.com/assets/16733/15480233/73ae15be-20f2-11e6-8d99-134ab511d362.png)
- The dashes are colored using the feature color as assigned by the layer's `draw` group (aka vertex color).
```
draw:
   dashed:
      color: yellow
```
![tangram-1464027797249](https://cloud.githubusercontent.com/assets/16733/15480239/79463452-20f2-11e6-996d-ce752c2b2411.png)
- By default, the "spaces" in the `dash` pattern are transparent. Alternatively, an opaque background color can be assigned with the `dash_background_color` parameter, which is useful for typical "stairs" or "railway"-like patterns (note: the dash background color parameter only uses the RGB component of the specified color, since the alpha channel is used for encoding dash/space internally), e.g.:
```
styles:
   dashed:
      base: lines
      dash: [1, 1]
      dash_background_color: grey
```
![tangram-1464027836777](https://cloud.githubusercontent.com/assets/16733/15480258/8f31e478-20f2-11e6-888c-fa3a9b09897e.png)
- Unlike the dash segment color, the background color is constant across the style and is unaffected by feature/vertex color.
- A line's `outline` can also be used in conjunction with a dashed line to create more complex patterns, with either the outline or inside line having a dash pattern (or both):

![tangram-1464027892685](https://cloud.githubusercontent.com/assets/16733/15480566/44757204-20f4-11e6-95a4-bb94dc4fa48e.png)
![tangram-1464028007658](https://cloud.githubusercontent.com/assets/16733/15480571/48eef0da-20f4-11e6-8b41-0f3c18a6f999.png)
![tangram-1464028575781](https://cloud.githubusercontent.com/assets/16733/15480575/4ab819be-20f4-11e6-8f68-9517440023bc.png)

**Line Textures**
The dash patterns are rendered using an underlying, generic line texture feature.

- The `texture` style parameter has been extended to `lines`.
- If provided, the texture is repeated across the line, with the width of the texture matching the width of the line, and the texture y coordinate scaled to match the aspect ratio of the image (its height over its width).
- The pattern specified with `dash` is rendered into a texture, which is then set to the style's `texture` property.
```
styles:
   arrows:
      base: lines
      texture: arrow.png
```

![tangram-1464038836553](https://cloud.githubusercontent.com/assets/16733/15485143/9d670a8c-210b-11e6-8643-e6cbd906a718.png)

**Implementation Notes**
- Dashed line patterns have transparency by default, but must often respect feature `order` (for interleaving paths or rail lines with roads, etc.). Rather than force all dashed lines to draw with an `inlay` blend mode (which would be limiting from a style authoring perspective and isn't supported in ES right now anyway), this implementation uses simple alpha testing (or "cutout"). Pixels in the line texture with alpha values below 0.5 are `discard`'ed when alpha blending is unavailable (`blend: opaque`, `add`, or `multiply`); when alpha blending is available (`blend: overlay` or `inlay`), the pixel's alpha is set to `0.0`. While it's generally preferable to avoid a shader branch and/or `discard`, I believe this is a reasonable compromise for a rendering feature usually reserved for a small number of features. It does however lead to poor aliasing in some cases.
- The `dash` pattern is [rendered to a texture](https://github.com/tangrams/tangram/blob/dasharray/src/styles/lines/dasharray.js) at run-time, as a simple set of alternating dashes and spaces (a value of 1 in the dash array is rendered as a single pixel) . The alpha channel is used to encode whether the pixel is a "dash" or "space". In the future, this could possibly be improved by rendering an SDF for antialiased patterns and/or other dash "shapes" (e.g. rounded cap / circle dash segments, currently more advanced patterns like this can be achieved through custom shader styles). An atlas of dash patterns could also be kept, to reduce texture use (render all patterns to one texture), or in case the same dash pattern is used by multiple styles.
- Line UVs show severe distortion in some cases. We should investigate either more intelligent UVs that take into account line curvature (maybe using a Bezier curve to calculate UVs in the shader? could be higher quality but expensive), or perhaps rendering some line patterns with different geometry that is aware of the pattern (e.g. adjusting the pattern to an optimal fit within each line segment, avoiding pattern stretch at segment joins, etc.).




