### PR TITLE
Apply repeat group logic to points

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -343,6 +343,9 @@ Object.assign(Points, {
         // Buffer (1d value or 2d array, expand 1d to 2d)
         draw.buffer = StyleParser.createPropertyCache(draw.buffer, v => (Array.isArray(v) ? v : [v, v]).map(parseFloat) || 0);
 
+        // Repeat rules
+        draw.repeat_distance = StyleParser.createPropertyCache(draw.repeat_distance, parseFloat);
+
         // Optional text styling
         draw.text = this.preprocessText(draw.text); // will return null if valid text styling wasn't provided
         if (draw.text) {
@@ -396,6 +399,23 @@ Object.assign(Points, {
             priority = -1 >>> 0; // default to max priority value if none set
         }
         layout.priority = priority;
+
+        // repeat minimum distance
+        layout.repeat_distance = StyleParser.evalCachedProperty(draw.repeat_distance, context);
+        layout.repeat_distance *= layout.units_per_pixel;
+
+        // repeat group key - only needed if a non-zero repeat distance
+        if (layout.repeat_distance) {
+            if (typeof draw.repeat_group === 'function') {
+                layout.repeat_group = draw.repeat_group(context);
+            }
+            else if (typeof draw.repeat_group === 'string') {
+                layout.repeat_group = draw.repeat_group;
+            }
+            else {
+                layout.repeat_group = draw.key; // default to unique set of matching layers
+            }
+        }
 
         return layout;
     },


### PR DESCRIPTION
We have only been applying repeat group logic (`repeat_group` and `repeat_distance`) to text labels (both point and line labels).

This behavior is also useful for points themselves. For example, this can be used to "thin out" shields at lower zooms:

![shield-thinning](https://cloud.githubusercontent.com/assets/16733/19315979/b4b124b2-906d-11e6-8631-5d914c503b86.gif)

This adds repeat groups to the `points` style, with the following distinctions from `text` styles:

- Repeat logic is *off* by default (`repeat_distance` defaults to zero). While generally expected for labels, I think repeat rules for standalone points/icons is something that users should opt into (or it can unintentionally obscure data).
- For `text`, the default repeat group name is a concatenation of fully qualified layer name (e.g. `roads:highways:labels`) **and** the label string. This means that repeat restrictions are applied to labels in the same layer with the same text (e.g. we don't want a "5th Ave" label to repeat over and over). For `points`, the repeat group consists *only* of fully qualified layer name (the point doesn't have any text or other distinguishing properties to add).
- A `text` draw group nested under a `points` draw group **can have different** repeat group settings. 

The above behavior was arrived at while working through the shield example above, where the desire is to have *reduced spacing for shields generally*, while maintaining the default label spacing on *shields with the same text*. Having to apply the same spacing to both led to cases that were either too sparse or too dense, or with a reasonable overall density but too many of the same shield repeating next to itself.

The above example is styled similar to this:

```
draw:
  icons:
    sprite: shield
    repeat_distance: 75px # set repeat distance for shields generally
    text:
      anchor: center
      text_source: shield_text
      # default repeat distance will additionally be applied for shields with the same text
```




