### PR TITLE
Fix and speed up isRTL function

### DIFF
--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -415,11 +415,10 @@ CanvasText.cache_stats = { hits: 0, misses: 0 };
 CanvasText.texcoord_cache = {};
 
 // Right-to-left / bi-directional text handling
-// Taken from http://stackoverflow.com/questions/12006095/javascript-how-to-check-if-character-is-rtl
+// Taken from http://stackoverflow.com/questions/12006095/javascript-how-to-check-if-character-is-rtl#answer-19143254
 function isRTL(s){
-    var weakChars       = '\u0000-\u0040\u005B-\u0060\u007B-\u00BF\u00D7\u00F7\u02B9-\u02FF\u2000-\u2BFF\u2010-\u2029\u202C\u202F-\u2BFF',
-        rtlChars        = '\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC',
-        rtlDirCheck     = new RegExp('^['+weakChars+']*['+rtlChars+']');
+    var rtlChars        = '\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC',
+        rtlDirCheck     = new RegExp('^[^'+rtlChars+']*?['+rtlChars+']');
 
     return rtlDirCheck.test(s);
 }


### PR DESCRIPTION
function was throwing errors and had an updated faster alternative from the original source on stackoverflow.

After updating from 0.8 to 0.10.4 I got the following errors on some maps, in some areas. I found that the original code that came from stackoverflow had an update from the code that was copied, and when I used that new updated code, the errors went away. However, I don't understand how to test if the original purpose of the code is still intact.

The exact error:
7c616e0a-0e16-440d-b1a5-64a3fd7865d7:1 Uncaught (in promise) Invalid regular expression: /^[-@[-`{-Â¿Ã—Ã·Ê¹-Ë¿â€€-â¯¿â€- â€¬â€¯-â¯¿]*[Ö‘-ß¿â€â€«â€®ï¬-ï·½ï¹°-ï»¼]/: Range out of order in character class: SyntaxError: Invalid regular expression: /^[-@[-`{-Â¿Ã—Ã·Ê¹-Ë¿â€€-â¯¿â€- â€¬â€¯-â¯¿]*[Ö‘-ß¿â€â€«â€®ï¬-ï·½ï¹°-ï»¼]/: Range out of order in character class
    at RegExp (native)
    at i (http://localhost/TheOtherMaps/dist/lib/tangram.min.js:17:25951)
    at a (http://localhost/TheOtherMaps/dist/lib/tangram.min.js:17:26064)
    at o (http://localhost/TheOtherMaps/dist/lib/tangram.min.js:17:26215)
    at http://localhost/TheOtherMaps/dist/lib/tangram.min.js:17:27514