### PR TITLE
Improve text clarity by aligning sprites to pixel grid

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -117,14 +117,15 @@ function extendLeaflet(options) {
                 map.on('zoomstart', this.hooks.zoomstart);
 
                 this.hooks.dragstart = () => {
-                    this.scene.view.panning = true;
+                    this.scene.view.setPanning(true);
                 };
                 map.on('dragstart', this.hooks.dragstart);
 
-                this.hooks.dragend = () => {
-                    this.scene.view.panning = false;
+                this.hooks.moveend = () => {
+                    this.scene.view.setPanning(false);
+                    this.scene.requestRedraw();
                 };
-                map.on('dragend', this.hooks.dragend);
+                map.on('moveend', this.hooks.moveend);
 
                 // Force leaflet zoom animations off
                 map._zoomAnimated = false;
@@ -174,7 +175,7 @@ function extendLeaflet(options) {
                 map.off('move', this.hooks.move);
                 map.off('zoomstart', this.hooks.zoomstart);
                 map.off('dragstart', this.hooks.dragstart);
-                map.off('dragend', this.hooks.dragend);
+                map.off('moveend', this.hooks.moveend);
                 map.off('click', this.hooks.click);
                 map.off('mousemove', this.hooks.mousemove);
                 map.off('mouseout', this.hooks.mouseout);

--- a/src/scene.js
+++ b/src/scene.js
@@ -434,7 +434,7 @@ export default class Scene {
         }
 
         // Redraw every frame if animating
-        if (this.animated === true) {
+        if (this.animated === true || this.view.isAnimating()) {
             this.dirty = true;
         }
 

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -88,7 +88,9 @@ Object.assign(Points, {
         }
 
         // Snap points to pixel grid after panning stop
-        this.defines.TANGRAM_VIEW_PAN_SNAP_RATE = 1 / VIEW_PAN_SNAP_TIME; // inverse time in seconds
+        if (debugSettings.suppress_label_snap_animation !== true) {
+            this.defines.TANGRAM_VIEW_PAN_SNAP_RATE = 1 / VIEW_PAN_SNAP_TIME; // inverse time in seconds
+        }
 
         this.collision_group_points = this.name+'-points';
         this.collision_group_text = this.name+'-text';

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -13,6 +13,7 @@ import Collision from '../../labels/collision';
 import LabelPoint from '../../labels/label_point';
 import placePointsOnLine from '../../labels/point_placement';
 import {TextLabels} from '../text/text_labels';
+import {VIEW_PAN_SNAP_TIME} from '../../view';
 import debugSettings from '../../utils/debug_settings';
 
 let fs = require('fs');
@@ -85,6 +86,9 @@ Object.assign(Points, {
             this.fade_in_time = 0.15; // time in seconds
             this.defines.TANGRAM_FADE_IN_RATE = 1 / this.fade_in_time;
         }
+
+        // Snap points to pixel grid after panning stop
+        this.defines.TANGRAM_VIEW_PAN_SNAP_RATE = 1 / VIEW_PAN_SNAP_TIME; // inverse time in seconds
 
         this.collision_group_points = this.name+'-points';
         this.collision_group_text = this.name+'-text';

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -5,7 +5,7 @@ uniform vec4 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 uniform float u_visible_time;
-uniform bool u_fade_in;
+uniform bool u_tile_fade_in;
 
 uniform mat3 u_normalMatrix;
 uniform mat3 u_inverseNormalMatrix;
@@ -82,7 +82,7 @@ void main (void) {
 
     // Fade in (if requested) based on time mesh has been visible
     #ifdef TANGRAM_FADE_IN_RATE
-    if (u_fade_in) {
+    if (u_tile_fade_in) {
         color.a *= clamp(u_visible_time * TANGRAM_FADE_IN_RATE, 0., 1.);
     }
     #endif

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -89,7 +89,11 @@ void main() {
         vec2 position_snap = position.xy + ((step(0.5, position_fract) - position_fract) * position.w * 2. / u_resolution);
 
         // Animate the snapping to smooth the transition and make it less noticeable
-        position.xy = mix(position.xy, position_snap, clamp(u_view_pan_snap_timer * TANGRAM_VIEW_PAN_SNAP_RATE, 0., 1.));
+        #ifdef TANGRAM_VIEW_PAN_SNAP_RATE
+            position.xy = mix(position.xy, position_snap, clamp(u_view_pan_snap_timer * TANGRAM_VIEW_PAN_SNAP_RATE, 0., 1.));
+        #else
+            position.xy = position_snap;
+        #endif
     }
 
     gl_Position = position;

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -82,5 +82,8 @@ void main() {
     // Device pixel ratio adjustment is because shape is in logical pixels
     position.xy += shape * position.w * 2. * u_device_pixel_ratio / u_resolution;
 
+    // Snap to pixel grid
+    position.xy = (floor(((position.xy * position.w) + 1.) * u_resolution * .5)) / (position.w * u_resolution * .5) - 1.;
+
     gl_Position = position;
 }

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -6,7 +6,8 @@ uniform float u_tile_proxy_depth;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 uniform float u_visible_time;
-uniform bool u_fade_in;
+uniform bool u_view_panning;
+uniform float u_view_pan_snap_timer;
 
 uniform mat4 u_model;
 uniform mat4 u_modelView;
@@ -82,8 +83,14 @@ void main() {
     // Device pixel ratio adjustment is because shape is in logical pixels
     position.xy += shape * position.w * 2. * u_device_pixel_ratio / u_resolution;
 
-    // Snap to pixel grid
-    position.xy = (floor(((position.xy * position.w) + 1.) * u_resolution * .5)) / (position.w * u_resolution * .5) - 1.;
+    // Snap to pixel grid - only applied to fully upright sprites/labels, while panning is not active
+    if (!u_view_panning && abs(theta) < TANGRAM_EPSILON) {
+        vec2 position_fract = fract((((position.xy / position.w) + 1.) * .5) * u_resolution);
+        vec2 position_snap = position.xy + ((step(0.5, position_fract) - position_fract) * position.w * 2. / u_resolution);
+
+        // Animate the snapping to smooth the transition and make it less noticeable
+        position.xy = mix(position.xy, position_snap, clamp(u_view_pan_snap_timer * TANGRAM_VIEW_PAN_SNAP_RATE, 0., 1.));
+    }
 
     gl_Position = position;
 }

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -4,8 +4,6 @@ uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
-uniform float u_visible_time;
-uniform bool u_fade_in;
 
 uniform mat3 u_normalMatrix;
 uniform mat3 u_inverseNormalMatrix;

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -5,8 +5,6 @@ uniform vec4 u_tile_origin;
 uniform float u_tile_proxy_depth;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
-uniform float u_visible_time;
-uniform bool u_fade_in;
 
 uniform mat4 u_model;
 uniform mat4 u_modelView;

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -462,7 +462,7 @@ class MultiLine {
         this.lines = [];
 
         this.ellipsis = '...';
-        this.ellipsis_width = context.measureText(this.ellipsis).width;
+        this.ellipsis_width = Math.ceil(context.measureText(this.ellipsis).width);
 
         this.max_lines = max_lines;
         this.text_wrap = text_wrap;
@@ -600,7 +600,7 @@ class Line {
         this.chars = 0;
         this.text = '';
 
-        this.height = height;
+        this.height = Math.ceil(height);
         this.text_wrap = text_wrap;
     }
 

--- a/src/tile.js
+++ b/src/tile.js
@@ -545,7 +545,7 @@ export default class Tile {
 
         // Fade in labels according to proxy status, avoiding "flickering" where
         // labels quickly go from invisible back to visible
-        program.uniform('1i', 'u_fade_in', this.fade_in && this.proxied_as !== 'child');
+        program.uniform('1i', 'u_tile_fade_in', this.fade_in && this.proxied_as !== 'child');
     }
 
     // Slice a subset of keys out of a tile

--- a/src/utils/debug_settings.js
+++ b/src/utils/debug_settings.js
@@ -4,5 +4,7 @@ export default {
     // draws a green rectangle border within the texture box of a label
     draw_label_texture_boxes: false,
     // suppreses fade-in of labels
-    suppress_label_fade_in: false
+    suppress_label_fade_in: false,
+    // suppress animaton of label snap to pixel grid
+    suppress_label_snap_animation: false
 };


### PR DESCRIPTION
It was recently pointed out, in #453, that some of our label text is undesirably blurry, and further investigation showed that this is because labels are often not aligned to the screen's pixel grid.

This PR addresses this in two ways:

- When text is drawn to a Canvas, it should be aligned to the Canvas's pixel grid. Line heights and string widths from the context `measureText()` function (which can return fractional values) now have a ceiling applied.
- When text labels are positioned on screen (model, view, etc. matrices are applied), the text will often not be screen-aligned. These are now "snapped" to the pixel grid, inside the vertex shader. Snapping continuously can cause a distracting jitter effect, especially during panning. To ameliorate this, the snapping is:
  - Not applied when the map is actively panning.
  - Applied with a transition animation when the map stops panning. (Google Maps appears to do something similar.) If desired, the snap transition can be disabled with the `Tangram.debug.debugSettings.suppress_label_snap_animation` flag.

This results in significantly better text clarity, especially for non-retina displays, small font sizes, and non-Latin scripts:

![snap-to-pixel](https://cloud.githubusercontent.com/assets/16733/20727388/4fda2ae8-b647-11e6-9f9a-280c8a6e1b16.gif)

![eyaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/16733/20727431/718c8672-b647-11e6-9ffa-44c50d709394.png)

![nbgqrgsp92waaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/16733/20727433/7193e584-b647-11e6-9469-932d5e8f2244.png)

![1fwc9c81wk838a49sbutheockaaaaaelftksuqmcc](https://cloud.githubusercontent.com/assets/16733/20727432/71922afa-b647-11e6-9518-866f01a2c7b5.png)
