### PR TITLE
Add ability to load scenes from zip files

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "gl-mat4": "1.1.4",
     "gl-shader-errors": "1.0.3",
     "js-yaml": "tangrams/js-yaml#read-only",
+    "jszip": "3.0.0",
     "match-feature": "tangrams/match-feature#v1.2.0",
     "pbf": "1.3.2",
     "strip-comments": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "gl-mat4": "1.1.4",
     "gl-shader-errors": "1.0.3",
     "js-yaml": "tangrams/js-yaml#read-only",
-    "jszip": "3.0.0",
+    "jszip": "tangrams/jszip#read-only",
     "match-feature": "tangrams/match-feature#v1.2.0",
     "pbf": "1.3.2",
     "strip-comments": "0.3.2",

--- a/src/module.js
+++ b/src/module.js
@@ -33,6 +33,7 @@ import FeatureSelection from './selection';
 import CanvasText from './styles/text/canvas_text';
 
 import yaml from 'js-yaml';
+import JSZip from 'jszip';
 
 // Make some modules accessible for debugging
 var debug = {
@@ -66,6 +67,7 @@ if (Thread.is_main) {
     // Allows FontFaceObserver to use polyfill (without needing to include its own duplicate polyfill)
     if (window.Promise === undefined) {
         window.Promise = Promise;
+        JSZip.external.Promise = Promise;
     }
 }
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -15,7 +15,7 @@ import TileManager from './tile_manager';
 import DataSource from './sources/data_source';
 import FeatureSelection from './selection';
 import RenderStateManager from './gl/render_state';
-import CanvasText from './styles/text/canvas_text';
+import FontManager from './styles/text/font_manager';
 
 import {Polygons} from './styles/polygons/polygons';
 import {Lines} from './styles/lines/lines';
@@ -981,7 +981,7 @@ export default class Scene {
         this.createDataSources();
         this.loadTextures();
         this.setBackground();
-        CanvasText.loadFonts(this.config.fonts);
+        FontManager.loadFonts(this.config.fonts);
 
         // TODO: detect changes to styles? already (currently) need to recompile anyway when camera or lights change
         this.updateStyles();

--- a/src/scene_bundle.js
+++ b/src/scene_bundle.js
@@ -55,29 +55,30 @@ export class ZipSceneBundle extends SceneBundle {
     }
 
     findRoot() {
-        // Must be a single YAML at top level of zip
-        let bundle_yaml = this.url.split('/').pop().split('.zip').shift() + '.yaml';
-        let root = Object.keys(this.files)
-            .filter(path => this.files[path].depth === 0)
-            .filter(path => Utils.extensionForURL(path) === 'yaml');
-
-        if (root.length === 1) {
-            this.root = root[0];
+        // First check for explicit scene.yaml at zip root
+        if (this.files['scene.yaml']) {
+            this.root = 'scene.yaml';
         }
-        else if (root.length > 1) {
-            // check for name of bundle w/YAML extension
-            let index = root.indexOf(bundle_yaml);
-            if (index > -1) {
-                this.root = root[index];
+
+        // Second check for a single YAML at top level of zip
+        let yamls = [];
+        if (!this.root) {
+            yamls = Object.keys(this.files)
+                .filter(path => this.files[path].depth === 0)
+                .filter(path => Utils.extensionForURL(path) === 'yaml');
+
+            if (yamls.length === 1) {
+                this.root = yamls[0];
             }
         }
 
+        // No root found
         if (!this.root) {
             let msg = `Could not find root scene for bundle '${this.url}': `;
-            msg += `there must be either a single scene YAML file at the root level of the zip archive, `;
-            msg += `or a scene YAML file with the same name as the archive file, e.g. '${bundle_yaml}'. `;
-            if (root.length > 0) {
-                msg += `Found these YAML files at the root level: ${root.map(r => '\'' + r + '\'' )}.`;
+            msg += `The zip archive's root level must contain either a single scene YAML file, `;
+            msg += `or a scene YAML file with name 'scene.yaml'. `;
+            if (yamls.length > 0) {
+                msg += `Found multiple YAML files at the root level but no 'scene.yaml': ${yamls.map(r => '\'' + r + '\'' )}.`;
             }
             else {
                 msg += `Found NO YAML files at the root level.`;

--- a/src/scene_bundle.js
+++ b/src/scene_bundle.js
@@ -1,7 +1,7 @@
-import Utils from './utils';
+import Utils from './utils/utils';
 import JSZip from 'jszip';
 
-export class ResourceBundle {
+export class SceneBundle {
 
     constructor(url, path) {
         this.url = url;
@@ -18,7 +18,7 @@ export class ResourceBundle {
 
 }
 
-export class ZipBundle extends ResourceBundle {
+export class ZipSceneBundle extends SceneBundle {
 
     constructor(url, path) {
         super(url, path);
@@ -83,9 +83,9 @@ export class ZipBundle extends ResourceBundle {
 
 }
 
-export function createResourceBundle(url, path) {
+export function createSceneBundle(url, path) {
     if (typeof url === 'string' && Utils.extensionForURL(url) === 'zip') {
-        return new ZipBundle(url, path);
+        return new ZipSceneBundle(url, path);
     }
-    return new ResourceBundle(url, path);
+    return new SceneBundle(url, path);
 }

--- a/src/scene_bundle.js
+++ b/src/scene_bundle.js
@@ -55,30 +55,21 @@ export class ZipSceneBundle extends SceneBundle {
     }
 
     findRoot() {
-        // First check for explicit scene.yaml at zip root
-        if (this.files['scene.yaml']) {
-            this.root = 'scene.yaml';
-        }
+        // There must be a single YAML file at the top level of the zip
+        const yamls = Object.keys(this.files)
+            .filter(path => this.files[path].depth === 0)
+            .filter(path => Utils.extensionForURL(path) === 'yaml');
 
-        // Second check for a single YAML at top level of zip
-        let yamls = [];
-        if (!this.root) {
-            yamls = Object.keys(this.files)
-                .filter(path => this.files[path].depth === 0)
-                .filter(path => Utils.extensionForURL(path) === 'yaml');
-
-            if (yamls.length === 1) {
-                this.root = yamls[0];
-            }
+        if (yamls.length === 1) {
+            this.root = yamls[0];
         }
 
         // No root found
         if (!this.root) {
             let msg = `Could not find root scene for bundle '${this.url}': `;
-            msg += `The zip archive's root level must contain either a single scene YAML file, `;
-            msg += `or a scene YAML file with name 'scene.yaml'. `;
+            msg += `The zip archive's root level must contain a single scene file with the '.yaml' extension. `;
             if (yamls.length > 0) {
-                msg += `Found multiple YAML files at the root level but no 'scene.yaml': ${yamls.map(r => '\'' + r + '\'' )}.`;
+                msg += `Found multiple YAML files at the root level: ${yamls.map(r => '\'' + r + '\'' ).join(', ')}.`;
             }
             else {
                 msg += `Found NO YAML files at the root level.`;

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -3,7 +3,7 @@ import Utils from './utils/utils';
 import GLSL from './gl/glsl';
 import mergeObjects from './utils/merge';
 import subscribeMixin from './utils/subscribe';
-import {createResourceBundle} from './utils/resource_bundle';
+import {createSceneBundle} from './scene_bundle';
 
 var SceneLoader;
 
@@ -40,7 +40,7 @@ export default SceneLoader = {
             return Promise.resolve({});
         }
 
-        let bundle = createResourceBundle(url, path);
+        let bundle = createSceneBundle(url, path);
 
         return bundle.load().then(config => {
             // accept single-string or array

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -3,6 +3,7 @@ import Utils from './utils/utils';
 import GLSL from './gl/glsl';
 import mergeObjects from './utils/merge';
 import subscribeMixin from './utils/subscribe';
+import {createResourceBundle} from './utils/resource_bundle';
 
 var SceneLoader;
 
@@ -39,25 +40,23 @@ export default SceneLoader = {
             return Promise.resolve({});
         }
 
-        if (typeof url === 'string') {
-            path = path || Utils.pathForURL(url);
-        }
+        let bundle = createResourceBundle(url, path);
 
-        return Utils.loadResource(url).then(config => {
+        return bundle.load().then(config => {
             // accept single-string or array
             if (typeof config.import === 'string') {
                 config.import = [config.import];
             }
 
             if (!Array.isArray(config.import)) {
-                this.normalize(config, path);
+                this.normalize(config, bundle);
                 return config;
             }
 
             // Collect URLs of scenes to import
             let imports = [];
             for (let url of config.import) {
-                imports.push(Utils.addBaseURL(url, path));
+                imports.push(bundle.urlFor(url));
             }
             delete config.import; // don't want to merge this property
 
@@ -65,7 +64,7 @@ export default SceneLoader = {
                 all(imports.map(url => this.loadSceneRecursive(url, null, errors))).
                 then(configs => {
                     config = mergeObjects({}, ...configs, config);
-                    this.normalize(config, path);
+                    this.normalize(config, bundle);
                     return config;
                 });
         }).catch(error => {
@@ -76,22 +75,22 @@ export default SceneLoader = {
     },
 
     // Normalize properties that should be adjust within each local scene file (usually by path)
-    normalize(config, path) {
-        this.normalizeDataSources(config, path);
-        this.normalizeFonts(config, path);
-        this.normalizeTextures(config, path);
+    normalize(config, bundle) {
+        this.normalizeDataSources(config, bundle);
+        this.normalizeFonts(config, bundle);
+        this.normalizeTextures(config, bundle);
         return config;
     },
 
     // Expand paths for data source
-    normalizeDataSources(config, path) {
+    normalizeDataSources(config, bundle) {
         config.sources = config.sources || {};
 
         for (let source of  Utils.values(config.sources)) {
-            source.url = Utils.addBaseURL(source.url, path);
+            source.url = bundle.urlFor(source.url);
 
             if (Array.isArray(source.scripts)) {
-                source.scripts = source.scripts.map(url => Utils.addBaseURL(url, path));
+                source.scripts = source.scripts.map(url => bundle.urlFor(url));
             }
         }
 
@@ -99,12 +98,12 @@ export default SceneLoader = {
     },
 
     // Expand paths for fonts
-    normalizeFonts(config, path) {
+    normalizeFonts(config, bundle) {
         config.fonts = config.fonts || {};
 
         for (let val of Utils.recurseValues(config.fonts)) {
             if (val.url) {
-                val.url = Utils.addBaseURL(val.url, path);
+                val.url = bundle.urlFor(val.url);
             }
         }
 
@@ -112,7 +111,7 @@ export default SceneLoader = {
     },
 
     // Expand paths and centralize texture definitions for a scene object
-    normalizeTextures(config, path) {
+    normalizeTextures(config, bundle) {
         config.textures = config.textures || {};
 
         // Add current scene's base path to globally defined textures
@@ -121,7 +120,7 @@ export default SceneLoader = {
         if (config.textures) {
             for (let texture of Utils.values(config.textures)) {
                 if (texture.url) {
-                    texture.url = Utils.addBaseURL(texture.url, path);
+                    texture.url = bundle.urlFor(texture.url);
                 }
             }
         }
@@ -139,7 +138,7 @@ export default SceneLoader = {
                 // Style `texture`
                 let tex = style.texture;
                 if (typeof tex === 'string' && !config.textures[tex]) {
-                    tex = Utils.addBaseURL(tex, path);
+                    tex = bundle.urlFor(tex);
                     config.textures[tex] = { url: tex };
                     style.texture = tex;
                 }
@@ -150,7 +149,7 @@ export default SceneLoader = {
                         // Material property has a texture
                         let tex = style.material[prop] != null && style.material[prop].texture;
                         if (typeof tex === 'string' && !config.textures[tex]) {
-                            tex = Utils.addBaseURL(tex, path);
+                            tex = bundle.urlFor(tex);
                             config.textures[tex] = { url: tex };
                             style.material[prop].texture = tex;
                         }
@@ -162,7 +161,7 @@ export default SceneLoader = {
                     for (let {type, value, key, uniforms} of GLSL.parseUniforms(style.shaders.uniforms)) {
                         // Texture by URL (string-named texture not referencing existing texture definition)
                         if (type === 'sampler2D' && typeof value === 'string' && !config.textures[value]) {
-                            let tex = Utils.addBaseURL(value, path);
+                            let tex = bundle.urlFor(value);
                             config.textures[tex] = { url: tex };
                             uniforms[key] = tex;
                         }

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -1,9 +1,6 @@
-/* global FontFace */
-import log from '../../utils/log';
 import Utils from '../../utils/utils';
 import Texture from '../../gl/texture';
-
-import FontFaceObserver from 'fontfaceobserver';
+import FontManager from './font_manager';
 
 export default class CanvasText {
 
@@ -39,7 +36,7 @@ export default class CanvasText {
     }
 
     textSizes (texts) {
-        return CanvasText.fonts_loaded.then(() => {
+        return FontManager.loadFonts().then(() => {
             for (let style in texts) {
                 let text_infos = texts[style];
                 let first = true;
@@ -300,130 +297,6 @@ export default class CanvasText {
         return px_size;
     }
 
-    // Load set of custom font faces
-    // `fonts` is an object where the key is a font family name, and the value is one or more font face
-    // definitions. The value can be either a single object, or an array of such objects.
-    // If the special string value 'external' is used, it indicates the the font will be loaded via external CSS.
-    static loadFonts (fonts) {
-        let queue = [];
-        for (let family in fonts) {
-            if (Array.isArray(fonts[family])) {
-                fonts[family].forEach(face => queue.push(this.loadFontFace(family, face)));
-            }
-            else {
-                queue.push(this.loadFontFace(family, fonts[family]));
-            }
-        }
-
-        CanvasText.fonts_loaded = Promise.all(queue.filter(x => x));
-        return CanvasText.fonts_loaded;
-    }
-
-    // Load a single font face
-    // `face` contains the font face definition, with optional parameters for `weight`, `style`, and `url`.
-    // If the `url` is defined, the font is injected into the document as a CSS font-face.
-    // If the object's value is the special string 'external', or if no `url` is defined, then the font face
-    // is assumed is assumed to been loaded via external CSS. In either case, the function returns a promise
-    // that resolves when the font face has loaded, or times out.
-    static loadFontFace (family, face) {
-        if (face == null || (typeof face !== 'object' && face !== 'external')) {
-            return;
-        }
-
-        let options = { family };
-        let inject = Promise.resolve();
-
-        if (typeof face === 'object') {
-            Object.assign(options, face);
-
-            // If URL is defined, inject font into document
-            if (typeof face.url === 'string') {
-                inject = this.injectFontFace(options);
-            }
-        }
-
-        // Wait for font to load
-        let observer = new FontFaceObserver(family, options);
-        return inject.then(() => observer.load()).then(
-            () => {
-                // Promise resolves, font is available
-                log('debug', `Font face '${family}' is available`, options);
-            },
-            () => {
-                // Promise rejects, font is not available
-                log('debug', `Font face '${family}' is NOT available`, options);
-            }
-        );
-    }
-
-    // Loads a font face via either the native FontFace API, or CSS injection
-    // TODO: consider support for multiple format URLs per face, unicode ranges
-    static injectFontFace ({ family, url, weight, style }) {
-        if (CanvasText.supports_native_font_loading === undefined) {
-            CanvasText.supports_native_font_loading = (window.FontFace !== undefined);
-        }
-
-        // Convert blob URLs, depending on whether the native FontFace API will be used or not.
-        //
-        // When the FontFace API *is* supported, the blob URL is read into a raw data array.
-        // NB: it's inefficient to be converting blob URLs into typed arrays here, since they originated
-        // as raw data *before* they were converted into blob URLs. However, this process should be fast since
-        // these are native browser functions and all data is local (no network request), and it keeps the
-        // logic streamlined by allowing us to continue to use a URL-based interface for all scene resources.
-        //
-        // When the FontFace API is *not* supported, the blob URL data is converted to a base64 data URL.
-        // This avoids security restricions in some browsers.
-        // Also see https://github.com/bramstein/fontloader/blob/598e9399117bdc946ff786fa2c5007a6bd7d3b9e/src/fontface.js#L145-L153
-        let preprocess = Promise.resolve(url);
-        if (url.slice(0, 5) === 'blob:') {
-            preprocess = Utils.io(url, 60000, 'arraybuffer').then(data => {
-                let bytes = new Uint8Array(data);
-                if (CanvasText.supports_native_font_loading) {
-                    return bytes; // use raw binary data
-                }
-                else {
-                    let str = '';
-                    for (let i = 0; i < bytes.length; i++) {
-                        str += String.fromCharCode(bytes[i]);
-                    }
-                    return 'data:font/opentype;base64,' + btoa(str); // base64 encode as data URL
-                }
-            });
-        }
-
-        return preprocess.then(data => {
-            if (CanvasText.supports_native_font_loading) {
-                // Use native FontFace API
-                let face;
-                if (typeof data === 'string') { // add as URL
-                    face = new FontFace(family, `url(${encodeURI(data)})`, { weight, style });
-                }
-                else if (data instanceof Uint8Array) { // add as binary data
-                    face = new FontFace(family, data, { weight, style });
-                }
-                document.fonts.add(face);
-                log('trace', 'Adding FontFace to document.fonts:', face);
-            }
-            else {
-                // Use CSS injection
-                let css = `
-                    @font-face {
-                        font-family: '${family}';
-                        font-weight: ${weight || 'normal'};
-                        font-style: ${style || 'normal'};
-                        src: url(${encodeURI(data)});
-                    }
-                `;
-
-                let style_el = document.createElement('style');
-                style_el.appendChild(document.createTextNode(""));
-                document.head.appendChild(style_el);
-                style_el.sheet.insertRule(css, 0);
-                log('trace', 'Injecting CSS font face:', css);
-            }
-        });
-    }
-
 }
 
 // Extract font size and units
@@ -432,6 +305,3 @@ CanvasText.font_size_re = /((?:[0-9]*\.)?[0-9]+)\s*(px|pt|em|%)?/;
 // Cache sizes of rendered text
 CanvasText.text_cache = {}; // by text style, then text string
 CanvasText.cache_stats = { hits: 0, misses: 0 };
-
-// Font detection
-CanvasText.fonts_loaded = Promise.resolve(); // resolves when all requested fonts have been detected

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -1,3 +1,4 @@
+/* global FontFace */
 import log from '../../utils/log';
 import Utils from '../../utils/utils';
 import Texture from '../../gl/texture';

--- a/src/styles/text/font_manager.js
+++ b/src/styles/text/font_manager.js
@@ -1,0 +1,139 @@
+/* global FontFace */
+import log from '../../utils/log';
+import Utils from '../../utils/utils';
+import FontFaceObserver from 'fontfaceobserver';
+
+const FontManager = {
+
+    // Font detection
+    fonts_loaded: Promise.resolve(), // resolves when all requested fonts have been detected
+
+    // Load set of custom font faces
+    // `fonts` is an object where the key is a font family name, and the value is one or more font face
+    // definitions. The value can be either a single object, or an array of such objects.
+    // If the special string value 'external' is used, it indicates the the font will be loaded via external CSS.
+    loadFonts (fonts) {
+        if (fonts) {
+            let queue = [];
+            for (let family in fonts) {
+                if (Array.isArray(fonts[family])) {
+                    fonts[family].forEach(face => queue.push(this.loadFontFace(family, face)));
+                }
+                else {
+                    queue.push(this.loadFontFace(family, fonts[family]));
+                }
+            }
+
+            this.fonts_loaded = Promise.all(queue.filter(x => x));
+        }
+        return this.fonts_loaded;
+    },
+
+    // Load a single font face
+    // `face` contains the font face definition, with optional parameters for `weight`, `style`, and `url`.
+    // If the `url` is defined, the font is injected into the document as a CSS font-face.
+    // If the object's value is the special string 'external', or if no `url` is defined, then the font face
+    // is assumed is assumed to been loaded via external CSS. In either case, the function returns a promise
+    // that resolves when the font face has loaded, or times out.
+    loadFontFace (family, face) {
+        if (face == null || (typeof face !== 'object' && face !== 'external')) {
+            return;
+        }
+
+        let options = { family };
+        let inject = Promise.resolve();
+
+        if (typeof face === 'object') {
+            Object.assign(options, face);
+
+            // If URL is defined, inject font into document
+            if (typeof face.url === 'string') {
+                inject = this.injectFontFace(options);
+            }
+        }
+
+        // Wait for font to load
+        let observer = new FontFaceObserver(family, options);
+        return inject.then(() => observer.load()).then(
+            () => {
+                // Promise resolves, font is available
+                log('debug', `Font face '${family}' is available`, options);
+            },
+            () => {
+                // Promise rejects, font is not available
+                log('debug', `Font face '${family}' is NOT available`, options);
+            }
+        );
+    },
+
+    // Loads a font face via either the native FontFace API, or CSS injection
+    // TODO: consider support for multiple format URLs per face, unicode ranges
+    injectFontFace ({ family, url, weight, style }) {
+        if (this.supports_native_font_loading === undefined) {
+            this.supports_native_font_loading = (window.FontFace !== undefined);
+        }
+
+        // Convert blob URLs, depending on whether the native FontFace API will be used or not.
+        //
+        // When the FontFace API *is* supported, the blob URL is read into a raw data array.
+        // NB: it's inefficient to be converting blob URLs into typed arrays here, since they originated
+        // as raw data *before* they were converted into blob URLs. However, this process should be fast since
+        // these are native browser functions and all data is local (no network request), and it keeps the
+        // logic streamlined by allowing us to continue to use a URL-based interface for all scene resources.
+        //
+        // When the FontFace API is *not* supported, the blob URL data is converted to a base64 data URL.
+        // This avoids security restricions in some browsers.
+        // Also see https://github.com/bramstein/fontloader/blob/598e9399117bdc946ff786fa2c5007a6bd7d3b9e/src/fontface.js#L145-L153
+        let preprocess = Promise.resolve(url);
+        if (url.slice(0, 5) === 'blob:') {
+            preprocess = Utils.io(url, 60000, 'arraybuffer').then(data => {
+                let bytes = new Uint8Array(data);
+                if (this.supports_native_font_loading) {
+                    return bytes; // use raw binary data
+                }
+                else {
+                    let str = '';
+                    for (let i = 0; i < bytes.length; i++) {
+                        str += String.fromCharCode(bytes[i]);
+                    }
+                    return 'data:font/opentype;base64,' + btoa(str); // base64 encode as data URL
+                }
+            });
+        }
+
+        return preprocess.then(data => {
+            if (this.supports_native_font_loading) {
+                // Use native FontFace API
+                let face;
+                if (typeof data === 'string') { // add as URL
+                    face = new FontFace(family, `url(${encodeURI(data)})`, { weight, style });
+                }
+                else if (data instanceof Uint8Array) { // add as binary data
+                    face = new FontFace(family, data, { weight, style });
+                }
+                document.fonts.add(face);
+                log('trace', 'Adding FontFace to document.fonts:', face);
+            }
+            else {
+                // Use CSS injection
+                let css = `
+                    @font-face {
+                        font-family: '${family}';
+                        font-weight: ${weight || 'normal'};
+                        font-style: ${style || 'normal'};
+                        src: url(${encodeURI(data)});
+                    }
+                `;
+
+                let style_el = document.createElement('style');
+                style_el.appendChild(document.createTextNode(""));
+                document.head.appendChild(style_el);
+                style_el.sheet.insertRule(css, 0);
+                log('trace', 'Injecting CSS font face:', css);
+            }
+        });
+    }
+
+};
+
+export default FontManager;

--- a/src/utils/resource_bundle.js
+++ b/src/utils/resource_bundle.js
@@ -1,0 +1,91 @@
+import Utils from './utils';
+import JSZip from 'jszip';
+
+export class ResourceBundle {
+
+    constructor(url, path) {
+        this.url = url;
+        this.path = path || Utils.pathForURL(this.url);
+    }
+
+    load() {
+        return Utils.loadResource(this.url);
+    }
+
+    urlFor(url) {
+        return Utils.addBaseURL(url, this.path);
+    }
+
+}
+
+export class ZipBundle extends ResourceBundle {
+
+    constructor(url, path) {
+        super(url, path);
+        this.zip = null;
+        this.files = {};
+        this.urls = {};
+
+        // Make root file name by substituting or .yaml extension to .zip file name
+        this.root = url.split('/').pop().split('.zip').shift() + '.yaml';
+    }
+
+    load() {
+        this.zip = new JSZip();
+
+        if (typeof this.url === 'string') {
+            return Utils.io(this.url, 60000, 'arraybuffer')
+                .then(body => this.zip.loadAsync(body))
+                .then(() => this.parseZipFiles())
+                .then(() => {
+                    let url = this.urlForZipFile(this.root);
+                    return Utils.loadResource(url);
+                })
+                .catch(e => { throw e; });
+        } else {
+            return Promise.resolve(this);
+        }
+    }
+
+    urlFor(url) {
+        if (Utils.isRelativeURL(url)) {
+            return this.urlForZipFile(url);
+        }
+        return Utils.addBaseURL(url, this.path);
+    }
+
+    parseZipFiles() {
+        let paths = [];
+        let queue = [];
+        this.zip.forEach((path, file) => {
+            if (!file.dir) {
+                paths.push(path);
+                queue.push(file.async('arraybuffer'));
+            }
+        });
+
+        return Promise.all(queue).then(data => {
+            for (let i=0; i < data.length; i++) {
+                this.files[paths[i]] = { data: data[i] };
+            }
+        });
+    }
+
+    urlForZipFile(file) {
+        if (this.files[file]) {
+            if (!this.files[file].url) {
+                this.files[file].url = Utils.createObjectURL(new Blob([this.files[file].data]));
+            }
+
+            return this.files[file].url;
+        }
+    }
+
+}
+
+export function createResourceBundle(url, path) {
+    if (typeof url === 'string' && Utils.extensionForURL(url) === 'zip') {
+        return new ZipBundle(url, path);
+    }
+    return new ResourceBundle(url, path);
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -62,6 +62,18 @@ Utils.pathForURL = function (url) {
     return './';
 };
 
+Utils.isRelativeURL = function (url) {
+    return !(url.search(/^(http|https|data|blob):\/\//) > -1 || url.substr(0, 2) === '//');
+};
+
+Utils.extensionForURL = function (url) {
+    url = url.split('/').pop();
+    let last_dot = url.lastIndexOf('.');
+    if (last_dot > -1) {
+        return url.substring(last_dot + 1);
+    }
+};
+
 // Add a set of query string params to a URL
 // params: hash of key/value pairs of query string parameters
 Utils.addParamsToURL = function (url, params) {


### PR DESCRIPTION
This PR adds the ability to load scene "bundles" from zip files. Any relative resources (imported scene files, images, fonts) are read from within the zip bundle.

The purpose of this feature is to improve distribution and management of complex scenes, particularly by allowing users to distribute a single self-contained file with images and/or fonts.

 **Scene Bundles**
A new `SceneBundle` class provides an interface for loading scene files. Given a scene URL to load, the scene bundle object loads that file, and resolves relative resources for any files loaded within the bundle. For "standard" scene YAML files (e.g. not zip bundles), this continues to work as prior scene loading has. The bundle stores a root URL for the scene, and prepends this root to any relative paths. If a resource has a remote URL, the bundle returns that as-is.

To support zip files, a `ZipSceneBundle` subclass adds additional behavior:
- When a scene zip file is loaded, the zip bundle first loads the zip file and decompresses all files within it, keeping an internal list of its resources.
- Zip files are determined by a `.zip` extension, other filenames will be treated as standard (non-zip) bundles.
- The zip bundle identifies a "root scene YAML" (*more on this below*), and loads and parses it as YAML, as a standard bundle would.
- To resolve relative resources, the zip bundle **creates a blob URL** (using `createObjectURL`) for the file's contents. This allows all bundles (standard and zip, and possible future types such as locally cached) to provide a common URL-based interface for retrieving any scene resource.
- As with non-zip bundles, remote resource URLs are passed through as-is.

Each imported scene (using `import`) is instantiated as its own scene bundle, which allows both zip and non-zip bundles to freely import further scenes of either type.

**Root Scene File**
**This is likely the only outstanding user-facing issue to decide before moving ahead with this feature**, though it is a significant one. When a scene zip bundle is loaded, we need to identify which YAML file *within* that bundle should be considered the "root". There are several approaches to this with varying levels of flexibility and complexity. My bias here is towards something that keeps things easy for the user (without becoming very complex to implement). The current behavior in this branch is:

- The root scene must be in the root folder level of the zip file, e.g. not within a sub-folder.
- The root scene file must **either** be a YAML file with the same name (minus extension) as the bundle itself (e.g. `bubble-wrap.yaml` for `bubble-wrap.zip`), **or** (if no file with that name is found) a single YAML file (with any name) at the zip bundle's root folder (e.g., a file named `bubble-wrap.yaml` would load for a bundle called `bubble-wrap-test.zip`, provided there were no other YAML files in the zip's root folder, though other scene imports could be in sub-folders).
- Using the **same-name-as-zip-file** is a straightforward rule to me that follows our existing convention for house styles: the repo and root scene yaml files are consistent, and all files in the repo could be zipped without modification (this is a key for me, not requiring the user to make modifications to their scene to allow it to be zipped).
  - However, this rule falls short in cases (that I encountered several times when testing this branch) in which I wanted to have multiple versions of the scene available for testing, e.g. `bubble-wrap-woff.zip` to test a version that loads WOFF fonts, etc.
- The best balance may be to simply keep the *other* rule instead, requiring that there be a **single YAML file in the zip's root level**. This puts some restrictions on authoring, but also fits all of our current house styles (including the new [Tron](github.com/tangrams/tron) structure), and is both easy to implement and to message to users in the case a root file is not found.
- Other options considered:
  - Require the root YAML to have a constant name such as `scene.yaml` or `root.yaml`. This is straightforward but I believe places too many restrictions / lack of compatibility with common scene patterns (I don't want to require people to rename their root scene -- or any other files -- before zipping).
  - Allow the root YAML to be in a sub-folder. Could still be combined with the "single file" rule, if the *first* sub-folder containing *any* YAML files must still have a single YAML. It may be hard to argue this complexity is worth it (and it's harder to explain), though it's worth noting that it's common, both for manually and automatically created archives to have their contents in a folder (for less messy un-archiving in-place). For example, github's [download links](https://github.com/tangrams/bubble-wrap/archive/gh-pages.zip) include the repo and branch name, e.g. `/bubble-wrap-gh-pages/bubble-wrap.yaml`. The current behavior can handle this case.
  - I experimented with parsing all scene files in the zip, and building a graph of their `import`s, to find the root. This gets complex quickly, especially in cases where relative paths may be used in imports (`import: ../other-folder/file.yaml`).

**JSZip**
Zip processing is done using [JSZip](https://stuk.github.io/jszip/), which appears to be the most robust JS-based zip library by far, and provides a modern Promise-based API. The primary downside is its large size: the current release minified is still 97k! JSZip provides full zip encode/write capabilities in addition to reading zip files. Since we don't need write capability, I have [forked the library](https://github.com/Stuk/jszip/compare/master...tangrams:read-only) and removed as much code as possible (we've followed a similar approach with js-yaml with good results). This reduces the minified library to **83k**, which is an improvement, though not as much as I had hoped. JSZip is designed with a single interface for reading/writing, which makes it a bit harder to remove code; it may be possible to reduce this further and warrants more investigation. There is an [outdated issue](https://github.com/Stuk/jszip/issues/170) regarding this that we should inquire on.

All told, with the read-only branch of JSZip, this branch increases the Tangram gzipped minified build to **153k**, up from 124k. While this is a substantial increase, I believe it's worth it for a feature that will enable significantly better management of increasingly complex scenes moving forward -- especially for new projects such as [Tron 2.0](https://github.com/tangrams/tron) and others that make heavy use of [Blocks](tangrams.github.io/blocks).

**Font Loading**
This branch also necessitated some changes to custom font loading:
- We now test for and use the native `FontFace` API for adding new font faces to the document. This API is long-supported in Chrome and Firefox, and will be supported in the upcoming Safari 10. Other browsers continue to fallback to using CSS `@font-face` injection.
- When fonts are loaded from zip files and the browser does *not* support the native `FontFace` API, the font data must first be converted to a base64-encoded `data` URL (which is used as the font source in the injected CSS). See the [fontloader polyfill](https://github.com/bramstein/fontloader/blob/master/src/fontface.js#L146-L153) for an example.
- There is a known issue with OpenType/TrueType fonts not loading properly from zip bundles on IE11 (but *do* load properly on Edge). WOFF fonts (much preferred) load on both IE11 and Edge. We may want to continue to investigate, but this is a reasonable limitation (the scene will still render with fallback fonts).
