### PR TITLE
Add ability to filter by screen area

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -214,10 +214,11 @@ layers:
 
     landuse:
         data: { source: mapzen }
+        filter:
+            - { $zoom: { min: 16 } }
+            - { area: { min: 500px2 } }
 
         areas:
-            filter:
-                function() { return $geometry === 'polygon' && $zoom >= feature.min_zoom }
             draw:
                 polygons:
                     order: global.feature_order
@@ -248,16 +249,8 @@ layers:
 
         labels:
             filter:
-                $geometry: point
                 label_placement: yes
                 kind: [park, forest, cemetery, graveyard]
-                any:
-                    # show labels for smaller landuse areas at higher zooms
-                    - { $zoom: { min: 9 }, area: { min: 100000000 } }
-                    - { $zoom: { min: 10 }, area: { min: 10000000 } }
-                    - { $zoom: { min: 12 }, area: { min: 1000000 } }
-                    - { $zoom: { min: 15 }, area: { min: 10000 } }
-                    - { $zoom: { min: 18 } }
             draw:
                 icons:
                     sprite: tree

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "gl-shader-errors": "1.0.3",
     "js-yaml": "tangrams/js-yaml#read-only",
     "jszip": "tangrams/jszip#read-only",
-    "match-feature": "tangrams/match-feature#v1.2.0",
+    "match-feature": "tangrams/match-feature#v1.3.0",
     "pbf": "1.3.2",
     "strip-comments": "0.3.2",
     "topojson": "1.6.19",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "gl-shader-errors": "1.0.3",
     "js-yaml": "tangrams/js-yaml#read-only",
     "jszip": "tangrams/jszip#read-only",
-    "match-feature": "tangrams/match-feature#v1.3.0",
+    "match-feature": "tangrams/match-feature#v1.3.1",
     "pbf": "1.3.2",
     "strip-comments": "0.3.2",
     "topojson": "1.6.19",

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -122,7 +122,7 @@ class Layer {
             this.buildZooms();
             this.buildPropMatches();
             if (this.filter != null && (typeof this.filter === 'function' || Object.keys(this.filter).length > 0)) {
-                this.filter = match(this.filter);
+                this.filter = match(this.filter, FilterOptions);
             }
             else {
                 this.filter = null;
@@ -326,6 +326,16 @@ export class LayerTree extends Layer {
     }
 
 }
+
+const FilterOptions = {
+    // Handle unit conversions on filter ranges
+    rangeTransform(val) {
+        if (typeof val === 'string' && val.trim().slice(-3) === 'px2') {
+            return `${parseFloat(val)} * context.meters_per_pixel_sq`;
+        }
+        return val;
+    }
+};
 
 function isWhiteListed(key) {
     return whiteList.indexOf(key) > -1;

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -79,6 +79,7 @@ StyleParser.getFeatureParseContext = function (feature, tile, global) {
         zoom: tile.style_zoom,
         geometry: Geo.geometryType(feature.geometry.type),
         meters_per_pixel: tile.meters_per_pixel,
+        meters_per_pixel_sq: tile.meters_per_pixel_sq,
         units_per_meter_overzoom: tile.units_per_meter_overzoom
     };
 };

--- a/src/tile.js
+++ b/src/tile.js
@@ -44,7 +44,8 @@ export default class Tile {
         this.bounds = { sw: { x: this.min.x, y: this.max.y }, ne: { x: this.max.x, y: this.min.y } };
         this.center_dist = 0;
 
-        this.meters_per_pixel = Geo.metersPerPixel(this.coords.z);
+        this.meters_per_pixel = Geo.metersPerPixel(this.style_zoom);
+        this.meters_per_pixel_sq = this.meters_per_pixel * this.meters_per_pixel;
         this.units_per_pixel = Geo.units_per_pixel / this.overzoom2; // adjusted for overzoom
         this.units_per_meter_overzoom = Geo.unitsPerMeter(this.coords.z) * this.overzoom2; // adjusted for overzoom
 
@@ -152,6 +153,7 @@ export default class Tile {
             max: this.max,
             units_per_pixel: this.units_per_pixel,
             meters_per_pixel: this.meters_per_pixel,
+            meters_per_pixel_sq: this.meters_per_pixel_sq,
             units_per_meter_overzoom: this.units_per_meter_overzoom,
             style_zoom: this.style_zoom,
             overzoom: this.overzoom,


### PR DESCRIPTION
This adds an option to filter feature properties by **zoom-independent screen area**, that is, by the number of square pixels they cover.

This is done through a new `px2` unit type that can be applied to range filters, e.g.:

`filter: { area: { min: 500px2 } }`

This example filters the feature's `area` property by the number of *square mercator meters* that cover a *500 pixel screen area* at the current zoom level. This means that the `area` property must be in *square mercator meters*, as the property provided by Mapzen vector tiles is.

As with other pixel-based values in the scene file, the `px2` units are expressed in *logical pixels* (or "CSS pixels"), meaning they are interpreted at a pixel density of 1, and are automatically scaled up for higher density displays.

This syntax can be used to significantly simplify more cumbersome per-zoom filters such as:

```
filter:
  - { $zoom: { min: 9 }, area: { min: 100000000 } }
  - { $zoom: { min: 10 }, area: { min: 10000000 } }
  - { $zoom: { min: 12 }, area: { min: 1000000 } }
  - { $zoom: { min: 15 }, area: { min: 10000 } }
```

The new range filter units are supported by a new version of the `match-feature` module, which enables range filters to be transformed to account for per-zoom scale:
https://github.com/tangrams/match-feature/commit/9152e1711ccf3b4278d5116b7095bc79515c0304

**Note:** This PR does *not* add an automatically derived area property for polygon features. That is, this filtering can only currently be applied if the data source already contains a suitable area property (it does not need to be named `area`, as any property name can be specified in the filter, but it must already exist in the data source). A future extension could be to add the option to derive an area property for each feature, but this could add considerable overhead (and isn't necessary for all data sources), so would likely be an opt-in flag on the data source.
