### PR TITLE
Tall labels

### DIFF
--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -302,7 +302,7 @@ class MultiLine {
         this.height = 0;
         this.lines = [];
 
-        this.ellipsis = '…';
+        this.ellipsis = '...';
         this.ellipsis_width = context.measureText(this.ellipsis).width;
 
         this.max_lines = max_lines;
@@ -388,9 +388,9 @@ class MultiLine {
         let line = multiline.createLine(line_height);
 
         // First iterate on space-break groups (will be one if max line length off), then iterate on line-break groups
-        for (let w=0; w < words.length; w++) {
-            let breaks = words[w].split('\n'); // split on line breaks
-            let new_line = (w === 0) ? true : false;
+        for (let i = 0; i < words.length; i++) {
+            let breaks = words[i].split('\n'); // split on line breaks
+            let new_line = (i === 0) ? true : false;
 
             for (let n=0; n < breaks.length; n++) {
                 if (!line){
@@ -406,7 +406,8 @@ class MultiLine {
                 let spaced_word = (new_line) ? word : ' ' + word;
 
                 // if adding current word would overflow, add a new line instead
-                if (text_wrap && line.exceedsTextwrap(spaced_word)) {
+                // first word (i === 0) always appends
+                if (text_wrap && i > 0 && line.exceedsTextwrap(spaced_word)) {
                     line = multiline.advance(line, line_height);
                     if (!line){
                         break;
@@ -425,7 +426,7 @@ class MultiLine {
                 }
             }
 
-            if (w === words.length - 1){
+            if (i === words.length - 1){
                 multiline.finish(line);
             }
         }

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -87,7 +87,7 @@ export default class CanvasText {
             words = [str]; // no max line word wrapping (but new lines will still be in effect)
         }
 
-        let multiline = new MultiLine(max_lines, text_wrap, ctx);
+        let multiline = new MultiLine(ctx, max_lines, text_wrap);
         let line = multiline.createLine(line_height);
 
         // First iterate on space-break groups (will be one if max line length off), then iterate on line-break groups
@@ -345,7 +345,7 @@ CanvasText.cache_stats = { hits: 0, misses: 0 };
 // Private class to arrange text labels into multiple lines based on
 // "text wrap" and "max line" values
 class MultiLine {
-    constructor (max_lines = Infinity, text_wrap = Infinity, context) {
+    constructor (context, max_lines = Infinity, text_wrap = Infinity) {
         this.width = 0;
         this.height = 0;
         this.lines = [];

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -351,8 +351,9 @@ class MultiLine {
         this.height = 0;
         this.lines = [];
 
-        this.ellipsis = '...';
+        this.ellipsis = '…';
         this.ellipsis_width = context.measureText(this.ellipsis).width;
+        this.space_width = context.measureText(' ').width;
 
         this.max_lines = max_lines;
         this.text_wrap = text_wrap;
@@ -372,7 +373,8 @@ class MultiLine {
         // remove last space from previous line
         if (this.lines.length > 0){
             let last_line = this.lines[this.lines.length - 1];
-            last_line.text = last_line.text.slice(0, last_line.text.length - 1);
+            last_line.removeLastChar();
+            last_line.width -= this.space_width;
         }
 
         if (this.lines.length < this.max_lines){
@@ -408,8 +410,10 @@ class MultiLine {
 
     addEllipsis (){
         let last_line = this.lines[this.lines.length - 1];
+        last_line.removeLastChar();
         last_line.append(this.ellipsis);
-        last_line.width += this.ellipsis_width;
+
+        last_line.width += this.ellipsis_width - this.space_width;
         if (last_line.width > this.width) {
             this.width = last_line.width;
         }
@@ -442,7 +446,11 @@ class Line {
         this.text += text;
     }
 
-    exceedsTextwrap(text){
+    exceedsTextwrap (text){
         return text.length + this.chars > this.text_wrap;
+    }
+
+    removeLastChar (){
+        this.text = this.text.slice(0, this.text.length - 1);
     }
 }

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -75,63 +75,7 @@ export default class CanvasText {
         let leading = 2 * Utils.device_pixel_ratio; // make configurable and/or use Canvas TextMetrics when available
         let line_height = this.px_size + leading; // px_size already in device pixels
 
-        // Word wrapping
-        // Line breaks can be caused by:
-        //  - implicit line break when a maximum character threshold is exceeded per line (text_wrap)
-        //  - explicit line break in the label text (\n)
-        let words;
-        if (typeof text_wrap === 'number') {
-            words = str.split(' '); // split words on spaces
-        }
-        else {
-            words = [str]; // no max line word wrapping (but new lines will still be in effect)
-        }
-
-        let multiline = new MultiLine(ctx, max_lines, text_wrap);
-        let line = multiline.createLine(line_height);
-
-        // First iterate on space-break groups (will be one if max line length off), then iterate on line-break groups
-        for (let w=0; w < words.length; w++) {
-            let breaks = words[w].split('\n'); // split on line breaks
-            let new_line = (w === 0) ? true : false;
-
-            for (let n=0; n < breaks.length; n++) {
-                if (!line){
-                    break;
-                }
-
-                let word = breaks[n].trim();
-
-                if (!word) {
-                    continue;
-                }
-
-                let spaced_word = (new_line) ? word : ' ' + word;
-
-                // if adding current word would overflow, add a new line instead
-                if (text_wrap && line.exceedsTextwrap(spaced_word)) {
-                    line = multiline.advance(line, line_height);
-                    if (!line){
-                        break;
-                    }
-                    line.append(word);
-                    new_line = true;
-                }
-                else {
-                    line.append(spaced_word);
-                }
-
-                // if line breaks present, add new line (unless on last line)
-                if (n < breaks.length - 1) {
-                    line = multiline.advance(line, line_height);
-                    new_line = true;
-                }
-            }
-
-            if (w === words.length - 1){
-                multiline.finish(line);
-            }
-        }
+        let multiline = MultiLine.parse(str, text_wrap, max_lines, line_height, ctx);
 
         // Final dimensions of text
         let height = multiline.height;
@@ -425,6 +369,67 @@ class MultiLine {
         else {
             this.addEllipsis();
         }
+    }
+
+    static parse (str, text_wrap, max_lines, line_height, ctx) {
+        // Word wrapping
+        // Line breaks can be caused by:
+        //  - implicit line break when a maximum character threshold is exceeded per line (text_wrap)
+        //  - explicit line break in the label text (\n)
+        let words;
+        if (typeof text_wrap === 'number') {
+            words = str.split(' '); // split words on spaces
+        }
+        else {
+            words = [str]; // no max line word wrapping (but new lines will still be in effect)
+        }
+
+        let multiline = new MultiLine(ctx, max_lines, text_wrap);
+        let line = multiline.createLine(line_height);
+
+        // First iterate on space-break groups (will be one if max line length off), then iterate on line-break groups
+        for (let w=0; w < words.length; w++) {
+            let breaks = words[w].split('\n'); // split on line breaks
+            let new_line = (w === 0) ? true : false;
+
+            for (let n=0; n < breaks.length; n++) {
+                if (!line){
+                    break;
+                }
+
+                let word = breaks[n].trim();
+
+                if (!word) {
+                    continue;
+                }
+
+                let spaced_word = (new_line) ? word : ' ' + word;
+
+                // if adding current word would overflow, add a new line instead
+                if (text_wrap && line.exceedsTextwrap(spaced_word)) {
+                    line = multiline.advance(line, line_height);
+                    if (!line){
+                        break;
+                    }
+                    line.append(word);
+                    new_line = true;
+                }
+                else {
+                    line.append(spaced_word);
+                }
+
+                // if line breaks present, add new line (unless on last line)
+                if (n < breaks.length - 1) {
+                    line = multiline.advance(line, line_height);
+                    new_line = true;
+                }
+            }
+
+            if (w === words.length - 1){
+                multiline.finish(line);
+            }
+        }
+        return multiline;
     }
 }
 

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -419,8 +419,7 @@ class MultiLine {
         if (line){
             this.push(line);
         }
-
-        if (this.max_lines === this.lines.length) {
+        else {
             this.addEllipsis();
         }
     }

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -75,6 +75,7 @@ export default class CanvasText {
         let leading = 2 * Utils.device_pixel_ratio; // make configurable and/or use Canvas TextMetrics when available
         let line_height = this.px_size + leading; // px_size already in device pixels
 
+        // Parse string into series of lines if it exceeds the text wrapping value or contains line breaks
         let multiline = MultiLine.parse(str, text_wrap, max_lines, line_height, ctx);
 
         // Final dimensions of text

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -30,6 +30,7 @@ export default TextSettings = {
         family: 'Helvetica',
         fill: 'white',
         text_wrap: 15,
+        max_lines: 5,
         align: 'center',
         stroke: null,
         stroke_width: 0
@@ -81,6 +82,7 @@ export default TextSettings = {
         // Word wrap and text alignment
         // Not a font properties, but affect atlas of unique text textures
         let text_wrap = draw.text_wrap; // use explicitly set value
+
         if (text_wrap == null && Geo.geometryType(feature.geometry.type) !== 'line') {
             // point labels (for point and polygon features) have word wrap on w/default max length,
             // line labels default off
@@ -92,6 +94,9 @@ export default TextSettings = {
             text_wrap = this.defaults.text_wrap;
         }
         style.text_wrap = text_wrap;
+
+        // max_lines setting to truncate very long labels with an ellipsis
+        style.max_lines = draw.max_lines || this.defaults.max_lines;
 
         return style;
     },

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -18,6 +18,7 @@ export default TextSettings = {
             settings.stroke_width,
             settings.transform,
             settings.text_wrap,
+            settings.max_lines,
             Utils.device_pixel_ratio
         ].join('/');
     },


### PR DESCRIPTION
Allows for a `max_lines` parameter for text fields to truncate excessively tall labels. The current default is 5 lines. This would require documentation if implemented.