### PR TITLE
Use simple box intersection function for collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "box-intersect": "1.0.0",
     "brfs": "1.4.3",
     "csscolorparser": "1.0.3",
     "earcut": "2.1.1",

--- a/src/labels/intersect.js
+++ b/src/labels/intersect.js
@@ -1,0 +1,24 @@
+
+// Do AABB `a` and `b` intersect?
+export function boxIntersectsBox (a, b) {
+    if (a[2] < b[0] || // a is left of b
+        a[0] > b[2] || // a is right of b
+        a[3] < b[1] || // a is above b
+        a[1] > b[3]) { // a is below b
+        return false;
+    }
+    return true; // boxes overlap
+}
+
+// Does AABB `a` intersect any of the AABBs in array `boxes`?
+// Invokes `callback` with index of intersecting box
+// Stops intersecting if `callback` returns non-null value (continues otherwise)
+export function boxIntersectsList (a, boxes, callback) {
+    for (let i=0; i < boxes.length; i++) {
+        if (boxIntersectsBox(a, boxes[i])) {
+            if (callback(i) != null) {
+                break;
+            }
+        }
+    }
+}

--- a/src/labels/label.js
+++ b/src/labels/label.js
@@ -1,5 +1,5 @@
 import PointAnchor from './point_anchor';
-import boxIntersect from 'box-intersect'; // https://github.com/mikolalysenko/box-intersect
+import {boxIntersectsList} from './intersect';
 import Utils from '../utils/utils';
 import OBB from '../utils/obb';
 // import log from '../utils/log';
@@ -31,7 +31,7 @@ export default class Label {
 
         // Broad phase
         if (aabbs.length > 0) {
-            boxIntersect([this.aabb], aabbs, (i, j) => {
+            boxIntersectsList(this.aabb, aabbs, (j) => {
                 // log('trace', 'collision: broad phase collide', this.layout.id, this, this.aabb, aabbs[j]);
 
                 // Skip if colliding with excluded label


### PR DESCRIPTION
Here's a fun one: reviewing our dependencies to reduce library size, I tried replacing our [`box-intersect`](https://github.com/mikolalysenko/box-intersect) module with a simple homegrown box intersection function:

The simple version not only produces a **6k smaller** minified/gzipped bundle, it's also **25% faster** on a complex label scene (Bubble Wrap central London z17).

It's possible a fancier implementation will be more performant when we have more complex collisions (such as pooling all tile labels and colliding in screen-space), so we can revisit at that time. Until then, score another one for the Dumbest Thing Possible.
