### PR TITLE
Control point placement by line length ratio

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -187,6 +187,8 @@ Object.assign(Points, {
 
         // Placement strategy
         style.placement = draw.placement;
+        style.placement_must_fit = draw.placement_must_fit;
+        style.placement_min_length_ratio = StyleParser.evalCachedProperty(draw.placement_min_length_ratio, context);
 
         // Spacing parameter (in pixels) to equally space points along a line
         if (style.placement === PLACEMENT.SPACED && draw.placement_spacing) {
@@ -369,6 +371,9 @@ Object.assign(Points, {
 
         draw.placement_spacing = draw.placement_spacing != null ? draw.placement_spacing : 80; // default spacing
         draw.placement_spacing = StyleParser.createPropertyCache(draw.placement_spacing, parseFloat);
+
+        draw.placement_min_length_ratio = draw.placement_min_length_ratio != null ? draw.placement_min_length_ratio : 1;
+        draw.placement_min_length_ratio = StyleParser.createPropertyCache(draw.placement_min_length_ratio, parseFloat);
 
         if (typeof draw.angle === 'number') {
             draw.angle = draw.angle * Math.PI / 180;


### PR DESCRIPTION
#409 improved placement of points-on-lines -- for symbols like road shields and one-way arrows -- by adding placement strategies on line segment *midpoints* (`placement: midpoint`), or *evenly spaced* along the line (`placement: spaced`).

For road shield placement, we are using `placement: midpoint` to keep shields as far away from line vertices as possible. This is because shields placed at vertices are more likely to be ambiguous, such as where two highways intersect.

The code from #409 places no restrictions on the *length* of the line segment on which it places a point, so a shield (or other icon) may be placed on a line segment much shorter than itself (the icon may entirely cover the line segment). This appears problematic for shields because highway interchanges are more likely to simply into many short line segments, causing the same type of ambiguity that vertex placement did.

To improve this, this PR introduces a new parameter, `placement_min_length_ratio`, that specifies the **minimum line segment length as a ratio to the point being placed**. Here are some example values for this parameter:

- `placement_min_length_ratio: 1` (default value), will only place points on line segments that are *at least as long* as the point itself (the point must fit 100% along the line segment)
- `placement_min_length_ratio: 0` disables this behavior by allowing a point to place on a line segment of *any* length (minimum length of 0)
- `placement_min_length_ratio: 2` requires the line segment to be *at least twice* as long as the point
- `placement_min_length_ratio: 0.5` requires the line segment to be *only 50%* as long as the point

Here is a before/after example in Chicago. Note there are several shields placed very near to intersections that are pushed further away with this behavior enabled.

![shield-min-ratio-chicago](https://cloud.githubusercontent.com/assets/16733/19935330/0e992f0a-a0f0-11e6-841d-d526e23e6f4b.gif)

This parameter is not a silver bullet, needs to be tuned (by zoom) or it can drop too many shields (not enough line segments that are long enough to fit), but in many cases it can provide significant improvement.

The parameter can be zoom-interpolated with stops, or accept a JS function. It is only used for `placement` strategies of `midpoint` and `spaced` (does not affect `vertex` placement).

This control was required because the desired behavior is somewhat dependent on the data source. Current Mapzen tiles still have enough short line segments at mid-zooms that the best ratio sometimes needs to be below `1` (or there is an insufficient # of shields placed). If we introduced further road network generalization in the future (through something like [skeletron's](https://github.com/migurski/Skeletron) approach), we would want to re-tune these.

The example screenshot above was using these values across zooms (should be tuned further by @sensescape and @nvkelso!):

```
placement_min_length_ratio:
  - [8, 0.1]
  - [9, 0.25]
  - [10, 0.5]
  - [11, 1]
  - [12, 1]
  - [13, 1.50]
  - [14, 2.0]
```
