### PR TITLE
Compiled code no longer backwards

### DIFF
--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -415,13 +415,10 @@ CanvasText.cache_stats = { hits: 0, misses: 0 };
 CanvasText.texcoord_cache = {};
 
 // Right-to-left / bi-directional text handling
-// Taken from http://stackoverflow.com/questions/12006095/javascript-how-to-check-if-character-is-rtl
+// Taken from http://stackoverflow.com/questions/12006095/javascript-how-to-check-if-character-is-rtl#answer-19143254
+let rtlRegEx = /^[^\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]*?[\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]/;
 function isRTL(s){
-    var weakChars       = '\u0000-\u0040\u005B-\u0060\u007B-\u00BF\u00D7\u00F7\u02B9-\u02FF\u2000-\u2BFF\u2010-\u2029\u202C\u202F-\u2BFF',
-        rtlChars        = '\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC',
-        rtlDirCheck     = new RegExp('^['+weakChars+']*['+rtlChars+']');
-
-    return rtlDirCheck.test(s);
+    return rtlRegEx.test(s);
 }
 
 function reorderWordsLTR(words) {


### PR DESCRIPTION
Resolves the issues brought up in https://github.com/tangrams/tangram/pull/425

Our unicode range strings to detect RTL text were being converted to their textual equivalents upon bundling. This caused some very bizarre errors, such as the appearance of unicode characters such as ﷽ in our source, in addition to much of our source code being _backwards_. 

The fix is to create the RegEx directly, instead of building it out of these strings that will get corrupted upon bundling. Thanks to @batje for spotting this!