### PR TITLE
Add support for custom fonts

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -475,10 +475,9 @@ layers:
                     text:
                         text_source: global.language_text_source
                         font:
-                            family: Helvetica
+                            family: Montserrat
                             size: 12px
                             fill: black
-                            weight: bold
 
         # add generic icon at high zoom
         generic:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -41,6 +41,10 @@ scene:
     background:
         color: '#9dc3de'
 
+fonts:
+    Montserrat:
+        url: https://fonts.gstatic.com/s/montserrat/v7/zhcz-_WihjSQC0oHJ9TCYL3hpw3pgy2gAi-Ip7WPMi0.woff
+
 textures:
     pois:
         url: images/poi_icons_32.png

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ http://mapzen.com/tangram
     <title>Tangram: WebGL for OpenStreetMap</title>
     <link rel="stylesheet" href="demos/css/main.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
+    <link href='https://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet' type='text/css'>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@ http://mapzen.com/tangram
     <title>Tangram: WebGL for OpenStreetMap</title>
     <link rel="stylesheet" href="demos/css/main.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
-    <link href='https://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet' type='text/css'>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "brfs": "1.4.3",
     "csscolorparser": "1.0.2",
     "earcut": "2.1.1",
+    "fontfaceobserver": "1.7.1",
     "geojson-vt": "2.1.6",
     "gl-mat3": "1.0.0",
     "gl-mat4": "1.1.4",

--- a/src/module.js
+++ b/src/module.js
@@ -65,6 +65,12 @@ var debug = {
 
 if (Thread.is_main) {
     Utils.requestAnimationFramePolyfill();
+
+    // Attach Promise polyfill to window
+    // Allows FontFaceObserver to use polyfill (without needing to include its own duplicate polyfill)
+    if (window.Promise === undefined) {
+        window.Promise = Promise;
+    }
 }
 
 module.exports = {

--- a/src/scene.js
+++ b/src/scene.js
@@ -15,6 +15,7 @@ import TileManager from './tile_manager';
 import DataSource from './sources/data_source';
 import FeatureSelection from './selection';
 import RenderState from './gl/render_state';
+import CanvasText from './styles/text/canvas_text';
 
 import {Polygons} from './styles/polygons/polygons';
 import {Lines} from './styles/lines/lines';
@@ -973,6 +974,7 @@ export default class Scene {
         this.createDataSources();
         this.loadTextures();
         this.setBackground();
+        CanvasText.loadFonts(this.config.fonts);
 
         // TODO: detect changes to styles? already (currently) need to recompile anyway when camera or lights change
         this.updateStyles();

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -201,6 +201,7 @@ export default SceneLoader = {
         config.lights = config.lights || {};
         config.styles = config.styles || {};
         config.layers = config.layers || {};
+        config.fonts = config.fonts || {};
 
         return config;
     }

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -56,6 +56,7 @@ export default SceneLoader = {
     // Normalize properties that should be adjust within each local scene file (usually by path)
     normalize(config, path) {
         SceneLoader.normalizeDataSources(config, path);
+        SceneLoader.normalizeFonts(config, path);
         SceneLoader.normalizeTextures(config, path);
         return config;
     },
@@ -69,6 +70,19 @@ export default SceneLoader = {
 
             if (Array.isArray(source.scripts)) {
                 source.scripts = source.scripts.map(url => Utils.addBaseURL(url, path));
+            }
+        }
+
+        return config;
+    },
+
+    // Expand paths for fonts
+    normalizeFonts(config, path) {
+        config.fonts = config.fonts || {};
+
+        for (let val of Utils.recurseValues(config.fonts)) {
+            if (val.url) {
+                val.url = Utils.addBaseURL(val.url, path);
             }
         }
 
@@ -201,7 +215,6 @@ export default SceneLoader = {
         config.lights = config.lights || {};
         config.styles = config.styles || {};
         config.layers = config.layers || {};
-        config.fonts = config.fonts || {};
 
         return config;
     }

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -343,7 +343,7 @@ export default class CanvasText {
         let css = `
             @font-face {
                 font-family: '${face}';
-                src: url(${url});
+                src: url(${encodeURI(url)});
             }
         `;
 

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -302,6 +302,7 @@ export default class CanvasText {
     // Load set of custom font faces
     // `fonts` is an object where the key is a font family name, and the value is one or more font face
     // definitions. The value can be either a single object, or an array of such objects.
+    // If the special string value 'external' is used, it indicates the the font will be loaded via external CSS.
     static loadFonts (fonts) {
         let queue = [];
         for (let family in fonts) {
@@ -313,16 +314,21 @@ export default class CanvasText {
             }
         }
 
-        CanvasText.fonts_loaded = Promise.all(queue);
+        CanvasText.fonts_loaded = Promise.all(queue.filter(x => x));
         return CanvasText.fonts_loaded;
     }
 
     // Load a single font face
     // `face` contains the font face definition, with optional parameters for `weight`, `style`, and `url`.
-    // If the `url` is defined, the font is injected into the document as a CSS font-face. If no `url` is defined,
-    // the font face is assumed is assumed to been loaded externally (e.g. through a CSS stylesheet).
-    // In either case, the function returns a promise that resolves when the font face has loaded, or times out.
+    // If the `url` is defined, the font is injected into the document as a CSS font-face.
+    // If the object's value is the special string 'external', or if no `url` is defined, then the font face
+    // is assumed is assumed to been loaded via external CSS. In either case, the function returns a promise
+    // that resolves when the font face has loaded, or times out.
     static loadFontFace (family, face) {
+        if (face == null || (typeof face !== 'object' && face !== 'external')) {
+            return;
+        }
+
         let options = { family };
 
         if (typeof face === 'object') {

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -330,7 +330,7 @@ export default class CanvasText {
 
             // If URL is defined, inject font into document
             if (typeof face.url === 'string') {
-                this.injectFont(options);
+                this.injectFontFace(options);
             }
         }
 
@@ -349,7 +349,7 @@ export default class CanvasText {
 
     // Loads a font face via CSS injection
     // TODO: consider support for multiple format URLs per face, unicode ranges
-    static injectFont ({ family, url, weight, style }) {
+    static injectFontFace ({ family, url, weight, style }) {
         let css = `
             @font-face {
                 font-family: '${family}';

--- a/src/utils/thread.js
+++ b/src/utils/thread.js
@@ -6,7 +6,7 @@ const Thread = {};
 export default Thread;
 
 try {
-    if (window.document !== undefined) {
+    if (window.document !== HTMLDocument) { // jshint ignore:line
         Thread.is_worker = false;
         Thread.is_main   = true;
     }
@@ -15,5 +15,10 @@ catch (e) {
     if (self !== undefined) {
         Thread.is_worker = true;
         Thread.is_main   = false;
+
+        // Patch for 3rd party libs that require these globals to be present. Specifically, FontFaceObserver.
+        // Brittle solution but allows that library to load on worker threads.
+        self.window = { document: {} };
+        self.document = self.window.document;
     }
 }


### PR DESCRIPTION
Adds supports for custom web fonts, either loaded directly by Tangram, or via an external CSS stylesheet.

- The scene file has a new optional, top-level `fonts` block, which is a mapping of **font definitions**.
- The *key* of each font definition is the font **family** name, and the *value* is one or more **font face definitions** (a single object, or an array of objects).
- Each **font face definition** is an object with the following possible parameters:
  - `weight`: defaults to `normal`, may also be `bold` or a numeric font weight, e.g. `500`
  - `style`: defaults to `normal`, may also be `italic`
  - `url`: the URL to load the font from. For maximum browser compatibility, fonts should be either `ttf`, `otf`, or `woff` (`woff2` is [currently supported](http://caniuse.com/#search=woff2) in Chrome and Firefox but not other major browsers). As with other scene resources, `url` is relative to the scene file.
- Alternately, instead of an object, a font face definition can be set to the special string value **`external`**, which indicates that the font will be loaded via an external CSS stylesheet (such as via Google Fonts).
  - The `external` option is JS-only syntax. Tangram JS still needs to know that these custom fonts will be used, even if it is not responsible for loading them, because it must wait to render text until they have loaded. There is currently no ES equivalent, so this is a no-op in ES.
- All font face parameters are *optional*.
  - If a `url` is specified, the font is loaded by injecting one or more CSS `@font-face` rules into the document head.
  - If no `url` is specified, Tangram JS will assume that the font has already been loaded via external CSS.

Example of a font with a single face definition:
```
fonts:
    Montserrat:
        url: https://fonts.gstatic.com/s/montserrat/v7/zhcz-_WihjSQC0oHJ9TCYL3hpw3pgy2gAi-Ip7WPMi0.woff
```

Example of a font with multiple face definitions:
```
fonts:
    Open Sans:
        - weight: 300
          url: fonts/open sans-300normal.ttf
        - weight: 300
          style: italic
          url: fonts/open sans-300italic.ttf
        - weight: 400
          url: fonts/open sans-400normal.ttf
        - weight: 400
          style: italic
          url: fonts/open sans-400italic.ttf
        - weight: 600
          url: fonts/open sans-600normal.ttf
        - weight: 600
          style: italic
          url: fonts/open sans-600italic.ttf
        - weight: 700
          url: fonts/open sans-700normal.ttf
        - weight: 700
          style: italic
          url: fonts/open sans-700italic.ttf
        - weight: 800
          url: fonts/open sans-800normal.ttf
        - weight: 800
          style: italic
          url: fonts/open sans-800italic.ttf
```

Example of a custom font loaded via external CSS:
```
fonts:
    Poiret One: external
```

And in the document:
`<link href='https://fonts.googleapis.com/css?family=Poiret+One' rel='stylesheet' type='text/css'>`






Any fonts specified in the `fonts` block can then be referenced in the `font` block when rendering with `text` or `points`-based styles. Tangram JS will block text rendering while custom fonts load, using the [`FontFaceObserver`](https://github.com/bramstein/fontfaceobserver) polyfill for [CSS Font Loading Module Level 3 events](https://drafts.csswg.org/css-font-loading/). 

This PR replaces the earlier implementation from #284.
