### PR TITLE
Revert move-into-tile functionality

### DIFF
--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -1,5 +1,6 @@
 import Label from './label';
 import PointAnchor from './point_anchor';
+import Geo from '../geo';
 import OBB from '../utils/obb';
 import {StyleParser} from '../styles/style_parser';
 
@@ -66,27 +67,65 @@ export default class LabelPoint extends Label {
         this.aabb = this.obb.getExtent();
     }
 
+    // Try to move the label into the tile bounds
+    // Returns true if label was moved into tile, false if it couldn't be moved
+    moveIntoTile () {
+        let updated = false;
+
+        if (this.aabb[0] < 0) {
+            this.position[0] += -this.aabb[0];
+            updated = true;
+        }
+
+        if (this.aabb[2] >= Geo.tile_scale) {
+            this.position[0] -= this.aabb[2] - Geo.tile_scale + 1;
+            updated = true;
+        }
+
+        if (this.aabb[3] > 0) {
+            this.position[1] -= this.aabb[3];
+            updated = true;
+        }
+
+        if (this.aabb[1] <= -Geo.tile_scale) {
+            this.position[1] -= this.aabb[1] + Geo.tile_scale - 1;
+            updated = true;
+        }
+
+        if (updated) {
+            this.updateBBoxes();
+        }
+
+        return updated;
+    }
+
     getNextFit() {
         if (!this.layout.cull_from_tile || this.inTileBounds()) {
             return true;
         }
 
-        if (Array.isArray(this.layout.anchor)) {
-            // Start on second anchor (first anchor was set on creation)
-            for (let i = 1; i < this.layout.anchor.length; i++) {
-                this.anchor = this.layout.anchor[i];
-                this.update();
+        if (this.layout.move_into_tile){
+            this.moveIntoTile();
+            return true;
+        }
+        else {
+            if (Array.isArray(this.layout.anchor)) {
+                // Start on second anchor (first anchor was set on creation)
+                for (let i = 1; i < this.layout.anchor.length; i++) {
+                    this.anchor = this.layout.anchor[i];
+                    this.update();
 
-                this.start_anchor_index = i;
+                    this.start_anchor_index = i;
 
-                if (this.inTileBounds()) {
-                    return true;
+                    if (this.inTileBounds()) {
+                        return true;
+                    }
                 }
             }
-        }
 
-        // no anchors result in fit
-        return false;
+            // no anchors result in fit
+            return false;
+        }
     }
 
     discard (bboxes, exclude = null) {

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -215,6 +215,10 @@ Object.assign(Points, {
             // This can be overriden, as long as it is less than or equal to the default
             tf.layout.priority = draw.text.priority ? Math.max(tf.layout.priority, style.priority + 0.5) : (style.priority + 0.5);
 
+            // Text labels attached to points should not be moved into tile
+            // (they should stay fixed relative to the point)
+            tf.layout.move_into_tile = false;
+
             Collision.addStyle(this.collision_group_text, tile.key);
         }
 
@@ -399,6 +403,9 @@ Object.assign(Points, {
 
         // tile boundary handling
         layout.cull_from_tile = (draw.cull_from_tile != null) ? draw.cull_from_tile : false;
+
+        // points should not move into tile if over tile boundary
+        layout.move_into_tile = false;
 
         // label anchors (point labels only)
         // label position will be adjusted in the given direction, relative to its original point

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -257,6 +257,9 @@ export const TextLabels = {
         // tile boundary handling
         layout.cull_from_tile = (draw.cull_from_tile != null) ? draw.cull_from_tile : true;
 
+        // standalone text can move into tile if specified
+        layout.move_into_tile = (draw.move_into_tile != null) ? draw.move_into_tile : true;
+
         // repeat rules include the text
         if (layout.repeat_distance) {
             layout.repeat_group += '/' + text;


### PR DESCRIPTION
Re-implement `move-into-tile` logic, but with `point` labels set to `move-into-tile = false`. This allows for text labels to be shifted into a tile to preserve features like neighborhoods, that aren't fixed to a particular geo location.