### PR TITLE
Data sources can specify min/max display zooms and bounding box

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -838,11 +838,11 @@ export default class Scene {
             });
         }
 
-        // Mark sources that generate geometry tiles
+        // Mark sources that will generate geometry tiles
         // (all except those that are only raster sources attached to other sources)
         for (let layer of Utils.values(this.config.layers)) {
             if (layer.data && this.sources[layer.data.source]) {
-                this.sources[layer.data.source].geometry_tiles = true;
+                this.sources[layer.data.source].builds_geometry_tiles = true;
             }
         }
     }

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -28,13 +28,11 @@ export default class DataSource {
         // NOTE: these are loaded alongside the library when the workers are instantiated
         this.scripts = config.scripts;
 
-        // no tiles will be requested below this zoom
-        this.min_zoom = (config.min_zoom != null) ? config.min_zoom : 0;
-
         // overzoom will apply for zooms higher than this
         this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
 
-        // no tiles will be *displayed* above this zoom
+        // no tiles will be requested or displayed outside of these min/max values
+        this.min_display_zoom = (config.min_display_zoom != null) ? config.min_display_zoom : 0;
         this.max_display_zoom = (config.max_display_zoom != null) ? config.max_display_zoom : null;
     }
 
@@ -148,7 +146,7 @@ export default class DataSource {
 
     // All data sources support a min zoom, tiled sources can subclass for more specific limits (e.g. bounding box)
     includesTile (coords, style_zoom) {
-        if (coords.z < this.min_zoom || (this.max_display_zoom != null && style_zoom > this.max_display_zoom)) {
+        if (coords.z < this.min_display_zoom || (this.max_display_zoom != null && style_zoom > this.max_display_zoom)) {
             return false;
         }
         return true;

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -251,7 +251,7 @@ export class NetworkTileSource extends NetworkSource {
     parseBounds (source) {
         if (Array.isArray(source.bounds) && source.bounds.length === 4) {
             this.bounds = source.bounds;
-            let [w, n, e, s] = this.bounds;
+            let [w, s, e, n] = this.bounds;
             this.bounds_meters = {
                 min: Geo.latLngToMeters([w, n]),
                 max: Geo.latLngToMeters([e, s]),

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -285,7 +285,7 @@ export class NetworkTileSource extends NetworkSource {
     }
 
     includesTile (coords, style_zoom) {
-        if (!super.includesTile(coords, style_zoom)) {
+        if (!this.builds_geometry_tiles || !super.includesTile(coords, style_zoom)) {
             return false;
         }
 

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -32,7 +32,10 @@ export default class DataSource {
         this.min_zoom = (config.min_zoom != null) ? config.min_zoom : 0;
 
         // overzoom will apply for zooms higher than this
-        this.max_zoom = config.max_zoom || Geo.default_source_max_zoom;
+        this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
+
+        // no tiles will be *displayed* above this zoom
+        this.max_display_zoom = (config.max_display_zoom != null) ? config.max_display_zoom : null;
     }
 
     // Create a tile source by type, factory-style
@@ -145,7 +148,7 @@ export default class DataSource {
 
     // All data sources support a min zoom, tiled sources can subclass for more specific limits (e.g. bounding box)
     includesTile (coords, style_zoom) {
-        if (coords.z < this.min_zoom) {
+        if (coords.z < this.min_zoom || (this.max_display_zoom != null && style_zoom > this.max_display_zoom)) {
             return false;
         }
         return true;

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -228,7 +228,7 @@ export default class TileManager {
         for (let s in this.scene.sources) {
             let source = this.scene.sources[s];
             // Check if data source should build this tile
-            if (!source.builds_geometry_tiles || !source.includesTile(coords, this.view.tile_zoom)) {
+            if (!source.includesTile(coords, this.view.tile_zoom)) {
                 continue;
             }
 

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -227,7 +227,8 @@ export default class TileManager {
         // Determine necessary tiles for each source
         for (let s in this.scene.sources) {
             let source = this.scene.sources[s];
-            if (!source.tiled || !source.geometry_tiles) {
+            // Check if data source should build this tile
+            if (!source.builds_geometry_tiles || !source.includesTile(coords, this.view.tile_zoom)) {
                 continue;
             }
 


### PR DESCRIPTION
This adds the ability for data sources to control when tiles are requested and displayed, with three new parameters:

- `min_display_zoom`: tiles will not be requested or displayed *below* this zoom
- `max_display_zoom`: tiles will not be requested or displayed *above* this zoom
- `bounds`: tiles will not be requested or displayed *outside* of this bounding box, specified as latitude/longitude in `[w, s, e, n]` format.

I think the behavior is straightforward and the primary discussion to be had here is around the **terminology**:

- Because of our existing `max_zoom` parameter, which controls overzooming (tiles will not be requested above this zoom, but they *will* be displayed, with tile geometry scaled up), I added a `display` qualifier in these parameter names. We could consider other naming as well.
- The `bounds` are currently specified as a single, flattened 4-element array of lat/lng values, in the order `[w, n, e, s]`. This was largely arbitrary, and we can easily use another format if desired. I considered using sub-arrays like `[[w, n], [e, s]]` to better show the coordinate groupings, but I felt this might be more error-prone than a flat list. _**Update**:_ based on discussion below, changed to `[w, s, e, n]` order._

Example:
```
    mapzen:
        type: TopoJSON
        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
        min_display_zoom: 9
        max_display_zoom: 18
        bounds: [-74.1274, 40.5780, -73.8004, 40.8253] # [w, s, e, n]
```