### PR TITLE
Multiple anchor placements for point labels

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -415,7 +415,6 @@ layers:
                     color: '#bddec5'
 
     road_labels:
-        visible: false
         data: { source: mapzen, layer: roads }
         filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
         highway:
@@ -467,183 +466,161 @@ layers:
                 filter: { highway: [residential, unclassified], $zoom: { max: 15 } }
                 visible: false
 
-        # shields:
-        #     filter:
-        #         all:
-        #             - highway: motorway
-        #             - |
-        #                 function() {
-        #                     var m = feature.ref &&
-        #                         feature.ref[0] === 'I' &&
-        #                         feature.ref.match(/\d+/);
-        #                     //var m = feature.ref && feature.ref.match(/\d+/);
-        #                     return m && m[0];
-        #                 }
-        #     draw:
-        #         icons:
-        #             sprite: shield
-        #             priority: 2
-        #             interactive: true
-        #             color: white
-        #             size: 24px
-        #             cull_from_tile: true
-        #             text:
-        #                 required: true
-        #                 anchor: center
-        #                 text_source: |
-        #                     function() {
-        #                         var m = feature.ref &&
-        #                             feature.ref[0] === 'I' &&
-        #                             feature.ref.match(/\d+/);
-        #                         // var m = feature.ref && feature.ref.match(/\d+/);
-        #                         return m && m[0];
-        #                     }
-        #                 font:
-        #                     family: Helvetica
-        #                     size: 11px
+        shields:
+            filter:
+                all:
+                    - highway: motorway
+                    - |
+                        function() {
+                            var m = feature.ref &&
+                                feature.ref[0] === 'I' &&
+                                feature.ref.match(/\d+/);
+                            //var m = feature.ref && feature.ref.match(/\d+/);
+                            return m && m[0];
+                        }
+            draw:
+                icons:
+                    sprite: shield
+                    priority: 2
+                    interactive: true
+                    color: white
+                    size: 24px
+                    cull_from_tile: true
+                    text:
+                        required: true
+                        anchor: center
+                        text_source: |
+                            function() {
+                                var m = feature.ref &&
+                                    feature.ref[0] === 'I' &&
+                                    feature.ref.match(/\d+/);
+                                // var m = feature.ref && feature.ref.match(/\d+/);
+                                return m && m[0];
+                            }
+                        font:
+                            family: Helvetica
+                            size: 11px
 
     pois:
-        # visible: false
         data: { source: mapzen }
         filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 }, $geometry: point }
         draw:
-            # icons:
-            #     size: [[13, 12px], [15, 18px]]
-            #     interactive: true
-            #     priority: 6
-            points:
-                # visible: false # turn on for debug
-                color: red
-                size: 8px
-                # collide: false
+            icons:
+                size: [[13, 12px], [15, 18px]]
+                interactive: true
+                priority: 6
+
+        # add text label at higher zoom
+        labels:
+            filter:
+                - { $zoom: { min: 17 } }
+                - { $zoom: { min: 16 }, kind: station }
+            draw:
+                icons:
+                    text:
+                        required: true
+                        anchor: [bottom, right, left, top]
+                        text_source: global.language_text_source
+                        font:
+                            family: Montserrat
+                            size: 12px
+                            fill: black
+
+        # add generic icon at high zoom
+        generic:
+            filter: { $zoom: { min: 18 } }
+            draw: { icons: { sprite: info } }
+
+        # examples of different icons mapped to feature properties
+        icons:
+            restaurant:
+                filter: { kind: [restaurant] }
+                draw: { icons: { sprite: restaurant } }
+            cafe:
+                filter: { kind: [cafe, convenience] }
+                draw: { icons: { sprite: cafe } }
+            bar:
+                filter: { kind: [bar, pub] }
+                draw: { icons: { sprite: bar } }
+            culture:
+                filter: { kind: [museum, library, church, place_of_worship, bank] }
+                draw: { icons: { sprite: museum } }
+            station:
+                filter: { kind: [station] }
+                draw: { icons: { sprite: train, priority: 2 } }
+            hospital:
+                filter: { kind: [hospital, pharmacy] }
+                draw: { icons: { sprite: hospital } }
+            hotel:
+                filter: { kind: [hotel, hostel] }
+                draw: { icons: { sprite: hotel } }
+            bus_stop:
+                filter: { kind: [bus_stop] }
+                draw: { icons: { sprite: bus } }
+            bookstore:
+                filter: { kind: [bookstore] }
+                draw: { icons: { sprite: bookstore } }
+
+    places:
+        data: { source: mapzen }
+        filter:
+            name: true
+            not: { kind: [county, state, island] }
+            any:
+                - { $zoom: { min: 1 }, kind: ocean }
+                - { $zoom: { min: 2, max: 5 }, kind: continent }
+                - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", " Россия", "中华人民共和国"] }
+                - { $zoom: { min: 5 }, kind: country }
+                - { $zoom: { min: 7 }, kind: [city, town, neighbourhood, macrohood] }
+
+        visible: false
+        draw:
+            text:
+                text_source: global.language_text_source
+                priority: 1
+                font:
+                    family: Helvetica
+                    size: 12px
+                    fill: [0, 0, 0, .8]
+                    stroke: { color: white, width: 4 }
+                    transform: uppercase
+
+        continents:
+            filter: { kind: continent }
+            visible: true
+
+        countries:
+            filter: { kind: country }
+            visible: true
+
+        oceans:
+            filter: { kind: ocean }
+            visible: true
+            draw:
                 text:
-                    anchor: [bottom, right, left, top]
-                    # anchor: [left, right, top]
-                    # anchor: right
-                    # collide: false
-                    required: true
-                    text_source: global.language_text_source
-                    # text_source: function(){ return 'Align test string' }
-                    repeat_distance: 0
                     font:
-                        family: Montserrat
-                        size: 12px
-                        fill: black
+                        family: Baskerville
+                        size: 14pt
+                        style: italic
 
-        # even:
-        #     filter: function(){ return feature.id % 2 }
-        #     draw: { points: { text: { anchor: left }}}
+        cities:
+            filter: { kind: [city] }
+            visible: true
+            draw:
+                text:
+                    font:
+                        weight: bold
+                        size: [[6, 12px], [9, 16px]]
 
-        # # add text label at higher zoom
-        # labels:
-        #     filter:
-        #         - { $zoom: { min: 17 } }
-        #         - { $zoom: { min: 16 }, kind: station }
-        #     draw:
-        #         icons:
-        #             text:
-        #                 required: true
-        #                 text_source: global.language_text_source
-        #                 font:
-        #                     family: Montserrat
-        #                     size: 12px
-        #                     fill: black
-
-        # # add generic icon at high zoom
-        # generic:
-        #     filter: { $zoom: { min: 18 } }
-        #     draw: { icons: { sprite: info } }
-
-        # # examples of different icons mapped to feature properties
-        # icons:
-        #     restaurant:
-        #         filter: { kind: [restaurant] }
-        #         draw: { icons: { sprite: restaurant } }
-        #     cafe:
-        #         filter: { kind: [cafe, convenience] }
-        #         draw: { icons: { sprite: cafe } }
-        #     bar:
-        #         filter: { kind: [bar, pub] }
-        #         draw: { icons: { sprite: bar } }
-        #     culture:
-        #         filter: { kind: [museum, library, church, place_of_worship, bank] }
-        #         draw: { icons: { sprite: museum } }
-        #     station:
-        #         filter: { kind: [station] }
-        #         draw: { icons: { sprite: train, priority: 2 } }
-        #     hospital:
-        #         filter: { kind: [hospital, pharmacy] }
-        #         draw: { icons: { sprite: hospital } }
-        #     hotel:
-        #         filter: { kind: [hotel, hostel] }
-        #         draw: { icons: { sprite: hotel } }
-        #     bus_stop:
-        #         filter: { kind: [bus_stop] }
-        #         draw: { icons: { sprite: bus } }
-        #     bookstore:
-        #         filter: { kind: [bookstore] }
-        #         draw: { icons: { sprite: bookstore } }
-
-    # places:
-    #     data: { source: mapzen }
-    #     filter:
-    #         name: true
-    #         not: { kind: [county, state, island] }
-    #         any:
-    #             - { $zoom: { min: 1 }, kind: ocean }
-    #             - { $zoom: { min: 2, max: 5 }, kind: continent }
-    #             - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", " Россия", "中华人民共和国"] }
-    #             - { $zoom: { min: 5 }, kind: country }
-    #             - { $zoom: { min: 7 }, kind: [city, town, neighbourhood, macrohood] }
-
-    #     visible: false
-    #     draw:
-    #         text:
-    #             text_source: global.language_text_source
-    #             priority: 1
-    #             font:
-    #                 family: Helvetica
-    #                 size: 12px
-    #                 fill: [0, 0, 0, .8]
-    #                 stroke: { color: white, width: 4 }
-    #                 transform: uppercase
-
-    #     continents:
-    #         filter: { kind: continent }
-    #         visible: true
-
-    #     countries:
-    #         filter: { kind: country }
-    #         visible: true
-
-    #     oceans:
-    #         filter: { kind: ocean }
-    #         visible: true
-    #         draw:
-    #             text:
-    #                 font:
-    #                     family: Baskerville
-    #                     size: 14pt
-    #                     style: italic
-
-    #     cities:
-    #         filter: { kind: [city] }
-    #         visible: true
-    #         draw:
-    #             text:
-    #                 font:
-    #                     weight: bold
-    #                     size: [[6, 12px], [9, 16px]]
-
-    #     neighborhoods:
-    #         filter: { kind: [macrohood, neighbourhood], $zoom: { min: 13 } }
-    #         visible: true
-    #         draw:
-    #             text:
-    #                 font:
-    #                     size: [[13, 11px], [14, 11px], [15, 13px]]
-    #                     style: italic
-    #                     fill: rgba(136, 45, 23, 0.9)
+        neighborhoods:
+            filter: { kind: [macrohood, neighbourhood], $zoom: { min: 13 } }
+            visible: true
+            draw:
+                text:
+                    font:
+                        size: [[13, 11px], [14, 11px], [15, 13px]]
+                        style: italic
+                        fill: rgba(136, 45, 23, 0.9)
 
 
     transit:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -246,32 +246,32 @@ layers:
                     polygons:
                         color: '#D9CFC3'
 
-        labels:
-            filter:
-                $geometry: point
-                label_placement: yes
-                kind: [park, forest, cemetery, graveyard]
-                any:
-                    # show labels for smaller landuse areas at higher zooms
-                    - { $zoom: { min: 9 }, area: { min: 100000000 } }
-                    - { $zoom: { min: 10 }, area: { min: 10000000 } }
-                    - { $zoom: { min: 12 }, area: { min: 1000000 } }
-                    - { $zoom: { min: 15 }, area: { min: 10000 } }
-                    - { $zoom: { min: 18 } }
-            draw:
-                icons:
-                    sprite: tree
-                    priority: 2
-                    size: 16px
-                    text:
-                        text_source: global.language_text_source
-                        offset: [0, 2px]
-                        font:
-                            family: Lucida Grande
-                            size: 10pt
-                            style: italic
-                            fill: darkgreen
-                            stroke: { color: white, width: 3 }
+        # labels:
+        #     filter:
+        #         $geometry: point
+        #         label_placement: yes
+        #         kind: [park, forest, cemetery, graveyard]
+        #         any:
+        #             # show labels for smaller landuse areas at higher zooms
+        #             - { $zoom: { min: 9 }, area: { min: 100000000 } }
+        #             - { $zoom: { min: 10 }, area: { min: 10000000 } }
+        #             - { $zoom: { min: 12 }, area: { min: 1000000 } }
+        #             - { $zoom: { min: 15 }, area: { min: 10000 } }
+        #             - { $zoom: { min: 18 } }
+        #     draw:
+        #         icons:
+        #             sprite: tree
+        #             priority: 2
+        #             size: 16px
+        #             text:
+        #                 text_source: global.language_text_source
+        #                 offset: [0, 2px]
+        #                 font:
+        #                     family: Lucida Grande
+        #                     size: 10pt
+        #                     style: italic
+        #                     fill: darkgreen
+        #                     stroke: { color: white, width: 3 }
 
     water:
         data: { source: mapzen }
@@ -415,6 +415,7 @@ layers:
                     color: '#bddec5'
 
     road_labels:
+        visible: false
         data: { source: mapzen, layer: roads }
         filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
         highway:
@@ -466,165 +467,177 @@ layers:
                 filter: { highway: [residential, unclassified], $zoom: { max: 15 } }
                 visible: false
 
-        shields:
-            filter:
-                all:
-                    - highway: motorway
-                    - |
-                        function() {
-                            var m = feature.ref &&
-                                feature.ref[0] === 'I' &&
-                                feature.ref.match(/\d+/);
-                            //var m = feature.ref && feature.ref.match(/\d+/);
-                            return m && m[0];
-                        }
-            draw:
-                icons:
-                    sprite: shield
-                    priority: 2
-                    interactive: true
-                    color: white
-                    size: 24px
-                    cull_from_tile: true
-                    text:
-                        required: true
-                        anchor: center
-                        text_source: |
-                            function() {
-                                var m = feature.ref &&
-                                    feature.ref[0] === 'I' &&
-                                    feature.ref.match(/\d+/);
-                                // var m = feature.ref && feature.ref.match(/\d+/);
-                                return m && m[0];
-                            }
-                        font:
-                            family: Helvetica
-                            size: 11px
+        # shields:
+        #     filter:
+        #         all:
+        #             - highway: motorway
+        #             - |
+        #                 function() {
+        #                     var m = feature.ref &&
+        #                         feature.ref[0] === 'I' &&
+        #                         feature.ref.match(/\d+/);
+        #                     //var m = feature.ref && feature.ref.match(/\d+/);
+        #                     return m && m[0];
+        #                 }
+        #     draw:
+        #         icons:
+        #             sprite: shield
+        #             priority: 2
+        #             interactive: true
+        #             color: white
+        #             size: 24px
+        #             cull_from_tile: true
+        #             text:
+        #                 required: true
+        #                 anchor: center
+        #                 text_source: |
+        #                     function() {
+        #                         var m = feature.ref &&
+        #                             feature.ref[0] === 'I' &&
+        #                             feature.ref.match(/\d+/);
+        #                         // var m = feature.ref && feature.ref.match(/\d+/);
+        #                         return m && m[0];
+        #                     }
+        #                 font:
+        #                     family: Helvetica
+        #                     size: 11px
 
     pois:
         # visible: false
         data: { source: mapzen }
-        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
+        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 }, $geometry: point }
         draw:
+            # icons:
+            #     size: [[13, 12px], [15, 18px]]
+            #     interactive: true
+            #     priority: 6
             points:
-                visible: false # turn on for debug
+                # visible: false # turn on for debug
                 color: red
                 size: 8px
-            icons:
-                size: [[13, 12px], [15, 18px]]
-                interactive: true
-                priority: 6
-
-        # add text label at higher zoom
-        labels:
-            filter:
-                - { $zoom: { min: 17 } }
-                - { $zoom: { min: 16 }, kind: station }
-            draw:
-                icons:
-                    text:
-                        required: true
-                        text_source: global.language_text_source
-                        font:
-                            family: Montserrat
-                            size: 12px
-                            fill: black
-
-        # add generic icon at high zoom
-        generic:
-            filter: { $zoom: { min: 18 } }
-            draw: { icons: { sprite: info } }
-
-        # examples of different icons mapped to feature properties
-        icons:
-            restaurant:
-                filter: { kind: [restaurant] }
-                draw: { icons: { sprite: restaurant } }
-            cafe:
-                filter: { kind: [cafe, convenience] }
-                draw: { icons: { sprite: cafe } }
-            bar:
-                filter: { kind: [bar, pub] }
-                draw: { icons: { sprite: bar } }
-            culture:
-                filter: { kind: [museum, library, church, place_of_worship, bank] }
-                draw: { icons: { sprite: museum } }
-            station:
-                filter: { kind: [station] }
-                draw: { icons: { sprite: train, priority: 2 } }
-            hospital:
-                filter: { kind: [hospital, pharmacy] }
-                draw: { icons: { sprite: hospital } }
-            hotel:
-                filter: { kind: [hotel, hostel] }
-                draw: { icons: { sprite: hotel } }
-            bus_stop:
-                filter: { kind: [bus_stop] }
-                draw: { icons: { sprite: bus } }
-            bookstore:
-                filter: { kind: [bookstore] }
-                draw: { icons: { sprite: bookstore } }
-
-    places:
-        data: { source: mapzen }
-        filter:
-            name: true
-            not: { kind: [county, state, island] }
-            any:
-                - { $zoom: { min: 1 }, kind: ocean }
-                - { $zoom: { min: 2, max: 5 }, kind: continent }
-                - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", " Россия", "中华人民共和国"] }
-                - { $zoom: { min: 5 }, kind: country }
-                - { $zoom: { min: 7 }, kind: [city, town, neighbourhood, macrohood] }
-
-        visible: false
-        draw:
-            text:
-                text_source: global.language_text_source
-                priority: 1
-                font:
-                    family: Helvetica
-                    size: 12px
-                    fill: [0, 0, 0, .8]
-                    stroke: { color: white, width: 4 }
-                    transform: uppercase
-
-        continents:
-            filter: { kind: continent }
-            visible: true
-
-        countries:
-            filter: { kind: country }
-            visible: true
-
-        oceans:
-            filter: { kind: ocean }
-            visible: true
-            draw:
+                # collide: false
                 text:
+                    anchor: [bottom, right, left, top]
+                    # anchor: [left, right, top]
+                    # anchor: right
+                    # collide: false
+                    text_source: global.language_text_source
+                    repeat_distance: 0
                     font:
-                        family: Baskerville
-                        size: 14pt
-                        style: italic
+                        family: Montserrat
+                        size: 12px
+                        fill: black
 
-        cities:
-            filter: { kind: [city] }
-            visible: true
-            draw:
-                text:
-                    font:
-                        weight: bold
-                        size: [[6, 12px], [9, 16px]]
+        # # add text label at higher zoom
+        # labels:
+        #     filter:
+        #         - { $zoom: { min: 17 } }
+        #         - { $zoom: { min: 16 }, kind: station }
+        #     draw:
+        #         icons:
+        #             text:
+        #                 required: true
+        #                 text_source: global.language_text_source
+        #                 font:
+        #                     family: Montserrat
+        #                     size: 12px
+        #                     fill: black
 
-        neighborhoods:
-            filter: { kind: [macrohood, neighbourhood], $zoom: { min: 13 } }
-            visible: true
-            draw:
-                text:
-                    font:
-                        size: [[13, 11px], [14, 11px], [15, 13px]]
-                        style: italic
-                        fill: rgba(136, 45, 23, 0.9)
+        # # add generic icon at high zoom
+        # generic:
+        #     filter: { $zoom: { min: 18 } }
+        #     draw: { icons: { sprite: info } }
+
+        # # examples of different icons mapped to feature properties
+        # icons:
+        #     restaurant:
+        #         filter: { kind: [restaurant] }
+        #         draw: { icons: { sprite: restaurant } }
+        #     cafe:
+        #         filter: { kind: [cafe, convenience] }
+        #         draw: { icons: { sprite: cafe } }
+        #     bar:
+        #         filter: { kind: [bar, pub] }
+        #         draw: { icons: { sprite: bar } }
+        #     culture:
+        #         filter: { kind: [museum, library, church, place_of_worship, bank] }
+        #         draw: { icons: { sprite: museum } }
+        #     station:
+        #         filter: { kind: [station] }
+        #         draw: { icons: { sprite: train, priority: 2 } }
+        #     hospital:
+        #         filter: { kind: [hospital, pharmacy] }
+        #         draw: { icons: { sprite: hospital } }
+        #     hotel:
+        #         filter: { kind: [hotel, hostel] }
+        #         draw: { icons: { sprite: hotel } }
+        #     bus_stop:
+        #         filter: { kind: [bus_stop] }
+        #         draw: { icons: { sprite: bus } }
+        #     bookstore:
+        #         filter: { kind: [bookstore] }
+        #         draw: { icons: { sprite: bookstore } }
+
+    # places:
+    #     data: { source: mapzen }
+    #     filter:
+    #         name: true
+    #         not: { kind: [county, state, island] }
+    #         any:
+    #             - { $zoom: { min: 1 }, kind: ocean }
+    #             - { $zoom: { min: 2, max: 5 }, kind: continent }
+    #             - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", " Россия", "中华人民共和国"] }
+    #             - { $zoom: { min: 5 }, kind: country }
+    #             - { $zoom: { min: 7 }, kind: [city, town, neighbourhood, macrohood] }
+
+    #     visible: false
+    #     draw:
+    #         text:
+    #             text_source: global.language_text_source
+    #             priority: 1
+    #             font:
+    #                 family: Helvetica
+    #                 size: 12px
+    #                 fill: [0, 0, 0, .8]
+    #                 stroke: { color: white, width: 4 }
+    #                 transform: uppercase
+
+    #     continents:
+    #         filter: { kind: continent }
+    #         visible: true
+
+    #     countries:
+    #         filter: { kind: country }
+    #         visible: true
+
+    #     oceans:
+    #         filter: { kind: ocean }
+    #         visible: true
+    #         draw:
+    #             text:
+    #                 font:
+    #                     family: Baskerville
+    #                     size: 14pt
+    #                     style: italic
+
+    #     cities:
+    #         filter: { kind: [city] }
+    #         visible: true
+    #         draw:
+    #             text:
+    #                 font:
+    #                     weight: bold
+    #                     size: [[6, 12px], [9, 16px]]
+
+    #     neighborhoods:
+    #         filter: { kind: [macrohood, neighbourhood], $zoom: { min: 13 } }
+    #         visible: true
+    #         draw:
+    #             text:
+    #                 font:
+    #                     size: [[13, 11px], [14, 11px], [15, 13px]]
+    #                     style: italic
+    #                     fill: rgba(136, 45, 23, 0.9)
 
 
     transit:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -521,12 +521,18 @@ layers:
                     # anchor: [left, right, top]
                     # anchor: right
                     # collide: false
+                    required: true
                     text_source: global.language_text_source
+                    # text_source: function(){ return 'Align test string' }
                     repeat_distance: 0
                     font:
                         family: Montserrat
                         size: 12px
                         fill: black
+
+        # even:
+        #     filter: function(){ return feature.id % 2 }
+        #     draw: { points: { text: { anchor: left }}}
 
         # # add text label at higher zoom
         # labels:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -517,7 +517,6 @@ layers:
             draw:
                 icons:
                     text:
-                        anchor: [bottom, right, left, top]
                         text_source: global.language_text_source
                         font:
                             family: Montserrat

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -246,32 +246,32 @@ layers:
                     polygons:
                         color: '#D9CFC3'
 
-        # labels:
-        #     filter:
-        #         $geometry: point
-        #         label_placement: yes
-        #         kind: [park, forest, cemetery, graveyard]
-        #         any:
-        #             # show labels for smaller landuse areas at higher zooms
-        #             - { $zoom: { min: 9 }, area: { min: 100000000 } }
-        #             - { $zoom: { min: 10 }, area: { min: 10000000 } }
-        #             - { $zoom: { min: 12 }, area: { min: 1000000 } }
-        #             - { $zoom: { min: 15 }, area: { min: 10000 } }
-        #             - { $zoom: { min: 18 } }
-        #     draw:
-        #         icons:
-        #             sprite: tree
-        #             priority: 2
-        #             size: 16px
-        #             text:
-        #                 text_source: global.language_text_source
-        #                 offset: [0, 2px]
-        #                 font:
-        #                     family: Lucida Grande
-        #                     size: 10pt
-        #                     style: italic
-        #                     fill: darkgreen
-        #                     stroke: { color: white, width: 3 }
+        labels:
+            filter:
+                $geometry: point
+                label_placement: yes
+                kind: [park, forest, cemetery, graveyard]
+                any:
+                    # show labels for smaller landuse areas at higher zooms
+                    - { $zoom: { min: 9 }, area: { min: 100000000 } }
+                    - { $zoom: { min: 10 }, area: { min: 10000000 } }
+                    - { $zoom: { min: 12 }, area: { min: 1000000 } }
+                    - { $zoom: { min: 15 }, area: { min: 10000 } }
+                    - { $zoom: { min: 18 } }
+            draw:
+                icons:
+                    sprite: tree
+                    priority: 2
+                    size: 16px
+                    text:
+                        text_source: global.language_text_source
+                        offset: [0, 2px]
+                        font:
+                            family: Lucida Grande
+                            size: 10pt
+                            style: italic
+                            fill: darkgreen
+                            stroke: { color: white, width: 3 }
 
     water:
         data: { source: mapzen }
@@ -487,7 +487,6 @@ layers:
                     size: 24px
                     cull_from_tile: true
                     text:
-                        required: true
                         anchor: center
                         text_source: |
                             function() {
@@ -503,7 +502,7 @@ layers:
 
     pois:
         data: { source: mapzen }
-        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 }, $geometry: point }
+        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
         draw:
             icons:
                 size: [[13, 12px], [15, 18px]]
@@ -518,7 +517,6 @@ layers:
             draw:
                 icons:
                     text:
-                        required: true
                         anchor: [bottom, right, left, top]
                         text_source: global.language_text_source
                         font:
@@ -547,7 +545,7 @@ layers:
                 draw: { icons: { sprite: museum } }
             station:
                 filter: { kind: [station] }
-                draw: { icons: { sprite: train, priority: 2 } }
+                draw: { icons: { sprite: train, priority: 2, required: false } }
             hospital:
                 filter: { kind: [hospital, pharmacy] }
                 draw: { icons: { sprite: hospital } }

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -120,6 +120,11 @@ export default Collision = {
             return label.placed;
         }
 
+        // Skip if an alternate placement was already placed
+        if (label.alternates && label.alternates.some(x => x.placed)) {
+            return false;
+        }
+
         // Test the label for intersections with other labels in the tile
         let bboxes = this.tiles[tile].bboxes;
         if (!layout.collide || !label.discard(bboxes, exclude && exclude.label)) {

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -117,20 +117,20 @@ export default Collision = {
     canBePlaced (object, tile, exclude = null) {
         let label = object.label;
         let layout = object.layout;
-        let placements = object.placements;
+        let candidates = object.candidates;
 
-        // Determine if any of the placement options can be assigned as the label
+        // Determine if any of the placement candidates options can be assigned as the label
         if (!label) {
-            if (Array.isArray(placements)) {
-                for (let p=0; p < placements.length; p++) {
-                    if (this.canBePlaced(placements[p], tile, exclude)) {
-                        object.label = placements[p].label; // assign placed label
-                        object.align = placements[p].align;
-                        object.placements = null; // don't check placements again
+            if (Array.isArray(candidates)) {
+                for (let p=0; p < candidates.length; p++) {
+                    if (this.canBePlaced(candidates[p], tile, exclude)) {
+                        object.label = candidates[p].label; // assign placed label
+                        object.align = candidates[p].align;
+                        object.candidates = null; // don't check candidates again
                         return true;
                     }
                 }
-                object.placements = null; // don't check placements again
+                object.candidates = null; // don't check candidates again
             }
 
             if (!object.label) {

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -44,7 +44,7 @@ export default Collision = {
         let state = this.tiles[tile];
         if (!state) {
             log('trace', 'Collision.collide() called with null tile', tile, this.tiles, style, objects);
-            return Promise.reject(Error('Collision.collide() called with null tile', tile, this.tiles, style, objects));
+            return Promise.resolve([]);
         }
 
         // Group by priority and style

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -114,7 +114,30 @@ export default Collision = {
     },
 
     // Run collision and repeat check to see if label can currently be placed
-    canBePlaced ({ label, layout }, tile, exclude = null) {
+    // canBePlaced ({ label, placements, layout }, tile, exclude = null) {
+    canBePlaced (object, tile, exclude = null) {
+        let label = object.label;
+        let layout = object.layout;
+        let placements = object.placements;
+
+        // Determine if any of the placement options can be assigned as the label
+        if (!label) {
+            if (Array.isArray(placements)) {
+                for (let p=0; p < placements.length; p++) {
+                    if (this.canBePlaced({ label: placements[p], layout }, tile, exclude)) {
+                        object.label = placements[p]; // assign placed label
+                        object.placements = null; // don't check placements again
+                        return true;
+                    }
+                }
+                object.placements = null; // don't check placements again
+            }
+
+            if (!object.label) {
+                return false;
+            }
+        }
+
         // Skip if already processed (e.g. by parent object)
         if (label.placed != null) {
             return label.placed;

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -117,25 +117,6 @@ export default Collision = {
     canBePlaced (object, tile, exclude = null) {
         let label = object.label;
         let layout = object.label.layout;
-        let candidates = object.candidates;
-
-        // Determine if any of the placement candidates options can be assigned as the label
-        if (!label) {
-            if (Array.isArray(candidates)) {
-                for (let p=0; p < candidates.length; p++) {
-                    if (this.canBePlaced(candidates[p], tile, exclude)) {
-                        object.label = candidates[p].label; // assign placed label
-                        object.candidates = null; // don't check candidates again
-                        return true;
-                    }
-                }
-                object.candidates = null; // don't check candidates again
-            }
-
-            if (!object.label) {
-                return false;
-            }
-        }
 
         // Skip if already processed (e.g. by parent object)
         if (label.placed != null) {

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -124,8 +124,9 @@ export default Collision = {
         if (!label) {
             if (Array.isArray(placements)) {
                 for (let p=0; p < placements.length; p++) {
-                    if (this.canBePlaced({ label: placements[p], layout }, tile, exclude)) {
-                        object.label = placements[p]; // assign placed label
+                    if (this.canBePlaced(placements[p], tile, exclude)) {
+                        object.label = placements[p].label; // assign placed label
+                        object.align = placements[p].align;
                         object.placements = null; // don't check placements again
                         return true;
                     }
@@ -141,11 +142,6 @@ export default Collision = {
         // Skip if already processed (e.g. by parent object)
         if (label.placed != null) {
             return label.placed;
-        }
-
-        // Skip if an alternate placement was already placed
-        if (label.alternates && label.alternates.some(x => x.placed)) {
-            return false;
         }
 
         // Test the label for intersections with other labels in the tile

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -51,7 +51,7 @@ export default Collision = {
         let tile_objects = state.objects;
         for (let i=0; i < objects.length; i++) {
             let obj = objects[i];
-            let priority = obj.layout.priority;
+            let priority = obj.label.layout.priority;
             tile_objects[priority] = tile_objects[priority] || {};
             tile_objects[priority][style] = tile_objects[priority][style] || [];
             tile_objects[priority][style].push(obj);
@@ -116,7 +116,7 @@ export default Collision = {
     // Run collision and repeat check to see if label can currently be placed
     canBePlaced (object, tile, exclude = null) {
         let label = object.label;
-        let layout = object.layout;
+        let layout = object.label.layout;
         let candidates = object.candidates;
 
         // Determine if any of the placement candidates options can be assigned as the label
@@ -125,7 +125,6 @@ export default Collision = {
                 for (let p=0; p < candidates.length; p++) {
                     if (this.canBePlaced(candidates[p], tile, exclude)) {
                         object.label = candidates[p].label; // assign placed label
-                        object.align = candidates[p].align;
                         object.candidates = null; // don't check candidates again
                         return true;
                     }
@@ -164,14 +163,14 @@ export default Collision = {
     },
 
     // Place label
-    place ({ label, layout }, tile) {
+    place ({ label }, tile) {
         // Skip if already processed (e.g. by parent object)
         if (label.placed != null) {
             return;
         }
 
         // Register as placed for future collision and repeat culling
-        RepeatGroup.add(label, layout, tile);
+        RepeatGroup.add(label, label.layout, tile);
         label.add(this.tiles[tile].bboxes);
     }
 

--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -114,7 +114,6 @@ export default Collision = {
     },
 
     // Run collision and repeat check to see if label can currently be placed
-    // canBePlaced ({ label, placements, layout }, tile, exclude = null) {
     canBePlaced (object, tile, exclude = null) {
         let label = object.label;
         let layout = object.layout;

--- a/src/labels/label.js
+++ b/src/labels/label.js
@@ -8,7 +8,6 @@ export default class Label {
     constructor (size, options = {}) {
         this.size = size;
         this.options = options;
-        // this.layout = options; // TODO: reduce dupe with options
         this.position = null;
         this.placed = null;
         this.aabb = null;

--- a/src/labels/label.js
+++ b/src/labels/label.js
@@ -8,6 +8,7 @@ export default class Label {
     constructor (size, options = {}) {
         this.size = size;
         this.options = options;
+        // this.layout = options; // TODO: reduce dupe with options
         this.position = null;
         this.placed = null;
         this.aabb = null;

--- a/src/labels/label.js
+++ b/src/labels/label.js
@@ -5,9 +5,9 @@ import OBB from '../utils/obb';
 
 export default class Label {
 
-    constructor (size, options = {}) {
+    constructor (size, layout = {}) {
         this.size = size;
-        this.options = options;
+        this.layout = layout;
         this.position = null;
         this.placed = null;
         this.aabb = null;
@@ -23,7 +23,7 @@ export default class Label {
         // Broad phase
         if (aabbs.length > 0) {
             boxIntersect([this.aabb], aabbs, (i, j) => {
-                // log('trace', 'collision: broad phase collide', this.options.id, this, this.aabb, aabbs[j]);
+                // log('trace', 'collision: broad phase collide', this.layout.id, this, this.aabb, aabbs[j]);
 
                 // Skip if colliding with excluded label
                 if (exclude && aabbs[j] === exclude.aabb) {
@@ -33,14 +33,14 @@ export default class Label {
 
                 // Skip narrow phase collision if no rotation
                 if (this.obb.angle === 0 && obbs[j].angle === 0) {
-                    // log('trace', 'collision: skip narrow phase collide because neither is rotated', this.options.id, this, this.obb, obbs[j]);
+                    // log('trace', 'collision: skip narrow phase collide because neither is rotated', this.layout.id, this, this.obb, obbs[j]);
                     intersect = true;
                     return true;
                 }
 
                 // Narrow phase
                 if (OBB.intersect(this.obb, obbs[j])) {
-                    // log('trace', 'collision: narrow phase collide', this.options.id, this, this.obb, obbs[j]);
+                    // log('trace', 'collision: narrow phase collide', this.layout.id, this, this.obb, obbs[j]);
                     intersect = true;
                     return true;
                 }
@@ -74,11 +74,11 @@ export default class Label {
     // (e.g. useful for linked objects that shouldn't affect each other's placement)
     discard (bboxes, exclude = null) {
         // Should the label be culled if it can't fit inside the tile bounds?
-        if (this.options.cull_from_tile) {
+        if (this.layout.cull_from_tile) {
             let in_tile = this.inTileBounds();
 
             // If it doesn't fit, should we try to move it into the tile bounds?
-            if (!in_tile && this.options.move_into_tile) {
+            if (!in_tile && this.layout.move_into_tile) {
                 // Can we fit the label into the tile?
                 if (!this.moveIntoTile()) {
                     return true; // can't fit in tile, discard

--- a/src/labels/label.js
+++ b/src/labels/label.js
@@ -1,3 +1,4 @@
+import PointAnchor from './point_anchor';
 import boxIntersect from 'box-intersect'; // https://github.com/mikolalysenko/box-intersect
 import Utils from '../utils/utils';
 import OBB from '../utils/obb';
@@ -9,9 +10,14 @@ export default class Label {
         this.size = size;
         this.layout = layout;
         this.position = null;
+        this.anchor = Array.isArray(this.layout.anchor) ? this.layout.anchor[0] : this.layout.anchor; // initial anchor
         this.placed = null;
         this.aabb = null;
         this.obb = null;
+    }
+
+    update () {
+        this.align = this.layout.align || PointAnchor.alignForAnchor(this.anchor);
     }
 
     // check for overlaps with other labels in the tile

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -1,19 +1,21 @@
 import Vector from '../vector';
 import Label from './label';
 import OBB from '../utils/obb';
+import PointAnchor from '../styles/points/point_anchor';
 
 export default class LabelLine extends Label {
 
-    constructor (size, lines, options) {
-        super(size, options);
+    constructor (size, lines, layout) {
+        super(size, layout);
 
         this.lines = lines;
-        this.offset = [this.options.offset[0], this.options.offset[1]];
+        this.offset = [this.layout.offset[0], this.layout.offset[1]];
+        this.anchor = this.layout.anchor;
 
         // optionally limit the line segments that the label may be placed in, by specifying a segment index range
         // used as a coarse subdivide for placing multiple labels per line geometry
-        this.segment_index = options.segment_start || 0;
-        this.segment_max = options.segment_end || this.lines.length;
+        this.segment_index = layout.segment_start || 0;
+        this.segment_max = layout.segment_end || this.lines.length;
         this.update();
     }
 
@@ -21,6 +23,7 @@ export default class LabelLine extends Label {
         let segment = this.currentSegment();
         this.angle = this.computeAngle();
         this.position = [(segment[0][0] + segment[1][0]) / 2, (segment[0][1] + segment[1][1]) / 2];
+        this.align = this.layout.align || PointAnchor.alignForAnchor(this.anchor); // TODO: move to parent Label class
         this.updateBBoxes();
     }
 
@@ -57,12 +60,12 @@ export default class LabelLine extends Label {
         let p0p1 = Vector.sub(segment[0], segment[1]);
         let length = Vector.length(p0p1);
 
-        let label_length = this.size[0] * this.options.units_per_pixel;
+        let label_length = this.size[0] * this.layout.units_per_pixel;
 
         if (label_length > length) {
             // an exceed heurestic of 100% would let the label fit in any cases
             let exceed = (1 - (length / label_length)) * 100;
-            return exceed < this.options.line_exceed;
+            return exceed < this.layout.line_exceed;
         }
 
         return label_length <= length;
@@ -76,9 +79,9 @@ export default class LabelLine extends Label {
     }
 
     updateBBoxes () {
-        let upp = this.options.units_per_pixel;
-        let width = (this.size[0] + this.options.buffer[0] * 2) * upp * Label.epsilon;
-        let height = (this.size[1] + this.options.buffer[1] * 2) * upp * Label.epsilon;
+        let upp = this.layout.units_per_pixel;
+        let width = (this.size[0] + this.layout.buffer[0] * 2) * upp * Label.epsilon;
+        let height = (this.size[1] + this.layout.buffer[1] * 2) * upp * Label.epsilon;
 
         // apply offset, x positive, y pointing down
         let offset = Vector.rot(this.offset, this.angle);

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -1,7 +1,6 @@
-import Vector from '../vector';
 import Label from './label';
+import Vector from '../vector';
 import OBB from '../utils/obb';
-import PointAnchor from '../styles/points/point_anchor';
 
 export default class LabelLine extends Label {
 
@@ -10,7 +9,6 @@ export default class LabelLine extends Label {
 
         this.lines = lines;
         this.offset = [this.layout.offset[0], this.layout.offset[1]];
-        this.anchor = this.layout.anchor;
 
         // optionally limit the line segments that the label may be placed in, by specifying a segment index range
         // used as a coarse subdivide for placing multiple labels per line geometry
@@ -20,10 +18,10 @@ export default class LabelLine extends Label {
     }
 
     update () {
+        super.update();
         let segment = this.currentSegment();
         this.angle = this.computeAngle();
         this.position = [(segment[0][0] + segment[1][0]) / 2, (segment[0][1] + segment[1][1]) / 2];
-        this.align = this.layout.align || PointAnchor.alignForAnchor(this.anchor); // TODO: move to parent Label class
         this.updateBBoxes();
     }
 

--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -10,6 +10,8 @@ export default class LabelPoint extends Label {
         super(size, options);
         this.position = [position[0], position[1]];
         this.offset = [this.options.offset[0], this.options.offset[1]];
+        this.anchor = this.options.anchor;
+        this.parent = this.options.parent;
         this.update();
     }
 
@@ -22,11 +24,11 @@ export default class LabelPoint extends Label {
         // return PointAnchor.computeOffset(this.offset, this.size, this.options.anchor);
 
         // Additional anchor/offset for point:
-        if (this.options.parent) {
-            let parent = this.options.parent;
+        if (this.parent) {
+            let parent = this.parent;
             // point's own anchor, text anchor applied to point, additional point offset
             this.offset = PointAnchor.computeOffset(this.offset, parent.size, parent.anchor);
-            this.offset = PointAnchor.computeOffset(this.offset, parent.size, this.options.anchor);
+            this.offset = PointAnchor.computeOffset(this.offset, parent.size, this.anchor);
             if (parent.offset !== StyleParser.zeroPair) {        // point has an offset
                 if (this.offset === StyleParser.zeroPair) { // no text offset, use point's
                     this.offset = parent.offset;
@@ -38,7 +40,7 @@ export default class LabelPoint extends Label {
             }
         }
 
-        return PointAnchor.computeOffset(this.offset, this.size, this.options.anchor);
+        return PointAnchor.computeOffset(this.offset, this.size, this.anchor);
     }
 
     updateBBoxes () {

--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -16,13 +16,11 @@ export default class LabelPoint extends Label {
     }
 
     update() {
-        this.offset = this.computeOffset();
+        this.computeOffset();
         this.updateBBoxes();
     }
 
     computeOffset () {
-        // return PointAnchor.computeOffset(this.offset, this.size, this.options.anchor);
-
         // Additional anchor/offset for point:
         if (this.parent) {
             let parent = this.parent;
@@ -40,7 +38,7 @@ export default class LabelPoint extends Label {
             }
         }
 
-        return PointAnchor.computeOffset(this.offset, this.size, this.anchor);
+        this.offset = PointAnchor.computeOffset(this.offset, this.size, this.anchor);
     }
 
     updateBBoxes () {

--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -2,6 +2,7 @@ import Label from './label';
 import Geo from '../geo';
 import OBB from '../utils/obb';
 import PointAnchor from '../styles/points/point_anchor';
+import {StyleParser} from '../styles/style_parser';
 
 export default class LabelPoint extends Label {
 
@@ -18,6 +19,25 @@ export default class LabelPoint extends Label {
     }
 
     computeOffset () {
+        // return PointAnchor.computeOffset(this.offset, this.size, this.options.anchor);
+
+        // Additional anchor/offset for point:
+        if (this.options.parent) {
+            let parent = this.options.parent;
+            // point's own anchor, text anchor applied to point, additional point offset
+            this.offset = PointAnchor.computeOffset(this.offset, parent.size, parent.anchor);
+            this.offset = PointAnchor.computeOffset(this.offset, parent.size, this.options.anchor);
+            if (parent.offset !== StyleParser.zeroPair) {        // point has an offset
+                if (this.offset === StyleParser.zeroPair) { // no text offset, use point's
+                    this.offset = parent.offset;
+                }
+                else {                                          // text has offset, add point's
+                    this.offset[0] += parent.offset[0];
+                    this.offset[1] += parent.offset[1];
+                }
+            }
+        }
+
         return PointAnchor.computeOffset(this.offset, this.size, this.options.anchor);
     }
 

--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -6,16 +6,17 @@ import {StyleParser} from '../styles/style_parser';
 
 export default class LabelPoint extends Label {
 
-    constructor (position, size, options) {
-        super(size, options);
+    constructor (position, size, layout) {
+        super(size, layout);
         this.position = [position[0], position[1]];
-        this.offset = [this.options.offset[0], this.options.offset[1]];
-        this.anchor = this.options.anchor;
-        this.parent = this.options.parent;
+        this.offset = [this.layout.offset[0], this.layout.offset[1]];
+        this.anchor = this.layout.anchor;
+        this.parent = this.layout.parent;
         this.update();
     }
 
     update() {
+        this.align = this.layout.align || PointAnchor.alignForAnchor(this.anchor); // TODO: move to parent Label class
         this.computeOffset();
         this.updateBBoxes();
     }
@@ -42,12 +43,12 @@ export default class LabelPoint extends Label {
     }
 
     updateBBoxes () {
-        let width = (this.size[0] + this.options.buffer[0] * 2) * this.options.units_per_pixel * Label.epsilon;
-        let height = (this.size[1] + this.options.buffer[1] * 2) * this.options.units_per_pixel * Label.epsilon;
+        let width = (this.size[0] + this.layout.buffer[0] * 2) * this.layout.units_per_pixel * Label.epsilon;
+        let height = (this.size[1] + this.layout.buffer[1] * 2) * this.layout.units_per_pixel * Label.epsilon;
 
         let p = [
-            this.position[0] + (this.offset[0] * this.options.units_per_pixel),
-            this.position[1] - (this.offset[1] * this.options.units_per_pixel)
+            this.position[0] + (this.offset[0] * this.layout.units_per_pixel),
+            this.position[1] - (this.offset[1] * this.layout.units_per_pixel)
         ];
 
         this.obb = new OBB(p[0], p[1], 0, width, height);

--- a/src/labels/point_anchor.js
+++ b/src/labels/point_anchor.js
@@ -4,31 +4,44 @@ const rights = ['right', 'top-right', 'bottom-right'];
 const tops = ['top', 'top-left', 'top-right'];
 const bottoms = ['bottom', 'bottom-left', 'bottom-right'];
 
-var PointAnchor;
+let PointAnchor;
 
 export default PointAnchor = {
 
-    computeOffset (offset, size, anchor) {
+    computeOffset (offset, size, anchor, buffer = null) {
         if (!anchor || anchor === 'center') {
             return offset;
         }
 
         let offset2 = [offset[0], offset[1]];
+        buffer = buffer || this.default_buffer;
 
         // An optional left/right offset
         if (this.isLeftAnchor(anchor)) {
             offset2[0] -= size[0] / 2;
+            if (anchor === 'left') {
+                offset2[0] -= buffer[0];
+            }
         }
         else if (this.isRightAnchor(anchor)) {
             offset2[0] += size[0] / 2;
+            if (anchor === 'right') {
+                offset2[0] += buffer[1];
+            }
         }
 
         // An optional top/bottom offset
         if (this.isTopAnchor(anchor)) {
             offset2[1] -= size[1] / 2;
+            if (anchor === 'top') {
+                offset2[1] -= buffer[2];
+            }
         }
         else if (this.isBottomAnchor(anchor)) {
             offset2[1] += size[1] / 2;
+            if (anchor === 'bottom') {
+                offset2[1] += buffer[3];
+            }
         }
 
         return offset2;
@@ -60,6 +73,10 @@ export default PointAnchor = {
 
     isBottomAnchor (anchor) {
         return (bottoms.indexOf(anchor) > -1);
-    }
+    },
+
+    // Buffers: [left, right, top, bottom]
+    default_buffer: [2.5, 2.5, 1.5, 0.75],
+    zero_buffer: [0, 0, 0, 0]
 
 };

--- a/src/styles/points/point_anchor.js
+++ b/src/styles/points/point_anchor.js
@@ -34,6 +34,18 @@ export default PointAnchor = {
         return offset2;
     },
 
+    alignForAnchor (anchor) {
+        if (anchor && anchor !== 'center') {
+            if (this.isLeftAnchor(anchor)) {
+                return 'right';
+            }
+            else if (this.isRightAnchor(anchor)) {
+                return 'left';
+            }
+        }
+        return 'center';
+    },
+
     isLeftAnchor (anchor) {
         return (lefts.indexOf(anchor) > -1);
     },

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -251,7 +251,6 @@ Object.assign(Points, {
                         context: q.context,
                         text: q.text_feature.text,
                         text_settings_key: q.text_feature.text_settings_key,
-                        text_settings: q.text_feature.text_settings, // TODO: ideally we shouldn't send this to main thread
                         layout: q.text_feature.layout,
                         point_label: label,
                         linked: point_obj   // link so text only renders when parent point is placed

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -12,7 +12,6 @@ import Vector from '../../vector';
 import Collision from '../../labels/collision';
 import LabelPoint from '../../labels/label_point';
 import {TextLabels} from '../text/text_labels';
-import TextSettings from '../text/text_settings';
 import PointAnchor from './point_anchor';
 
 let fs = require('fs');

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -331,12 +331,15 @@ Object.assign(Points, {
         draw.text = this.preprocessText(draw.text); // will return null if valid text styling wasn't provided
         if (draw.text) {
             draw.text.key = draw.key; // copy layer key for use as label repeat group
-            draw.text.anchor = draw.text.anchor || 'bottom'; // Default text anchor to bottom
+            draw.text.anchor = draw.text.anchor || this.default_anchor;
             draw.text.optional = (typeof draw.text.optional === 'boolean') ? draw.text.optional : false; // default text to required
         }
 
         return draw;
     },
+
+    // Default to trying all anchor placements
+    default_anchor: ['bottom', 'top', 'right', 'left', 'bottom-right', 'bottom-left', 'top-right', 'top-left'],
 
     // Compute label layout-related properties
     computeLayout (target, feature, draw, context, tile) {

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -397,33 +397,20 @@ Object.assign(Points, {
                 let anchors = fq.layout.anchor;
                 for (let a=0; a < anchors.length; a++) {
                     fq.layout.anchor = anchors[a];
-
-                    // TODO: move align calc to function, separate from TextSettings
-                    let align = fq.text_settings.align;
-                    if (!align) {
-                        if (PointAnchor.isLeftAnchor(fq.layout.anchor)) {
-                            align = 'right';
-                        }
-                        else if (PointAnchor.isRightAnchor(fq.layout.anchor)) {
-                            align = 'left';
-                        }
-                        else {
-                            align = 'center';
-                        }
-                    }
-
+                    let align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
                     let label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
                     alternates.push({ label, align, layout: fq.layout });
                 }
-                fq.layout.anchor = anchors; // restore anchors (TODO: will this be accessed again?)
+                fq.layout.anchor = anchors; // restore anchors
                 fq.placements = alternates;
-                labels.push(fq);
             }
             else {
-                fq.align = fq.text_settings.align || 'center';
+                // Single-anchor label
+                fq.align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
                 fq.label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-                labels.push(fq);
             }
+
+            labels.push(fq);
         }
         return labels;
     },

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -391,16 +391,16 @@ Object.assign(Points, {
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
 
             if (Array.isArray(fq.layout.anchor)) {
-                let alternates = [];
+                let candidates = [];
                 let anchors = fq.layout.anchor;
                 for (let a=0; a < anchors.length; a++) {
                     fq.layout.anchor = anchors[a];
                     let align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
                     let label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-                    alternates.push({ label, align, layout: fq.layout });
+                    candidates.push({ label, align, layout: fq.layout });
                 }
                 fq.layout.anchor = anchors; // restore anchors
-                fq.placements = alternates;
+                fq.candidates = candidates;
             }
             else {
                 // Single-anchor label

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -402,14 +402,17 @@ Object.assign(Points, {
                     fql.layout.anchor = anchors[a];
 
                     // TODO: move align calc to function, separate from TextSettings
-                    if (PointAnchor.isLeftAnchor(fql.layout.anchor)) {
-                        fql.align = 'right';
-                    }
-                    else if (PointAnchor.isRightAnchor(fql.layout.anchor)) {
-                        fql.align = 'left';
-                    }
-                    else {
-                        fql.align = 'center';
+                    fql.align = fql.text_settings.align;
+                    if (!fql.align) {
+                        if (PointAnchor.isLeftAnchor(fql.layout.anchor)) {
+                            fql.align = 'right';
+                        }
+                        else if (PointAnchor.isRightAnchor(fql.layout.anchor)) {
+                            fql.align = 'left';
+                        }
+                        else {
+                            fql.align = 'center';
+                        }
                     }
 
                     fql.label = new LabelPoint(fql.point_label.position, text_info.size.collision_size, fql.layout);
@@ -421,7 +424,7 @@ Object.assign(Points, {
                 fq.placements = alternates;
             }
             else {
-                fq.align = fq.text_settings.align;
+                fq.align = fq.text_settings.align || 'center';
                 fq.label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
                 labels.push(fq);
             }

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -12,7 +12,6 @@ import Vector from '../../vector';
 import Collision from '../../labels/collision';
 import LabelPoint from '../../labels/label_point';
 import {TextLabels} from '../text/text_labels';
-import PointAnchor from './point_anchor';
 
 let fs = require('fs');
 const shaderSrc_pointsVertex = fs.readFileSync(__dirname + '/points_vertex.glsl', 'utf8');
@@ -388,26 +387,7 @@ Object.assign(Points, {
         for (let f=0; f < feature_queue.length; f++) {
             let fq = feature_queue[f];
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
-
-            if (Array.isArray(fq.layout.anchor)) {
-                // let candidates = [];
-                // let anchors = fq.layout.anchor;
-                // for (let a=0; a < anchors.length; a++) {
-                //     fq.layout.anchor = anchors[a];
-                //     let align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
-                //     let label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-                //     candidates.push({ label, align, layout: fq.layout });
-                // }
-                // fq.layout.anchor = anchors; // restore anchors
-                // fq.candidates = candidates;
-                fq.layout.anchor = fq.layout.anchor[0];
-            }
-            // else {
-                // Single-anchor label
-                // fq.align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
-                fq.label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-            // }
-
+            fq.label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
             labels.push(fq);
         }
         return labels;

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -239,7 +239,6 @@ Object.assign(Points, {
                     draw: q.draw,
                     context: q.context,
                     style,
-                    layout: style,
                     label
                 };
                 point_objs.push(point_obj);
@@ -294,7 +293,7 @@ Object.assign(Points, {
                         style.size = text_info.size.logical_size;
                         style.angle = q.label.angle || 0;
                         style.sampler = 1; // non-0 = labels
-                        style.texcoords = text_info.align[q.align].texcoords;
+                        style.texcoords = text_info.align[q.label.align].texcoords;
 
                         Style.addFeature.call(this, q.feature, q.draw, q.context);
                     });
@@ -391,22 +390,23 @@ Object.assign(Points, {
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
 
             if (Array.isArray(fq.layout.anchor)) {
-                let candidates = [];
-                let anchors = fq.layout.anchor;
-                for (let a=0; a < anchors.length; a++) {
-                    fq.layout.anchor = anchors[a];
-                    let align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
-                    let label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-                    candidates.push({ label, align, layout: fq.layout });
-                }
-                fq.layout.anchor = anchors; // restore anchors
-                fq.candidates = candidates;
+                // let candidates = [];
+                // let anchors = fq.layout.anchor;
+                // for (let a=0; a < anchors.length; a++) {
+                //     fq.layout.anchor = anchors[a];
+                //     let align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
+                //     let label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
+                //     candidates.push({ label, align, layout: fq.layout });
+                // }
+                // fq.layout.anchor = anchors; // restore anchors
+                // fq.candidates = candidates;
+                fq.layout.anchor = fq.layout.anchor[0];
             }
-            else {
+            // else {
                 // Single-anchor label
-                fq.align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
+                // fq.align = fq.draw.align || PointAnchor.alignForAnchor(fq.layout.anchor);
                 fq.label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-            }
+            // }
 
             labels.push(fq);
         }

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -392,36 +392,32 @@ Object.assign(Points, {
             let fq = feature_queue[f];
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
 
-            // fq.label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
-
             if (Array.isArray(fq.layout.anchor)) {
                 let alternates = [];
                 let anchors = fq.layout.anchor;
                 for (let a=0; a < anchors.length; a++) {
-                    let fql = Object.create(fq);
-                    fql.layout.anchor = anchors[a];
+                    fq.layout.anchor = anchors[a];
 
                     // TODO: move align calc to function, separate from TextSettings
-                    fql.align = fql.text_settings.align;
-                    if (!fql.align) {
-                        if (PointAnchor.isLeftAnchor(fql.layout.anchor)) {
-                            fql.align = 'right';
+                    let align = fq.text_settings.align;
+                    if (!align) {
+                        if (PointAnchor.isLeftAnchor(fq.layout.anchor)) {
+                            align = 'right';
                         }
-                        else if (PointAnchor.isRightAnchor(fql.layout.anchor)) {
-                            fql.align = 'left';
+                        else if (PointAnchor.isRightAnchor(fq.layout.anchor)) {
+                            align = 'left';
                         }
                         else {
-                            fql.align = 'center';
+                            align = 'center';
                         }
                     }
 
-                    fql.label = new LabelPoint(fql.point_label.position, text_info.size.collision_size, fql.layout);
-                    alternates.push(fql.label);
-                    labels.push(fql);
+                    let label = new LabelPoint(fq.point_label.position, text_info.size.collision_size, fq.layout);
+                    alternates.push({ label, align, layout: fq.layout });
                 }
                 fq.layout.anchor = anchors; // restore anchors (TODO: will this be accessed again?)
-                alternates.forEach(label => label.alternates = alternates);
                 fq.placements = alternates;
+                labels.push(fq);
             }
             else {
                 fq.align = fq.text_settings.align || 'center';

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -197,7 +197,17 @@ export default class CanvasText {
             for (let text in text_infos) {
                 let info = text_infos[text];
                 let text_settings = info.text_settings;
-                let lines = CanvasText.text_cache[style][text].lines; // get previously computed lines of text
+                // let lines = CanvasText.text_cache[style][text].lines; // get previously computed lines of text
+
+                let lines;
+                if (!CanvasText.text_cache[style]) {
+                    CanvasText.text_cache[style] = {};
+                }
+                if (!CanvasText.text_cache[style][text]) {
+                    CanvasText.text_cache[style][text] =
+                        this.textSize(text, text_settings.transform, text_settings.text_wrap);
+                }
+                lines = CanvasText.text_cache[style][text].lines;
 
                 if (first) {
                     this.setFont(text_settings);

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -197,34 +197,27 @@ export default class CanvasText {
             for (let text in text_infos) {
                 let info = text_infos[text];
                 let text_settings = info.text_settings;
-                // let lines = CanvasText.text_cache[style][text].lines; // get previously computed lines of text
-
-                let lines;
-                if (!CanvasText.text_cache[style]) {
-                    CanvasText.text_cache[style] = {};
-                }
-                if (!CanvasText.text_cache[style][text]) {
-                    CanvasText.text_cache[style][text] =
-                        this.textSize(text, text_settings.transform, text_settings.text_wrap);
-                }
-                lines = CanvasText.text_cache[style][text].lines;
+                let lines = CanvasText.text_cache[style][text].lines; // get previously computed lines of text
 
                 if (first) {
                     this.setFont(text_settings);
                     first = false;
                 }
 
-                this.drawText(lines, info.position, info.size, {
-                    stroke: text_settings.stroke,
-                    transform: text_settings.transform,
-                    align: text_settings.align
-                });
+                // each alignment needs to be rendered separately
+                for (let align in info.align) {
+                    this.drawText(lines, info.align[align].texture_position, info.size, {
+                        stroke: text_settings.stroke,
+                        transform: text_settings.transform,
+                        align: align
+                    });
 
-                info.texcoords = Texture.getTexcoordsForSprite(
-                    info.position,
-                    info.size.texture_size,
-                    texture_size
-                );
+                    info.align[align].texcoords = Texture.getTexcoordsForSprite(
+                        info.align[align].texture_position,
+                        info.size.texture_size,
+                        texture_size
+                    );
+                }
             }
         }
     }
@@ -248,20 +241,26 @@ export default class CanvasText {
         let height = 0;     // overall atlas height
         for (let style in texts) {
             let text_infos = texts[style];
+
             for (let text in text_infos) {
                 let text_info = text_infos[text];
+                // rendered size is same for all alignments
                 let size = text_info.size.texture_size;
-                if (cy + size[1] < max_texture_size) {
-                    text_info.position = [cx, cy]; // add label to current column
-                    cy += size[1];
-                    if (cy > height) {
-                        height = cy;
+
+                // but each alignment needs to be rendered separately
+                for (let align in text_info.align) {
+                    if (cy + size[1] < max_texture_size) {
+                        text_info.align[align].texture_position = [cx, cy]; // add label to current column
+                        cy += size[1];
+                        if (cy > height) {
+                            height = cy;
+                        }
                     }
-                }
-                else { // start new column if taller than texture
-                    cx += widest;
-                    cy = 0;
-                    text_info.position = [cx, cy];
+                    else { // start new column if taller than texture
+                        cx += widest;
+                        cy = 0;
+                        text_info.align[align].texture_position = [cx, cy];
+                    }
                 }
             }
         }

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -94,12 +94,23 @@ Object.assign(TextStyle, {
 
                         // setup styling object expected by Style class
                         let style = this.feature_style;
-                        style.label = q.label;
+                        // style.label = q.label;
                         style.size = text_info.size.logical_size;
-                        style.angle = q.label.angle || 0;
+                        // style.angle = q.label.angle || 0;
                         style.texcoords = text_info.texcoords;
 
-                        Style.addFeature.call(this, q.feature, q.draw, q.context);
+                        // if (q.label instanceof LabelGroup) {
+                        //     q.label.labels.forEach(label => {
+                        //         style.label = label;
+                        //         style.angle = label.angle || 0;
+                        //         Style.addFeature.call(this, q.feature, q.draw, q.context);
+                        //     });
+                        // }
+                        // else {
+                            style.label = q.label;
+                            style.angle = q.label.angle || 0;
+                            Style.addFeature.call(this, q.feature, q.draw, q.context);
+                        // }
                     });
                 }
                 this.freeText(tile);
@@ -149,7 +160,24 @@ Object.assign(TextStyle, {
                 this.buildLineLabels(size, lines[i], options, labels);
             }
         } else if (geometry.type === "Point") {
-            labels.push(new LabelPoint(geometry.coordinates, size, options));
+            // labels.push(new LabelPoint(geometry.coordinates, size, options));
+
+            if (Array.isArray(options.anchor)) {
+                let anchors = options.anchor;
+                // let group = [];
+                for (let a=0; a < anchors.length; a++) {
+                    options.anchor = anchors[a];
+                    // group.push(new LabelPoint(geometry.coordinates, size, options));
+                    labels.push(new LabelPoint(geometry.coordinates, size, options));
+                }
+                // labels.push(new LabelGroup(group));
+                options.anchor = anchors; // restore anchors
+
+                labels.forEach(label => label.alternates = labels);
+            }
+            else {
+                labels.push(new LabelPoint(geometry.coordinates, size, options));
+            }
         } else if (geometry.type === "MultiPoint") {
             let points = geometry.coordinates;
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -90,7 +90,9 @@ Object.assign(TextStyle, {
                     // Build queued features
                     labels.forEach(q => {
                         let text_settings_key = q.text_settings_key;
-                        let text_info = this.texts[tile.key] && this.texts[tile.key][text_settings_key] && this.texts[tile.key][text_settings_key][q.text];
+                        let text_info =
+                            this.texts[tile.key][text_settings_key] &&
+                            this.texts[tile.key][text_settings_key][q.text];
 
                         // setup styling object expected by Style class
                         let style = this.feature_style;

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -3,6 +3,7 @@
 import Geo from '../../geo';
 import {Style} from '../style';
 import {Points} from '../points/points';
+import PointAnchor from '../points/point_anchor';
 import Collision from '../../labels/collision';
 import LabelPoint from '../../labels/label_point';
 import LabelLine from '../../labels/label_line';
@@ -96,23 +97,12 @@ Object.assign(TextStyle, {
 
                         // setup styling object expected by Style class
                         let style = this.feature_style;
-                        // style.label = q.label;
+                        style.label = q.label;
                         style.size = text_info.size.logical_size;
-                        // style.angle = q.label.angle || 0;
-                        style.texcoords = text_info.texcoords;
+                        style.angle = q.label.angle || 0;
+                        style.texcoords = text_info.align[q.align].texcoords;
 
-                        // if (q.label instanceof LabelGroup) {
-                        //     q.label.labels.forEach(label => {
-                        //         style.label = label;
-                        //         style.angle = label.angle || 0;
-                        //         Style.addFeature.call(this, q.feature, q.draw, q.context);
-                        //     });
-                        // }
-                        // else {
-                            style.label = q.label;
-                            style.angle = q.label.angle || 0;
-                            Style.addFeature.call(this, q.feature, q.draw, q.context);
-                        // }
+                        Style.addFeature.call(this, q.feature, q.draw, q.context);
                     });
                 }
                 this.freeText(tile);
@@ -131,6 +121,7 @@ Object.assign(TextStyle, {
 
     // Sets up caching for draw properties
     _preprocess (draw) {
+        draw.anchor = Array.isArray(draw.anchor) ? draw.anchor[0] : draw.anchor; // TODO: support multi anchors
         return this.preprocessText(draw);
     },
 
@@ -139,6 +130,7 @@ Object.assign(TextStyle, {
         let labels = [];
         for (let f=0; f < feature_queue.length; f++) {
             let fq = feature_queue[f];
+            fq.align = fq.draw.align || PointAnchor.alignForAnchor(fq.draw.anchor); // TODO: support multi anchors
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
             let feature_labels = this.buildLabels(text_info.size.collision_size, fq.feature.geometry, fq.layout);
             for (let i = 0; i < feature_labels.length; i++) {
@@ -151,69 +143,51 @@ Object.assign(TextStyle, {
     },
 
     // Builds one or more labels for a geometry
-    buildLabels (size, geometry, options) {
+    buildLabels (size, geometry, layout) {
         let labels = [];
 
         if (geometry.type === "LineString") {
-            this.buildLineLabels(size, geometry.coordinates, options, labels);
+            this.buildLineLabels(geometry.coordinates, size, layout, labels);
         } else if (geometry.type === "MultiLineString") {
             let lines = geometry.coordinates;
             for (let i = 0; i < lines.length; ++i) {
-                this.buildLineLabels(size, lines[i], options, labels);
+                this.buildLineLabels(lines[i], size, layout, labels);
             }
         } else if (geometry.type === "Point") {
-            // labels.push(new LabelPoint(geometry.coordinates, size, options));
-
-            if (Array.isArray(options.anchor)) {
-                let anchors = options.anchor;
-                // let group = [];
-                for (let a=0; a < anchors.length; a++) {
-                    options.anchor = anchors[a];
-                    // group.push(new LabelPoint(geometry.coordinates, size, options));
-                    labels.push(new LabelPoint(geometry.coordinates, size, options));
-                }
-                // labels.push(new LabelGroup(group));
-                options.anchor = anchors; // restore anchors
-
-                labels.forEach(label => label.alternates = labels);
-            }
-            else {
-                labels.push(new LabelPoint(geometry.coordinates, size, options));
-            }
+            labels.push(new LabelPoint(geometry.coordinates, size, layout));
         } else if (geometry.type === "MultiPoint") {
             let points = geometry.coordinates;
-
             for (let i = 0; i < points.length; ++i) {
-                labels.push(new LabelPoint(points[i], size, options));
+                labels.push(new LabelPoint(points[i], size, layout));
             }
         } else if (geometry.type === "Polygon") {
             let centroid = Geo.centroid(geometry.coordinates);
-            labels.push(new LabelPoint(centroid, size, options));
+            labels.push(new LabelPoint(centroid, size, layout));
         } else if (geometry.type === "MultiPolygon") {
             let centroid = Geo.multiCentroid(geometry.coordinates);
-            labels.push(new LabelPoint(centroid, size, options));
+            labels.push(new LabelPoint(centroid, size, layout));
         }
 
         return labels;
     },
 
     // Build one or more labels for a line geometry
-    buildLineLabels (size, line, options, labels) {
-        let subdiv = Math.min(options.subdiv, line.length - 1);
+    buildLineLabels (line, size, layout, labels) {
+        let subdiv = Math.min(layout.subdiv, line.length - 1);
         if (subdiv > 1) {
             // Create multiple labels for line, with each allotted a range of segments
             // in which it will attempt to place
             let seg_per_div = (line.length - 1) / subdiv;
             for (let i=0; i < subdiv; i++) {
-                options.segment_start = Math.floor(i * seg_per_div);
-                options.segment_end = Math.floor((i+1) * seg_per_div);
-                labels.push(new LabelLine(size, line, options));
+                layout.segment_start = Math.floor(i * seg_per_div);
+                layout.segment_end = Math.floor((i+1) * seg_per_div);
+                labels.push(new LabelLine(size, line, layout)); // TODO: swap constructor arg order
             }
-            options.segment_start = null;
-            options.segment_end = null;
+            layout.segment_start = null;
+            layout.segment_end = null;
         }
         else {
-            labels.push(new LabelLine(size, line, options));
+            labels.push(new LabelLine(size, line, layout)); // TODO: swap constructor arg order
         }
     }
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -3,7 +3,6 @@
 import Geo from '../../geo';
 import {Style} from '../style';
 import {Points} from '../points/points';
-import PointAnchor from '../points/point_anchor';
 import Collision from '../../labels/collision';
 import LabelPoint from '../../labels/label_point';
 import LabelLine from '../../labels/label_line';
@@ -100,7 +99,7 @@ Object.assign(TextStyle, {
                         style.label = q.label;
                         style.size = text_info.size.logical_size;
                         style.angle = q.label.angle || 0;
-                        style.texcoords = text_info.align[q.align].texcoords;
+                        style.texcoords = text_info.align[q.label.align].texcoords;
 
                         Style.addFeature.call(this, q.feature, q.draw, q.context);
                     });
@@ -121,7 +120,6 @@ Object.assign(TextStyle, {
 
     // Sets up caching for draw properties
     _preprocess (draw) {
-        draw.anchor = Array.isArray(draw.anchor) ? draw.anchor[0] : draw.anchor; // TODO: support multi anchors
         return this.preprocessText(draw);
     },
 
@@ -130,7 +128,6 @@ Object.assign(TextStyle, {
         let labels = [];
         for (let f=0; f < feature_queue.length; f++) {
             let fq = feature_queue[f];
-            fq.align = fq.draw.align || PointAnchor.alignForAnchor(fq.draw.anchor); // TODO: support multi anchors
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
             let feature_labels = this.buildLabels(text_info.size.collision_size, fq.feature.geometry, fq.layout);
             for (let i = 0; i < feature_labels.length; i++) {

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -54,7 +54,7 @@ export const TextLabels = {
         }
 
         return {
-            draw, text, text_settings_key, layout
+            draw, text, text_settings, text_settings_key, layout
         };
     },
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -135,7 +135,7 @@ export const TextLabels = {
                 let text_settings_key = q.text_settings_key;
                 let text_info = texts[text_settings_key] && texts[text_settings_key][q.text];
                 text_info.align = text_info.align || {};
-                text_info.align[q.align] = {};
+                text_info.align[q.label.align] = {};
             });
 
             // second call to main thread, for rasterizing the set of texts
@@ -283,6 +283,8 @@ export const TextLabels = {
 
         // Max number of subdivisions to try
         layout.subdiv = tile.overzoom2;
+
+        layout.align = draw.align;
 
         return layout;
     }

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -39,10 +39,9 @@ export const TextLabels = {
         let layout = this.computeTextLayout({}, feature, draw, context, tile, text);
         let text_settings = TextSettings.compute(feature, draw, context);
         let text_settings_key = TextSettings.key(text_settings);
-        text_settings.key = text_settings_key;
 
         // first label in tile, or with this style?
-        this.texts[tile.key] = this.texts[tile.key] || { sizes: {} };
+        this.texts[tile.key] = this.texts[tile.key] || {};
         let sizes = this.texts[tile.key][text_settings_key] = this.texts[tile.key][text_settings_key] || {};
 
         // unique text strings, grouped by text drawing style
@@ -55,7 +54,7 @@ export const TextLabels = {
         }
 
         return {
-            draw, text, text_settings, text_settings_key, layout
+            draw, text, text_settings_key, layout
         };
     },
 

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -1,7 +1,6 @@
 import Utils from '../../utils/utils';
 import Geo from '../../geo';
 import {StyleParser} from '../style_parser';
-import PointAnchor from '../points/point_anchor';
 
 var TextSettings;
 
@@ -91,19 +90,6 @@ export default TextSettings = {
             text_wrap = this.defaults.text_wrap;
         }
         style.text_wrap = text_wrap;
-
-        // TODO: probably move aligment code out of here, since it's not part of the key anymore
-        // default alignment to match anchor
-        if (!draw.align && draw.anchor && draw.anchor !== 'center') {
-            if (PointAnchor.isLeftAnchor(draw.anchor)) {
-                draw.align = 'right';
-            }
-            else if (PointAnchor.isRightAnchor(draw.anchor)) {
-                draw.align = 'left';
-            }
-        }
-
-        style.align = draw.align; // || this.defaults.align;
 
         return style;
     },

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -103,7 +103,7 @@ export default TextSettings = {
             }
         }
 
-        style.align = draw.align || this.defaults.align;
+        style.align = draw.align; // || this.defaults.align;
 
         return style;
     },

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -19,7 +19,6 @@ export default TextSettings = {
             settings.stroke_width,
             settings.transform,
             settings.text_wrap,
-            settings.align,
             Utils.device_pixel_ratio
         ].join('/');
     },
@@ -93,6 +92,7 @@ export default TextSettings = {
         }
         style.text_wrap = text_wrap;
 
+        // TODO: probably move aligment code out of here, since it's not part of the key anymore
         // default alignment to match anchor
         if (!draw.align && draw.anchor && draw.anchor !== 'center') {
             if (PointAnchor.isLeftAnchor(draw.anchor)) {


### PR DESCRIPTION
Support for specifying multiple `anchor` values on point labels. This is to go with similar upcoming functionality in ES: https://github.com/tangrams/tangram-es/pull/806. Completes #344.

During label placement, each anchor position is tried in the order provided. This substantially improves the density of placed labels.

Example:
```
draw:
   points:
      ...
      text:
         anchor: [bottom, right, left, top]
         ...
```

Live preview (thanks to precog!):
https://precog.mapzen.com/tangrams/tangram/multi-anchor/#35.667086218359884,139.75703186094174,17.39925782629959

Before/after:
![output_vg1b0b](https://cloud.githubusercontent.com/assets/16733/16702650/774ef384-4535-11e6-9ff0-520b5c14818f.gif)
![output_qgegkn](https://cloud.githubusercontent.com/assets/16733/16702649/7545d3a0-4535-11e6-85e9-7c4661aeb667.gif)
![output_qcpvwd](https://cloud.githubusercontent.com/assets/16733/16702652/79eb6384-4535-11e6-8474-c97ae8fa377f.gif)

Note that while this does work for standalone `text`, it's likely more useful for `text` attached to `points`, such as a POI icon/text pair.