### PR TITLE
Add video capture methods

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -383,6 +383,28 @@ Enjoy!
         };
         gui.add(gui, 'screenshot');
 
+        // Take a video capture and save to file
+        if (typeof window.MediaRecorder == 'function') {
+            gui.video = function () {
+                if (!gui.video_capture) {
+                    if (scene.startVideoCapture()) {
+                        gui.video_capture = true;
+                        gui.video_button.name('stop video');
+                    }
+                }
+                else {
+                    return scene.stopVideoCapture().then(function(video) {
+                        gui.video_capture = false;
+                        gui.video_button.name('capture video');
+                        saveAs(video.blob, 'tangram-video-' + (+new Date()) + '.webm');
+                    });
+                }
+            };
+            gui.video_button = gui.add(gui, 'video');
+            gui.video_button.name('capture video');
+            gui.video_capture = false;
+        }
+
         // Layers
         var layer_gui = gui.addFolder('Layers');
         var layer_controls = {};

--- a/src/scene.js
+++ b/src/scene.js
@@ -62,6 +62,7 @@ export default class Scene {
         this.render_count_changed = false;
         this.frame = 0;
         this.queue_screenshot = null;
+        this.video_capture = null;
         this.selection = null;
         this.introspection = false;
         this.resetTime();
@@ -1122,6 +1123,52 @@ export default class Scene {
             this.queue_screenshot.resolve({ url, blob });
             this.queue_screenshot = null;
         }
+    }
+
+    startVideoCapture () {
+        if (typeof window.MediaRecorder !== 'function' || !this.canvas || typeof this.canvas.captureStream !== 'function') {
+            log('warn', 'Video capture (Canvas.captureStream and/or MediaRecorder APIs) not supported by browser');
+            return false;
+        }
+        else if (this.video_capture) {
+            log('warn', 'Video capture already in progress, call Scene.stopVideoCapture() first');
+            return false;
+        }
+
+        // Start a new capture
+        try {
+            let cap = this.video_capture = {};
+            cap.chunks = [];
+            cap.stream = this.canvas.captureStream();
+            cap.options = { mimeType: 'video/webm' }; // TODO: support other format options
+            cap.media_recorder = new MediaRecorder(cap.stream, cap.options);
+            cap.media_recorder.ondataavailable = function (event) {
+                if (event.data.size > 0) {
+                   cap.chunks.push(event.data);
+                }
+            };
+            cap.media_recorder.start();
+        }
+        catch (e) {
+            this.video_capture = null;
+            log('error', 'Scene video capture failed', e);
+            return false;
+        }
+        return true;
+    }
+
+    stopVideoCapture () {
+        if (!this.video_capture) {
+            log('warn', 'No scene video capture in progress, call Scene.startVideoCapture() first');
+            return Promise.resolve({});
+        }
+
+        this.video_capture.media_recorder.stop();
+        let blob = new Blob(this.video_capture.chunks, { type: this.video_capture.options.mimeType });
+        let url = Utils.createObjectURL(blob);
+        this.video_capture = null;
+
+        return Promise.resolve({ url, blob });
     }
 
 

--- a/src/utils/media_capture.js
+++ b/src/utils/media_capture.js
@@ -1,0 +1,110 @@
+/* global MediaRecorder */
+import log from './log';
+import Utils from './utils';
+
+export default class MediaCapture {
+
+    constructor() {
+        this.queue_screenshot = null;
+        this.video_capture = null;
+    }
+
+    setCanvas (canvas) {
+        this.canvas = canvas;
+    }
+
+    // Take a screenshot, returns a promise that resolves with the screenshot data when available
+    screenshot () {
+        if (this.queue_screenshot != null) {
+            return this.queue_screenshot.promise; // only capture one screenshot at a time
+        }
+
+        // Will resolve once rendering is complete and render buffer is captured
+        this.queue_screenshot = {};
+        this.queue_screenshot.promise = new Promise((resolve, reject) => {
+            this.queue_screenshot.resolve = resolve;
+            this.queue_screenshot.reject = reject;
+        });
+        return this.queue_screenshot.promise;
+    }
+
+    // Called after rendering, captures render buffer and resolves promise with the image data
+    completeScreenshot () {
+        if (this.queue_screenshot != null) {
+            // Get data URL, convert to blob
+            // Strip host/mimetype/etc., convert base64 to binary without UTF-8 mangling
+            // Adapted from: https://gist.github.com/unconed/4370822
+            const url = this.canvas.toDataURL('image/png');
+            const data = atob(url.slice(22));
+            const buffer = new Uint8Array(data.length);
+            for (let i = 0; i < data.length; ++i) {
+                buffer[i] = data.charCodeAt(i);
+            }
+            const blob = new Blob([buffer], { type: 'image/png' });
+
+            // Resolve with screenshot data
+            this.queue_screenshot.resolve({ url, blob, type: 'png' });
+            this.queue_screenshot = null;
+        }
+    }
+
+    // Starts capturing a video stream from the canvas
+    startVideoCapture () {
+        if (typeof window.MediaRecorder !== 'function' || !this.canvas || typeof this.canvas.captureStream !== 'function') {
+            log('warn', 'Video capture (Canvas.captureStream and/or MediaRecorder APIs) not supported by browser');
+            return false;
+        }
+        else if (this.video_capture) {
+            log('warn', 'Video capture already in progress, call Scene.stopVideoCapture() first');
+            return false;
+        }
+
+        // Start a new capture
+        try {
+            let cap = this.video_capture = {};
+            cap.chunks = [];
+            cap.stream = this.canvas.captureStream();
+            cap.options = { mimeType: 'video/webm' }; // TODO: support other format options
+            cap.media_recorder = new MediaRecorder(cap.stream, cap.options);
+            cap.media_recorder.ondataavailable = function (event) {
+                if (event.data.size > 0) {
+                   cap.chunks.push(event.data);
+                }
+
+                // Stopped recording? Create the final capture file blob
+                if (cap.resolve) {
+                    let blob = new Blob(cap.chunks, { type: cap.options.mimeType });
+                    let url = Utils.createObjectURL(blob);
+                    cap.resolve({ url, blob, type: 'webm' });
+                }
+            };
+            cap.media_recorder.start();
+        }
+        catch (e) {
+            this.video_capture = null;
+            log('error', 'Scene video capture failed', e);
+            return false;
+        }
+        return true;
+    }
+
+    // Stops capturing a video stream from the canvas, returns a promise that resolves with the video when available
+    stopVideoCapture () {
+        if (!this.video_capture) {
+            log('warn', 'No scene video capture in progress, call Scene.startVideoCapture() first');
+            return Promise.resolve({});
+        }
+
+        // Promise that will resolve when final stream is available
+        this.video_capture.promise = new Promise((resolve, reject) => {
+            this.video_capture.resolve = resolve;
+            this.video_capture.reject = reject;
+        });
+
+        // Stop recording
+        this.video_capture.media_recorder.stop();
+
+        return this.video_capture.promise;
+    }
+
+}


### PR DESCRIPTION
It turns out there is a surprisingly complete set of new [MediaRecorder APIs](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder) that allow you to [capture the contents of a Canvas element](https://hacks.mozilla.org/2016/04/record-almost-everything-in-the-browser-with-mediarecorder/) to a video stream. 

This PR adds new `Scene.startVideoCapture()` and `Scene.stopVideoCapture()` methods for capturing a WebM-encoded movie of a Tangram map.

`stopVideoCapture()` returns a promise that will resolve with `url` and `blob` properties, similar to the existing `Scene.screenshot()` API. In addition, a new `type` property is now returned with both screenshot and video promises, indicating the file type. Currently the `type` is always `png` for screenshots, and `webm` for videos.

This PR also consolidates screenshot and video behavior into a new `MediaCapture` module.

MediaRecorder functionality is currently supported in Chrome and Firefox. `startVideoCapture()` will return `false` on other browsers.

A simple video capture button is also added to the bundled demo.