### PR TITLE
upgrade csscolorparser@1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-runtime": "6.11.6",
     "box-intersect": "1.0.0",
     "brfs": "1.4.3",
-    "csscolorparser": "1.0.2",
+    "csscolorparser": "1.0.3",
     "earcut": "2.1.1",
     "fontfaceobserver": "1.7.1",
     "geojson-vt": "2.1.6",


### PR DESCRIPTION
Which now supports CSS Color Level 4 (a fancy way of saying "support `rebeccapurple`), closing the gap on full compatibility for color parsing between Tangram Play and Tangram.js. (See https://github.com/tangrams/tangram-play/issues/519)