### PR TITLE
Optimize feature filters and config sync

### DIFF
--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -109,7 +109,7 @@ Object.assign(self, {
         });
 
         // Parse each top-level layer as a separate rule tree
-        self.layers = Utils.stringsToFunctions(config.layers, StyleParser.wrapFunction);
+        self.layers = config.layers;
         self.rules = parseRules(self.layers);
 
         // Sync tetxure info from main thread

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -1,5 +1,5 @@
 import DataSource, {NetworkSource, NetworkTileSource} from './data_source';
-import {MVTSource} from './mvt';
+import {decodeMultiPolygon} from './mvt';
 import Geo from '../geo';
 
 // For tiling GeoJSON client-side
@@ -82,7 +82,7 @@ export class GeoJSONSource extends NetworkSource {
                         f.geometry.type = 'MultiLineString';
                     }
                     else  {
-                        f.geometry = MVTSource.decodeMultiPolygon(f.geometry); // un-flatten rings
+                        f.geometry = decodeMultiPolygon(f.geometry); // un-flatten rings
                     }
                 }
                 else {

--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -194,6 +194,7 @@ Rule.id = 0;
 export class RuleLeaf extends Rule {
     constructor({name, parent, draw, visible, filter}) {
         super({name, parent, draw, visible, filter});
+        this.is_leaf = true;
     }
 
 }
@@ -201,6 +202,7 @@ export class RuleLeaf extends Rule {
 export class RuleTree extends Rule {
     constructor({name, parent, draw, visible, rules, filter}) {
         super({name, parent, draw, visible, filter});
+        this.is_tree = true;
         this.rules = rules || [];
     }
 
@@ -392,15 +394,14 @@ export function matchFeature(context, rules, collectedRules, collectedRulesIds) 
     for (let r=0; r < rules.length; r++) {
         let current = rules[r];
 
-        if (current instanceof RuleLeaf) {
-
+        if (current.is_leaf) {
             if (doesMatch(current, context)) {
                 matched = true;
                 collectedRules.push(current);
                 collectedRulesIds.push(current.id);
             }
 
-        } else if (current instanceof RuleTree) {
+        } else if (current.is_tree) {
             if (doesMatch(current, context)) {
                 matched = true;
 

--- a/src/styles/rule.js
+++ b/src/styles/rule.js
@@ -270,26 +270,6 @@ function isEmpty(obj) {
     return Object.keys(obj).length === 0;
 }
 
-export function walkUp(rule, cb) {
-
-    if (rule.parent) {
-        walkUp(rule.parent, cb);
-    }
-
-    cb(rule);
-}
-
-export function walkDown(rule, cb) {
-
-    if (rule.rules) {
-        rule.rules.forEach((r) => {
-            walkDown(r, cb);
-        });
-    }
-
-    cb(rule);
-}
-
 export function groupProps(obj) {
     let whiteListed = {}, nonWhiteListed = {};
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -237,7 +237,7 @@ Utils.stringsToFunctions = function(obj, wrap) {
         obj = Utils.stringToFunction(obj, wrap);
     }
     // Loop through object properties
-    else if (typeof obj === 'object') {
+    else if (obj != null && typeof obj === 'object') {
         for (let p in obj) {
             obj[p] = Utils.stringsToFunctions(obj[p], wrap);
         }
@@ -249,7 +249,7 @@ Utils.stringsToFunctions = function(obj, wrap) {
 // TODO: make function matching tolerant of whitespace and multilines
 Utils.stringToFunction = function(val, wrap) {
     // Convert strings back into functions
-    if (val.match(/^\s*function\s*\w*\s*\([\s\S]*\)\s*\{[\s\S]*\}/m) != null) {
+    if (typeof val === 'string' && val.match(/^\s*function\s*\w*\s*\([\s\S]*\)\s*\{[\s\S]*\}/m) != null) {
         var f;
         try {
             if (typeof wrap === 'function') {

--- a/src/utils/worker_broker.js
+++ b/src/utils/worker_broker.js
@@ -3,7 +3,7 @@
 // WorkerBroker routes messages between web workers and the main thread, allowing for simpler
 // async code via promises. Example usage:
 //
-// In web worker, register self as target define a method:
+// In web worker, register self as a callable "target", and define a method:
 //
 //     WorkerBroker.addTarget('self', self);
 //
@@ -171,7 +171,7 @@ function setupMainThread () {
         // Keep track of all registered workers
         workers.set(worker, worker_id++);
 
-        worker.addEventListener('message', (event) => {
+        worker.addEventListener('message', function WorkerBrokerMainThreadHandler(event) {
             let data = maybeDecode(event.data);
             let id = data.message_id;
 
@@ -309,7 +309,7 @@ function setupWorkerThread () {
         return promise;
     };
 
-    self.addEventListener('message', (event) => {
+    self.addEventListener('message', function WorkerBrokerWorkerThreadHandler(event) {
         let data = maybeDecode(event.data);
         let id = data.message_id;
 

--- a/test/rule_spec.js
+++ b/test/rule_spec.js
@@ -118,7 +118,7 @@ describe('.mergeTrees()', () => {
 
 describe('.parseRules(rules)', () => {
 
-    const {parseRules, walkDown}= require('../src/styles/rule');
+    const {parseRules}= require('../src/styles/rule');
     const ruleTree   = require('./fixtures/sample-style');
 
     describe('when given a raw ruleTree', () => {
@@ -129,12 +129,19 @@ describe('.parseRules(rules)', () => {
 
         it('returns the correct number of children rules', () => {
             let tree = parseRules(ruleTree).root;
-            let number = 0;
+            let children = 0;
 
-            walkDown(tree, (rule) => {
-                number += 1;
-            });
-            assert.equal(number, 4);
+            function walkDown (rule) {
+                if (rule.rules) {
+                    rule.rules.forEach((r) => {
+                        walkDown(r);
+                    });
+                }
+                children++;
+            }
+            walkDown(tree);
+
+            assert.equal(children, 4);
         });
     });
 });


### PR DESCRIPTION
This PR optimizes a few pieces of the feature/geometry build process, namely:

- "Simple" key/value filter conditions (for both feature properties, and `$`-style context properties like `$zoom`) are pulled out and given separate, optimized treatment. This includes matches on single or multiple values, e.g. `kind: rail`, or `landuse: [residential, commercial, industrial]`.
  - These matches are put into a simplified data structure, and are matched on in "native" JS, rather than in the dynamically compiled JS filters. (As with similar optimizations for zoom matching, these conditions are removed from the filter before it is compiled.) Property matches happen *after* zoom conditions (if any), but *before* remaining dynamic JS filter (if any).
   - See 
[`buildPropMatches()`](https://github.com/tangrams/tangram/compare/optimize-filters#diff-deabab718e02af3782a643dcdbbde01aR162), [`doPropMatches()`](https://github.com/tangrams/tangram/compare/optimize-filters#diff-deabab718e02af3782a643dcdbbde01aR193), and the [execution of these](https://github.com/tangrams/tangram/compare/optimize-filters#diff-deabab718e02af3782a643dcdbbde01aR401).
- Filters and their list of parent draw rules are calculated [lazily](https://github.com/tangrams/tangram/compare/optimize-filters#diff-deabab718e02af3782a643dcdbbde01aR392), the first time the layer is encountered (e.g. a feature matches its parent rule, or it is a top-level rule).
  - This means any JS function compilation for either filter or draw parameters are deferred until needed, amortizing their cost and decreasing initial startup time to process the scene config.
- Compiled JS functions are now serialized into strings (before the config is sent to the workers) only in cases where the scene config is sourced from a JS object.
  - When the scene source is a URL/file (the most common case), we know that it will not contain any compiled JS functions (it may contain strings that will be compiled into functions later).
  - The scene source can be a JS object either in cases of `scene.load(object)`, or when `scene.updateConfig()` or `scene.rebuild()` is called (in the latter two cases, it is a JS object modified in place).
  - This speeds up initial config parse/sync time to workers.
- Minor misc changes to remove ES6 iterators that blocked V8 optimization path.

Together these changes show substantial improvements of between **20%-45%** less build time.

With Bubble Wrap, in NYC at [40.697299008636755/-73.97094726562501], with a 1020x540 viewport, build times (average of 20 rebuilds) in milliseconds:

master/0.7.2 | optimize-filters | % reduction
-----------------|----------------------|--------------
694 | 380 | 45.24%
855 | 638 | 25.38%
1166	 | 859 | 26.33%
1077 | 739 | 31.38%
1148 | 876 | 23.69%
1034 | 817 | 20.99%
1020 | 767 | 24.80%
1163 | 865 | 25.62%
964 | 756 | 21.58%
832 | 656 | 21.15%
517 | 383 | 25.92%
518 | 376 | 27.41%

