### PR TITLE
Fix #369

### DIFF
--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -23,13 +23,9 @@ export default class CanvasText {
         let ctx = this.context;
 
         ctx.font = font_css;
-        if (stroke) {
+        if (stroke && stroke_width > 0) {
             ctx.strokeStyle = stroke;
             ctx.lineWidth = stroke_width;
-        }
-        else {
-            ctx.strokeStyle = null;
-            ctx.lineWidth = 0;
         }
         ctx.fillStyle = fill;
         ctx.miterLimit = 2;
@@ -180,7 +176,7 @@ export default class CanvasText {
             // 0.75 buffer produces a better approximate vertical centering of text
             let ty = y + buffer * 0.75 + (line_num + 1) * line_height;
 
-            if (stroke) {
+            if (stroke && stroke.stroke_width > 0) {
                 this.context.strokeText(str, tx, ty);
             }
             this.context.fillText(str, tx, ty);

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -30,7 +30,9 @@ export default TextSettings = {
         family: 'Helvetica',
         fill: 'white',
         text_wrap: 15,
-        align: 'center'
+        align: 'center',
+        stroke: null,
+        stroke_width: 0
     },
 
     compute (feature, draw, context) {


### PR DESCRIPTION
Fixes the problem if a scene file has a `stroke` definition with `width = 0`. A canvas context ignores setting `linewidth = 0` (and `strokeStyle = null`). Instead no `strokeText()` method should be called if the stroke's width is 0.