### PR TITLE
Bundleable and Renameable Tangram

### DIFF
--- a/build/shim.js
+++ b/build/shim.js
@@ -1,36 +1,41 @@
 // A Browserify plugin to save the source code of a standalone library
 // in a property of the library
-
 var through = require('through2');
-var uglify = require("uglify-js");
 
 var PROPERTY = '_worker_src'; // Property name of Tangram
 
 // export a Browserify plugin
 module.exports = function (browserify, opts) {
+    browserify.on("bundle", function(){
+        var first = true;
 
-    // Intercept standalone UMD wrapper
-    var first = true;
-    var wrap = through.obj(function (row, enc, next) {
-        if (first){
-            // When Tangram is placed on the global object, create a property containing
-            // its stringified source code
-            var str = row.toString();
-            var replaceStr = 'g.Tangram = f(); g.Tangram.' + PROPERTY + ' = f.toString()';
-            str = str.replace('g.Tangram = f()', replaceStr);
-            first = false;
-            row = new Buffer(str);
-        }
+        // Intercept standalone UMD wrapper
+        var wrap = through.obj(function (row, enc, next) {
+            if (first){
+                var searchStr = replaceStr = '';
 
-        this.push(row);
-        next();
-    });
+                // When Tangram is placed on the global object, create a property containing
+                // its stringified source code
+                var str = row.toString();
 
-    browserify.pipeline.get('wrap').push(wrap);
+                // for attaching to window Tangram object
+                searchStr = 'g.Tangram = f()';
+                replaceStr = searchStr + '; g.Tangram.source.' + PROPERTY + ' = f.toString()';
+                str = str.replace(searchStr, replaceStr);
 
-    // Allows live-reload by continually building Tangram
-    browserify.on("reset", function () {
-        first = true;
-        browserify.pipeline.get("wrap").push(wrap);
+                // for attaching to CommonJS required-in Tangram (with a blank source field)
+                searchStr = 'module.exports=f()';
+                replaceStr = searchStr + '; if (module.exports.source !== undefined){ module.exports.source.' + PROPERTY + ' = f.toString()}';
+                str = str.replace(searchStr, replaceStr);
+
+                first = false;
+                row = new Buffer(str);
+            }
+
+            this.push(row);
+            next();
+        });
+
+        browserify.pipeline.get('wrap').unshift(wrap);
     });
 };

--- a/build/shim.js
+++ b/build/shim.js
@@ -1,0 +1,36 @@
+// A Browserify plugin to save the source code of a standalone library
+// in a property of the library
+
+var through = require('through2');
+var uglify = require("uglify-js");
+
+var PROPERTY = '_worker_src'; // Property name of Tangram
+
+// export a Browserify plugin
+module.exports = function (browserify, opts) {
+
+    // Intercept standalone UMD wrapper
+    var first = true;
+    var wrap = through.obj(function (row, enc, next) {
+        if (first){
+            // When Tangram is placed on the global object, create a property containing
+            // its stringified source code
+            var str = row.toString();
+            var replaceStr = 'g.Tangram = f(); g.Tangram.' + PROPERTY + ' = f.toString()';
+            str = str.replace('g.Tangram = f()', replaceStr);
+            first = false;
+            row = new Buffer(str);
+        }
+
+        this.push(row);
+        next();
+    });
+
+    browserify.pipeline.get('wrap').push(wrap);
+
+    // Allows live-reload by continually building Tangram
+    browserify.on("reset", function () {
+        first = true;
+        browserify.pipeline.get("wrap").push(wrap);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "karma-start": "./node_modules/karma/bin/karma start --browsers Chrome --no-watch",
     "karma-run": "./node_modules/karma/bin/karma run --browsers Chrome",
     "lint": "$(npm bin)/jshint src/ && jshint test/",
-    "build": "npm run build-bundle -- -o dist/tangram.debug.js && npm run build-minify",
+    "build": "npm run build-debug && npm run build-minify",
     "build-test": "npm run build-bundle -- -o dist/tangram.test.js",
     "build-debug": "npm run build-bundle -- -o dist/tangram.debug.js",
-    "build-bundle": "$(npm bin)/browserify src/module.js -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram -p browserify-derequire --debug",
+    "build-bundle": "$(npm bin)/browserify src/module.js -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram -p browserify-derequire -p './build/shim.js' --debug",
     "build-minify": "$(npm bin)/uglifyjs dist/tangram.debug.js -c warnings=false -m -o dist/tangram.min.js && npm run build-size",
     "build-size": "gzip dist/tangram.min.js -c | wc -c | awk '{kb=$1/1024; print kb}' OFMT='%.0fk minified+gzipped'",
-    "watch": "$(npm bin)/budo src/module.js:dist/tangram.debug.js --port 8000 --cors --live -- -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram"
+    "watch": "$(npm bin)/budo src/module.js:dist/tangram.debug.js --port 8000 --cors --live -- -t [ babelify --presets [ es2015 ] ] -t brfs -p './build/shim.js' -s Tangram"
   },
   "author": {
     "name": "Mapzen",

--- a/src/module.js
+++ b/src/module.js
@@ -1,5 +1,4 @@
 /*jshint worker: true*/
-
 import './utils/polyfills';
 
 // The leaflet layer plugin is currently the primary public API
@@ -35,6 +34,7 @@ import Collision from './labels/collision';
 import FeatureSelection from './selection';
 import CanvasText from './styles/text/canvas_text';
 import debugSettings from './utils/debug_settings';
+import source from './source'; // pointer to Tangram source code for loading workers
 
 import yaml from 'js-yaml';
 import JSZip from 'jszip';
@@ -80,5 +80,6 @@ if (Thread.is_main) {
 module.exports = {
     leafletLayer,
     debug,
-    version
+    version,
+    source
 };

--- a/src/scene.js
+++ b/src/scene.js
@@ -19,6 +19,7 @@ import FeatureSelection from './selection';
 import RenderStateManager from './gl/render_state';
 import FontManager from './styles/text/font_manager';
 import MediaCapture from './utils/media_capture';
+import source from './source';
 
 // Load scene definition: pass an object directly, or a URL as string to load remotely
 export default class Scene {
@@ -244,8 +245,16 @@ export default class Scene {
 
     // Get the URL to load the web worker from
     getWorkerUrl() {
-        let worker_url = URLs.createObjectURL(new Blob(['(' + Tangram._worker_src + ')()'], { type: 'application/javascript' }));
-        delete Tangram._worker_src;
+        let worker_url;
+        if (source._worker_src){
+            // load from source object using browserify shim (preferred)
+            worker_url = URLs.createObjectURL(new Blob(['(' + source._worker_src + ')()'], { type: 'application/javascript' }));
+            delete source._worker_src;
+        }
+        else {
+            // hardcode distribution build names (not preferred)
+            worker_url = this.worker_url || URLs.findCurrentURL('tangram.debug.js', 'tangram.min.js');
+        }
 
         if (!worker_url) {
             throw new Error("Can't load worker because couldn't find base URL that library was loaded from");

--- a/src/scene.js
+++ b/src/scene.js
@@ -244,7 +244,8 @@ export default class Scene {
 
     // Get the URL to load the web worker from
     getWorkerUrl() {
-        let worker_url = this.worker_url || URLs.findCurrentURL('tangram.debug.js', 'tangram.min.js');
+        let worker_url = URLs.createObjectURL(new Blob(['(' + Tangram._worker_src + ')()'], { type: 'application/javascript' }));
+        delete Tangram._worker_src;
 
         if (!worker_url) {
             throw new Error("Can't load worker because couldn't find base URL that library was loaded from");

--- a/src/source.js
+++ b/src/source.js
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
This PR allows Tangram to be imported/required in as a CommonJS module. In addition it allows the distribution files (`tangram.debug.js`, `tangram.min.js`) to be renamed by the end user. 

Previously this was not allowed because our Web Workers needed a pre-defined filename to load their source code from. Now this source code is generated at runtime by getting the source code from within our UMD build by calling the `Function.prototype.toString` method. We intercept Browserify's bundling step to do this with a rather fragile string replacement. Another way to do this is to wrap Tangram in a self-executing function and call `arguments.callee.toString()` to get the source code, but there is no way I've found to do this without leaking a global variable.

I've confirmed that this build works both for Tangram development (which uses `Tangram` on the `window` object), and on Mapzen.js and Tangram-play by importing Tangram (using a local CommonJS build).

We can now look to putting Tangram on the NPM registry, and having Mapzen.js and Tangram-play use this method of importing Tangram so they can be bundled with Tangram.