### PR TITLE
Support TMS-style tiled data sources

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -250,6 +250,7 @@ export class NetworkTileSource extends NetworkSource {
         // and left disabled for sources that are never referenced, or only used as raster textures
         this.builds_geometry_tiles = false;
 
+        this.tms = (source.tms === true); // optionally flip tile coords for TMS
         this.url_hosts = null;
         var host_match = this.url.match(/{s:\[([^}+]+)\]}/);
         if (host_match != null && host_match.length > 1) {
@@ -309,6 +310,11 @@ export class NetworkTileSource extends NetworkSource {
 
     formatUrl(url_template, tile) {
         let coords = Geo.wrapTile(tile.coords, { x: true });
+
+        if (this.tms) {
+            coords.y = Math.pow(2, coords.z) - 1 - coords.y; // optionally flip tile coords for TMS
+        }
+
         let url = url_template.replace('{x}', coords.x).replace('{y}', coords.y).replace('{z}', coords.z);
 
         if (this.url_hosts != null) {


### PR DESCRIPTION
Allow for tiled data sources to specify `tms` to flip tile URL y coordinate. See #359 for more info and test links.