### PR TITLE
Remove move_into_tile parameter for PointLabel and LineLabel

### DIFF
--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -1,6 +1,5 @@
 import Label from './label';
 import PointAnchor from './point_anchor';
-import Geo from '../geo';
 import OBB from '../utils/obb';
 import {StyleParser} from '../styles/style_parser';
 
@@ -36,10 +35,10 @@ export default class LabelPoint extends Label {
             this.offset = PointAnchor.computeOffset(this.offset, parent.size, parent.anchor, PointAnchor.zero_buffer);
             this.offset = PointAnchor.computeOffset(this.offset, parent.size, this.anchor, PointAnchor.zero_buffer);
             if (parent.offset !== StyleParser.zeroPair) {        // point has an offset
-                if (this.offset === StyleParser.zeroPair) { // no text offset, use point's
+                if (this.offset === StyleParser.zeroPair) {      // no text offset, use point's
                     this.offset = parent.offset;
                 }
-                else {                                          // text has offset, add point's
+                else {                                           // text has offset, add point's
                     this.offset[0] += parent.offset[0];
                     this.offset[1] += parent.offset[1];
                 }
@@ -62,64 +61,27 @@ export default class LabelPoint extends Label {
         this.aabb = this.obb.getExtent();
     }
 
-    // Try to move the label into the tile bounds
-    // Returns true if label was moved into tile, false if it couldn't be moved
-    moveIntoTile () {
-        let updated = false;
-
-        if (this.aabb[0] < 0) {
-            this.position[0] += -this.aabb[0];
-            updated = true;
-        }
-
-        if (this.aabb[2] >= Geo.tile_scale) {
-            this.position[0] -= this.aabb[2] - Geo.tile_scale + 1;
-            updated = true;
-        }
-
-        if (this.aabb[3] > 0) {
-            this.position[1] -= this.aabb[3];
-            updated = true;
-        }
-
-        if (this.aabb[1] <= -Geo.tile_scale) {
-            this.position[1] -= this.aabb[1] + Geo.tile_scale - 1;
-            updated = true;
-        }
-
-        if (updated) {
-            this.updateBBoxes();
-        }
-
-        return updated;
-    }
-
     getNextFit() {
         if (!this.layout.cull_from_tile || this.inTileBounds()) {
             return true;
         }
 
-        if (this.layout.move_into_tile) {
-            this.moveIntoTile();
-            return true;
-        }
-        else {
-            if (Array.isArray(this.layout.anchor)) {
-                // Start on second anchor (first anchor was set on creation)
-                for (let i = 1; i < this.layout.anchor.length; i++) {
-                    this.anchor = this.layout.anchor[i];
-                    this.update();
+        if (Array.isArray(this.layout.anchor)) {
+            // Start on second anchor (first anchor was set on creation)
+            for (let i = 1; i < this.layout.anchor.length; i++) {
+                this.anchor = this.layout.anchor[i];
+                this.update();
 
-                    this.start_anchor_index = i;
+                this.start_anchor_index = i;
 
-                    if (this.inTileBounds()) {
-                        return true;
-                    }
+                if (this.inTileBounds()) {
+                    return true;
                 }
             }
-            // no anchors result in fit
-            return false;
         }
+
+        // no anchors result in fit
+        return false;
     }
 
     discard (bboxes, exclude = null) {

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -200,10 +200,6 @@ Object.assign(Points, {
             // This can be overriden, as long as it is less than or equal to the default
             tf.layout.priority = draw.text.priority ? Math.max(tf.layout.priority, style.priority + 0.5) : (style.priority + 0.5);
 
-            // Text labels attached to points should not be moved into tile
-            // (they should stay fixed relative to the point)
-            tf.layout.move_into_tile = false;
-
             Collision.addStyle(this.collision_group_text, tile.key);
         }
 
@@ -368,7 +364,6 @@ Object.assign(Points, {
 
         // tile boundary handling
         layout.cull_from_tile = (draw.cull_from_tile != null) ? draw.cull_from_tile : false;
-        layout.move_into_tile = (draw.move_into_tile != null) ? draw.move_into_tile : false;
 
         // polygons rendering as points will render at each of the polygon's vertices by default,
         // but can be set to render at the polygon's centroid instead

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -256,7 +256,6 @@ export const TextLabels = {
 
         // tile boundary handling
         layout.cull_from_tile = (draw.cull_from_tile != null) ? draw.cull_from_tile : true;
-        layout.move_into_tile = (draw.move_into_tile != null) ? draw.move_into_tile : true;
 
         // repeat minimum distance
         layout.repeat_distance = StyleParser.evalCachedProperty(draw.repeat_distance, context);

--- a/test/labels_spec.js
+++ b/test/labels_spec.js
@@ -40,14 +40,6 @@ describe('Labels', () => {
                     assert.isFalse(label.inTileBounds());
                 });
 
-                it(`can move back into tile for ${edge} edge`, () => {
-                    label.position = p;
-                    label.update();
-                    let moved = label.moveIntoTile();
-                    assert.isTrue(moved);
-                    assert.isTrue(label.inTileBounds());
-                });
-
             });
 
         });


### PR DESCRIPTION
This removes the `move_into_tile` parameter in the scene file. The behavior that it controlled is now fixed instead of user-defined. `PointLabels` have `move_into_tile` as `false` and `LineLabels` have `move_into_tile` as true.