### PR TITLE
Re-apply global property substitution

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -749,6 +749,7 @@ export default class Scene {
     */
     loadScene(config_source = null, config_path = null) {
         this.config_source = config_source || this.config_source;
+        this.config_globals_applied = [];
 
         if (typeof this.config_source === 'string') {
             this.config_path = Utils.pathForURL(config_path || this.config_source);
@@ -980,6 +981,7 @@ export default class Scene {
         this.generation = ++Scene.generation;
         this.updating++;
 
+        this.config = SceneLoader.applyGlobalProperties(this.config, this.config_globals_applied);
         this.style_manager.init();
         this.view.reset();
         this.createLights();

--- a/src/view.js
+++ b/src/view.js
@@ -60,6 +60,10 @@ export default class View {
                     return name;
                 }
             }
+
+            // If no camera set as active, use first one
+            let keys = Object.keys(this.scene.config.cameras);
+            return keys.length && keys[0];
         }
     }
 


### PR DESCRIPTION
As pointed out in #390, `global` properties were being substituted **once**, when the scene loads, but were not updating with changes on subsequent updates to the `scene.config` object. This is both inconsistent with other property updates to `scene.config`, and limits some important use cases, like run-time toggles (turn transit layer on/off, turn building extrusion on/off, etc.).

This branch re-applies global property substitution when `Scene.updateConfig()` is called. This includes:
- Saving "links" between global properties and the places that they are substituted.
- Finding new references to global properties that may have been added since the last update, and adding them to the list of links.

Tangram ES recently added this functionality as well, in https://github.com/tangrams/tangram-es/pull/965.

**NOTE:** Due to JS limitations, there is currently one exception to this behavior: links between properties cannot be "destroyed" at run-time. That is, if a property value references a global, that global will be re-applied when `updateConfig()` is called, *even if* the property was directly updated to some other value.

Example scene:
```
global:
  water: blue

layers:
  water:
    ...
    draw:
      polygons:
        color: global.water
```

At run-time:
```
scene.config.global.water = 'red'; // update the global
scene.updateConfig(); // water will be updated to new red value

scene.config.layers.water.draw.polygons.color = 'yellow'; // set to explicit value, instead of referencing property
scene.updateConfig(); // water will be updated BACK to red value because property link still exists
```

I investigated solutions for this, such as wrapping all JS primitive values in their object wrapper counterparts (`Number`, `String`, etc.), so that we could test for object instance equivalence to see if the substituted value had been changed. This did work for detecting property changes, however it introduced too many other potential issues elsewhere in the codebase (which could also affect any 3rd party libs we use), since type checks such as `typeof x === 'number'` will no longer work with object wrappers. For reference, this work can be seen in https://github.com/tangrams/tangram/commit/09991a9531bc6e0425f0884d34d08451425721bc.

While not ideal, this is likely not a common need, so it is an acceptable limitation for now.