### PR TITLE
Alpha blending

### DIFF
--- a/src/light.js
+++ b/src/light.js
@@ -106,50 +106,27 @@ export default class Light {
                 vec4 color = vec4(0.0);
 
                 // Keep material alpha channel when alpha blending is on
-                #if !defined(TANGRAM_BLEND_OPAQUE)
-                    #if defined(TANGRAM_BLEND_BUFINLAY)
-                        color.a = _color.a; // use vertex color alpha
+                #if !defined(TANGRAM_BLEND_OPAQUE) && !defined(TANGRAM_BLEND_DEPTHINLAY)
 
-                        #ifdef TANGRAM_MATERIAL_EMISSION
-                           color.rgb = material.emission.rgb * material.emission.a;
-                        #endif
+                    #ifdef TANGRAM_MATERIAL_EMISSION
+                        color = material.emission;
+                    #endif
 
-                        #ifdef TANGRAM_MATERIAL_AMBIENT
-                            color.rgb += light_accumulator_ambient.rgb * _color.rgb * material.ambient.rgb * material.ambient.a;
-                        #else
-                            #ifdef TANGRAM_MATERIAL_DIFFUSE
-                                color.rgb += light_accumulator_ambient.rgb * _color.rgb * material.diffuse.rgb * material.diffuse.a;
-                            #endif
-                        #endif
-    
-                        #ifdef TANGRAM_MATERIAL_DIFFUSE
-                            color.rgb += light_accumulator_diffuse.rgb * _color.rgb * material.diffuse.rgb * material.diffuse.a;
-                        #endif
-    
-                        #ifdef TANGRAM_MATERIAL_SPECULAR
-                            color.rgb += light_accumulator_specular.rgb * material.specular.rgb * material.specular.a;
-                        #endif
+                    #ifdef TANGRAM_MATERIAL_AMBIENT
+                        color += light_accumulator_ambient * _color * material.ambient;
                     #else
-                        #ifdef TANGRAM_MATERIAL_EMISSION
-                            color = material.emission;
-                        #endif
-    
-                        #ifdef TANGRAM_MATERIAL_AMBIENT
-                            color += light_accumulator_ambient * _color * material.ambient;
-                        #else
-                            #ifdef TANGRAM_MATERIAL_DIFFUSE
-                                color += light_accumulator_ambient * _color * material.diffuse;
-                            #endif
-                        #endif
-
                         #ifdef TANGRAM_MATERIAL_DIFFUSE
-                            color += light_accumulator_diffuse * _color * material.diffuse;
-                        #endif
-
-                        #ifdef TANGRAM_MATERIAL_SPECULAR
-                            color += light_accumulator_specular * material.specular;
+                            color += light_accumulator_ambient * _color * material.diffuse;
                         #endif
                     #endif
+                    #ifdef TANGRAM_MATERIAL_DIFFUSE
+                        color += light_accumulator_diffuse * _color * material.diffuse;
+                    #endif
+
+                    #ifdef TANGRAM_MATERIAL_SPECULAR
+                        color += light_accumulator_specular * material.specular;
+                    #endif
+
                 // Multiply material alpha channel into material RGB when alpha blending is off
                 #else
                     color.a = _color.a; // use vertex color alpha

--- a/src/light.js
+++ b/src/light.js
@@ -107,24 +107,48 @@ export default class Light {
 
                 // Keep material alpha channel when alpha blending is on
                 #if !defined(TANGRAM_BLEND_OPAQUE)
-                    #ifdef TANGRAM_MATERIAL_EMISSION
-                        color = material.emission;
-                    #endif
+                    #if defined(TANGRAM_BLEND_BUFINLAY)
+                        color.a = _color.a; // use vertex color alpha
 
-                    #ifdef TANGRAM_MATERIAL_AMBIENT
-                        color += light_accumulator_ambient * _color * material.ambient;
-                    #else
-                        #ifdef TANGRAM_MATERIAL_DIFFUSE
-                            color += light_accumulator_ambient * _color * material.diffuse;
+                        #ifdef TANGRAM_MATERIAL_EMISSION
+                           color.rgb = material.emission.rgb * material.emission.a;
                         #endif
-                    #endif
 
-                    #ifdef TANGRAM_MATERIAL_DIFFUSE
-                        color += light_accumulator_diffuse * _color * material.diffuse;
-                    #endif
+                        #ifdef TANGRAM_MATERIAL_AMBIENT
+                            color.rgb += light_accumulator_ambient.rgb * _color.rgb * material.ambient.rgb * material.ambient.a;
+                        #else
+                            #ifdef TANGRAM_MATERIAL_DIFFUSE
+                                color.rgb += light_accumulator_ambient.rgb * _color.rgb * material.diffuse.rgb * material.diffuse.a;
+                            #endif
+                        #endif
+    
+                        #ifdef TANGRAM_MATERIAL_DIFFUSE
+                            color.rgb += light_accumulator_diffuse.rgb * _color.rgb * material.diffuse.rgb * material.diffuse.a;
+                        #endif
+    
+                        #ifdef TANGRAM_MATERIAL_SPECULAR
+                            color.rgb += light_accumulator_specular.rgb * material.specular.rgb * material.specular.a;
+                        #endif
+                    #else
+                        #ifdef TANGRAM_MATERIAL_EMISSION
+                            color = material.emission;
+                        #endif
+    
+                        #ifdef TANGRAM_MATERIAL_AMBIENT
+                            color += light_accumulator_ambient * _color * material.ambient;
+                        #else
+                            #ifdef TANGRAM_MATERIAL_DIFFUSE
+                                color += light_accumulator_ambient * _color * material.diffuse;
+                            #endif
+                        #endif
 
-                    #ifdef TANGRAM_MATERIAL_SPECULAR
-                        color += light_accumulator_specular * material.specular;
+                        #ifdef TANGRAM_MATERIAL_DIFFUSE
+                            color += light_accumulator_diffuse * _color * material.diffuse;
+                        #endif
+
+                        #ifdef TANGRAM_MATERIAL_SPECULAR
+                            color += light_accumulator_specular * material.specular;
+                        #endif
                     #endif
                 // Multiply material alpha channel into material RGB when alpha blending is off
                 #else

--- a/src/scene.js
+++ b/src/scene.js
@@ -618,7 +618,7 @@ export default class Scene {
                 });
             }
             // Traditional alpha blending
-            else if (blend === 'overlay' || blend === 'inlay' || blend === 'bufinlay') {
+            else if (blend === 'overlay' || blend === 'inlay' || blend === 'depthinlay') {
                 render_states.blending.set({
                     blend: true,
                     src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA,

--- a/src/scene.js
+++ b/src/scene.js
@@ -618,7 +618,7 @@ export default class Scene {
                 });
             }
             // Traditional alpha blending
-            else if (blend === 'overlay' || blend === 'inlay') {
+            else if (blend === 'overlay' || blend === 'inlay' || blend === 'bufinlay') {
                 render_states.blending.set({
                     blend: true,
                     src: gl.SRC_ALPHA, dst: gl.ONE_MINUS_SRC_ALPHA,

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -563,7 +563,8 @@ export var Style = {
         add: { depth_test: true, depth_write: false },
         multiply: { depth_test: true, depth_write: false },
         inlay: { depth_test: true, depth_write: false },
-        overlay: { depth_test: false, depth_write: false }
+        overlay: { depth_test: false, depth_write: false },
+        bufinlay: { depth_test: true, depth_write: true }
     },
 
     // Default sort order for blend modes

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -564,7 +564,7 @@ export var Style = {
         multiply: { depth_test: true, depth_write: false },
         inlay: { depth_test: true, depth_write: false },
         overlay: { depth_test: false, depth_write: false },
-        bufinlay: { depth_test: true, depth_write: true }
+        depthinlay: { depth_test: true, depth_write: true }
     },
 
     // Default sort order for blend modes


### PR DESCRIPTION
Hi guys!

We have a problem with the alpha channel and how flat polygons are rendered without a background (transparent one) and a simple leaftlet layer behind.

Let's see an example:

* How it should be:

<img width="148" alt="screen shot 2016-11-23 at 10 18 52" src="https://cloud.githubusercontent.com/assets/463462/20601947/78e35594-b25b-11e6-9859-c4197a5021a4.png">

* How it is:

<img width="166" alt="screen shot 2016-11-23 at 10 16 37" src="https://cloud.githubusercontent.com/assets/463462/20602000/b9dd131e-b25b-11e6-9d17-9a882a468cae.png">

I've made some changes to tangram adding a new blend option called depthinlay (I know, the name is the worst, sorry), to add the alpha channel and depth_write option just like an opaque but adding the src_alpha and dst_alpha just like an overlay or inlay.

I don't know if this is the best way to do this, could you help me on this problem? (Also changing the name of the option if it is necessary a new option).

Thank you guys!