### PR TITLE
Compile shaders lazily

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -510,6 +510,7 @@ export default class Scene {
         let last_blend;
         for (let s=0; s < styles.length; s++) {
             let style = styles[s];
+
             // Only update render state when blend mode changes
             if (style.blend !== last_blend) {
                 let state = Object.assign({},
@@ -525,20 +526,17 @@ export default class Scene {
         return count;
     }
 
-    renderStyle(style, program_key) {
+    renderStyle(style_name, program_key) {
+        let style = this.styles[style_name];
         let first_for_style = true;
         let render_count = 0;
-
-        let program = this.styles[style][program_key];
-        if (!program || !program.compiled) {
-            return 0;
-        }
+        let program;
 
         // Render tile GL geometries
         for (let t=0; t < this.renderable_tiles.length; t++) {
             let tile = this.renderable_tiles[t];
 
-            if (tile.meshes[style] == null) {
+            if (tile.meshes[style_name] == null) {
                 continue;
             }
 
@@ -548,8 +546,25 @@ export default class Scene {
             if (first_for_style === true) {
                 first_for_style = false;
 
+                // Get shader program from style, lazily compiling if necessary
+                try {
+                    program = style.getProgram(program_key);
+                    if (!program) {
+                        return 0;
+                    }
+                }
+                catch(error) {
+                    this.trigger('warning', {
+                        type: 'styles',
+                        message: `Error compiling style ${style_name}`,
+                        style,
+                        shader_errors: style.program && style.program.shader_errors
+                    });
+                    return 0;
+                }
+
                 program.use();
-                this.styles[style].setup();
+                style.setup();
 
                 program.uniform('1f', 'u_time', this.animated ? (((+new Date()) - this.start_time) / 1000) : 0);
                 this.view.setupProgram(program);
@@ -559,8 +574,8 @@ export default class Scene {
             }
 
             // Skip proxy tiles if new tiles have finished loading this style
-            if (!tile.shouldProxyForStyle(style)) {
-                // log('trace', `Scene.renderStyle(): Skip proxy tile for style '${style}' `, tile, tile.proxy_for);
+            if (!tile.shouldProxyForStyle(style_name)) {
+                // log('trace', `Scene.renderStyle(): Skip proxy tile for style '${style_name}' `, tile, tile.proxy_for);
                 continue;
             }
 
@@ -568,13 +583,14 @@ export default class Scene {
             this.view.setupTile(tile, program);
 
             // Render tile
-            if (this.styles[style].render(tile.meshes[style])) {
+            let mesh = tile.meshes[style_name];
+            if (style.render(mesh)) {
                 // Don't incur additional renders while viewport is moving
                 if (!(this.view.panning || this.view.zooming)) {
                    this.requestRedraw();
                 }
             }
-            render_count += tile.meshes[style].geometry_count;
+            render_count += mesh.geometry_count;
         }
 
         return render_count;
@@ -716,7 +732,7 @@ export default class Scene {
             // Update config (in case JS objects were manipulated directly)
             if (sync) {
                 this.syncConfigToWorker({ serialize_funcs });
-                this.style_manager.compile(this.updateActiveStyles(), this); // only recompile newly active styles
+                // this.style_manager.compile(this.updateActiveStyles(), this); // only recompile newly active styles
             }
             this.resetFeatureSelection();
             this.resetTime();
@@ -888,7 +904,6 @@ export default class Scene {
 
         // Find & compile active styles
         this.updateActiveStyles();
-        this.style_manager.compile(Object.keys(this.active_styles), this);
 
         this.dirty = true;
     }

--- a/src/scene.js
+++ b/src/scene.js
@@ -497,6 +497,7 @@ export default class Scene {
         // Sort styles by blend order
         let styles = this.tile_manager.getActiveStyles().
             map(s => this.styles[s]).
+            filter(s => s). // guard against missing styles, such as while loading a new scene
             sort(Style.blendOrderSort);
 
         // Render styles

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -66,9 +66,11 @@ Object.assign(Lines, {
     },
 
     // Override
-    compile () {
-        this.parseLineTexture();
-        return Style.compile.apply(this, arguments);
+    compileSetup () {
+        if (!this.compile_setup) {
+            this.parseLineTexture();
+        }
+        return Style.compileSetup.apply(this, arguments);
     },
 
     // Optionally apply a dash array pattern to this line

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -611,13 +611,6 @@ export var Style = {
         }
 
         return a.name < b.name ? -1 : 1; // use name as tie breaker
-    },
-
-    update () {
-        // Style-specific animation
-        // if (typeof this.animation === 'function') {
-        //     this.animation();
-        // }
     }
 
 };

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -27,8 +27,7 @@ export var Style = {
         this.shaders = (this.hasOwnProperty('shaders') && this.shaders) || {}; // shader customization (uniforms, defines, blocks, etc.)
         this.introspection = introspection || false;
         this.selection = this.selection || this.introspection || false;   // flag indicating if this style supports feature selection
-        this.compiling = false;                     // programs are currently compiling
-        this.compiled = false;                      // programs are finished compiling
+        this.compile_setup = false;                 // one-time setup steps for program compilation
         this.program = null;                        // GL program reference (for main render pass)
         this.selection_program = null;              // GL program reference for feature selection render pass
         this.feature_style = {};                    // style for feature currently being parsed, shared to lessen GC/memory thrash
@@ -293,16 +292,31 @@ export var Style = {
         return mesh.render();
     },
 
-    compile () {
+    // Get a specific program, compiling if necessary
+    getProgram (key = 'program') {
+        this.compileSetup();
+
+        const program = this[key];
+        if (!program || program.error) {
+            return;
+        }
+
+        if (!program.compiled) {
+            log('debug', `Compiling style '${this.name}', program key '${key}'`);
+            program.compile();
+        }
+        return program;
+    },
+
+    // One-time setup for compiling style's programs
+    compileSetup () {
+        if (this.compile_setup) {
+            return;
+        }
+
         if (!this.gl) {
             throw(new Error(`style.compile(): skipping for ${this.name} because no GL context`));
         }
-
-        if (this.compiling) {
-            throw(new Error(`style.compile(): skipping for ${this.name} because style is already compiling`));
-        }
-        this.compiling = true;
-        this.compiled = false;
 
         // Build defines & for selection (need to create a new object since the first is stored as a reference by the program)
         var defines = this.buildDefineList();
@@ -323,50 +337,40 @@ export var Style = {
         }
 
         // Create shaders
-        try {
-            this.program = new ShaderProgram(
+        this.program = new ShaderProgram(
+            this.gl,
+            this.vertex_shader_src,
+            this.fragment_shader_src,
+            {
+                name: this.name,
+                defines,
+                uniforms,
+                blocks,
+                block_scopes,
+                extensions
+            }
+        );
+
+        if (this.selection) {
+            this.selection_program = new ShaderProgram(
                 this.gl,
                 this.vertex_shader_src,
-                this.fragment_shader_src,
+                shaderSrc_selectionFragment,
                 {
-                    name: this.name,
-                    defines,
+                    name: (this.name + ' (selection)'),
+                    defines: selection_defines,
                     uniforms,
                     blocks,
                     block_scopes,
                     extensions
                 }
             );
-            this.program.compile();
-
-            if (this.selection) {
-                this.selection_program = new ShaderProgram(
-                    this.gl,
-                    this.vertex_shader_src,
-                    shaderSrc_selectionFragment,
-                    {
-                        name: (this.name + ' (selection)'),
-                        defines: selection_defines,
-                        uniforms,
-                        blocks,
-                        block_scopes,
-                        extensions
-                    }
-                );
-                this.selection_program.compile();
-            }
-            else {
-                this.selection_program = null;
-            }
         }
-        catch(error) {
-            this.compiling = false;
-            this.compiled = false;
-            throw(new Error(`style.compile(): style ${this.name} error:`, error));
+        else {
+            this.selection_program = null;
         }
 
-        this.compiling = false;
-        this.compiled = true;
+        this.compile_setup = true;
     },
 
     // Add a shader block

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -366,30 +366,6 @@ export class StyleManager {
         return parents;
     }
 
-    // Compile all styles
-    compile (keys, scene) {
-        keys = keys || Object.keys(this.styles);
-        keys.forEach(key => {
-            let style = this.styles[key];
-            try {
-                style.compile();
-                log('trace', `StyleManager.compile(): compiled style ${key}`);
-            }
-            catch(error) {
-                log('error', `StyleManager.compile(): error compiling style ${key}:`, error);
-
-                scene.trigger('warning', {
-                    type: 'styles',
-                    message: `Error compiling style ${key}`,
-                    style,
-                    shader_errors: style.program && style.program.shader_errors
-                });
-            }
-        });
-
-        log('debug', `StyleManager.compile(): compiled all styles`);
-    }
-
     // Get all styles with mesh data for a given tile
     static stylesForTile (tile_key, styles) {
         let tile_styles = [];

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -13,6 +13,8 @@ export default class TileManager {
         this.visible_coords = {};
         this.queued_coords = [];
         this.building_tiles = null;
+        this.renderable_tiles = [];
+        this.active_styles = [];
 
         // Provide a hook for this object to be called from worker threads
         this.main_thread_target = ['TileManager', this.scene.id].join('_');
@@ -122,6 +124,8 @@ export default class TileManager {
         this.loadQueuedCoordinates();
         this.updateProxyTiles();
         this.view.pruneTilesForView();
+        this.updateRenderableTiles();
+        this.updateActiveStyles();
     }
 
     updateProxyTiles () {
@@ -182,15 +186,34 @@ export default class TileManager {
         this.removeTiles(tile => !tile.visible);
     }
 
-    getRenderableTiles() {
-        let tiles = [];
+    getRenderableTiles () {
+        return this.renderable_tiles;
+    }
+
+    updateRenderableTiles() {
+        this.renderable_tiles = [];
         for (let t in this.tiles) {
             let tile = this.tiles[t];
             if (tile.visible && tile.loaded) {
-                tiles.push(tile);
+                this.renderable_tiles.push(tile);
             }
         }
-        return tiles;
+        return this.renderable_tiles;
+    }
+
+    getActiveStyles () {
+        return this.active_styles;
+    }
+
+    updateActiveStyles () {
+        let tiles = this.renderable_tiles;
+        let active = {};
+        for (let t=0; t < tiles.length; t++) {
+            let tile = tiles[t];
+            Object.keys(tile.meshes).forEach(s => active[s] = true);
+        }
+        this.active_styles = Object.keys(active);
+        return this.active_styles;
     }
 
     isLoadingVisibleTiles() {

--- a/test/scene_spec.js
+++ b/test/scene_spec.js
@@ -60,10 +60,6 @@ describe('Scene', function () {
                 assert.instanceOf(subject.gl, WebGLRenderingContext);
             });
 
-            it('compiles render styles', () => {
-                assert.isTrue(subject.styles.rainbow.compiled);
-                assert.ok(subject.styles.rainbow.program);
-            });
         });
 
         describe('loading scene from an existing object', () => {
@@ -248,54 +244,6 @@ describe('Scene', function () {
             assert.isTrue(subject.update());
         });
 
-    });
-
-    describe('.updateStyles()', () => {
-
-        beforeEach(() => {
-            return subject.load();
-        });
-
-        describe('when a new style is added', () => {
-
-            beforeEach(() => {
-                subject.config.styles.elevator = {
-                    "base": "polygons",
-                    "animated": true,
-                    "shaders": {
-                        "blocks": {
-                            "vertex": "position.z *= (sin(position.z + u_time) + 1.0); // elevator buildings"
-                        }
-                    }
-                };
-            });
-
-            it('doesn\'t compile if the style isn\'t referenced by a layer', () => {
-                subject.updateStyles();
-                assert.isFalse(subject.styles.elevator.compiled);
-            });
-
-            it('does compile if the style is referenced by a layer', () => {
-                subject.config.layers.buildings.draw.polygons.style = 'elevator';
-                subject.updateStyles();
-                assert.isTrue(subject.styles.elevator.compiled);
-                assert.ok(subject.styles.elevator.program);
-            });
-
-        });
-
-        it('adds properties to an existing style', () => {
-            subject.config.styles.rainbow.shaders.uniforms = { u_test: 10 };
-            subject.config.styles.rainbow.defines = subject.config.styles.rainbow.defines || {};
-            subject.config.styles.rainbow.defines.TEST = true;
-            subject.updateStyles();
-
-            assert.ok(subject.styles.rainbow);
-            assert.isTrue(subject.styles.rainbow.compiled);
-            assert.ok(subject.styles.rainbow.program);
-            assert.deepPropertyVal(subject, 'styles.rainbow.shaders.uniforms.u_test', 10);
-            assert.deepPropertyVal(subject, 'styles.rainbow.defines.TEST', true);
-        });
     });
 
 });

--- a/test/style_spec.js
+++ b/test/style_spec.js
@@ -59,28 +59,25 @@ describe('Styles:', () => {
 
             it('compiles parent custom style', () => {
                 style_manager.styles.rainbow.setGL(gl);
-                style_manager.styles.rainbow.compile();
+                style_manager.styles.rainbow.getProgram();
                 assert.equal(style_manager.styles.rainbow.constructor, Style.constructor);
                 assert.equal(style_manager.styles.rainbow.base, 'polygons');
-                assert.ok(style_manager.styles.rainbow.compiled);
                 assert.ok(style_manager.styles.rainbow.program.compiled);
             });
 
             it('compiles child style dependent on another custom style', () => {
                 style_manager.styles.rainbow_child.setGL(gl);
-                style_manager.styles.rainbow_child.compile();
+                style_manager.styles.rainbow_child.getProgram();
                 assert.equal(style_manager.styles.rainbow_child.constructor, Style.constructor);
                 assert.equal(style_manager.styles.rainbow_child.base, 'polygons');
-                assert.ok(style_manager.styles.rainbow_child.compiled);
                 assert.ok(style_manager.styles.rainbow_child.program.compiled);
             });
 
             it('compiles a style with the same style mixed by multiple ancestors', () => {
                 style_manager.styles.descendant.setGL(gl);
-                style_manager.styles.descendant.compile();
+                style_manager.styles.descendant.getProgram();
                 assert.equal(style_manager.styles.descendant.constructor, Style.constructor);
                 assert.equal(style_manager.styles.descendant.base, 'polygons');
-                assert.ok(style_manager.styles.descendant.compiled);
                 assert.ok(style_manager.styles.descendant.program.compiled);
             });
 
@@ -105,16 +102,15 @@ describe('Styles:', () => {
         it('compiles a program', () => {
             style_manager.styles.polygons.init();
             style_manager.styles.polygons.setGL(gl);
-            style_manager.styles.polygons.compile();
-            assert.ok(style_manager.styles.polygons.compiled);
+            style_manager.styles.polygons.getProgram();
+            assert.ok(style_manager.styles.polygons.program.compiled);
         });
 
         it('injects a dependent uniform in a custom style', () => {
             style_manager.create('scale', sampleScene.styles.scale);
             style_manager.styles.scale.init();
             style_manager.styles.scale.setGL(gl);
-            style_manager.styles.scale.compile();
-            assert.ok(style_manager.styles.scale.compiled);
+            style_manager.styles.scale.getProgram();
             assert.ok(style_manager.styles.scale.program.compiled);
         });
 

--- a/test/tile_manager_spec.js
+++ b/test/tile_manager_spec.js
@@ -4,7 +4,6 @@ import Tile from '../src/tile';
 
 let nycLatLng = { lng: -73.97229909896852, lat: 40.76456761707639, zoom: 17 };
 let midtownTile = { x: 38603, y: 49255, z: 17 };
-let midtownTileKey = `${midtownTile.x}/${midtownTile.y}/${midtownTile.z}`;
 
 describe('TileManager', function () {
 
@@ -19,7 +18,6 @@ describe('TileManager', function () {
     });
 
     afterEach(() => {
-        // scene.destroy();
         scene = null;
     });
 
@@ -68,7 +66,6 @@ describe('TileManager', function () {
         });
 
         describe('when the tile manager already has the tile', () => {
-            let key = midtownTileKey;
             let tile, tiles;
 
             beforeEach(() => {
@@ -86,7 +83,6 @@ describe('TileManager', function () {
             afterEach(() => {
                 tile_manager.keepTile.restore();
                 tile.build.restore();
-                tile_manager.tiles[key] = undefined;
             });
 
             it('does not build the tile', () => {


### PR DESCRIPTION
Compile style shader programs on-demand, the first time they are encountered in a renderable tile.

Previously, all styles referenced by a layer were compiled at scene load time.