### PR TITLE
Styles can specify default `draw` parameters

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -89,6 +89,13 @@ styles:
                 filter: |
                     color.rgb *= 1.25; // pump up the colors
                     color.a = 0.5;     // translucent
+        draw: # default draw parameters
+            color: function() { return feature.colour || 'gray'; }
+            width: 6px
+            outline:
+                color: [.8, .8, .8]
+                width: 1px
+            interactive: true
 
     rainbow:
         base: polygons
@@ -747,18 +754,6 @@ layers:
             lines:
                 style: transit-lines
                 order: 400
-                color: gray
-                width: 6px
-                outline:
-                    color: [.8, .8, .8]
-                    width: 1px
-                interactive: true
-
-        colored:
-            filter: { colour: true }
-            draw:
-                lines:
-                    color: function() { return feature.colour; }
 
     # schools:
     #     data: { source: schools }

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -86,7 +86,8 @@ class Layer {
         // Denormalize layer name to draw groups
         if (this.draw) {
             for (let group in this.draw) {
-                if (this.draw[group] == null || typeof this.draw[group] !== 'object') {
+                this.draw[group] = (this.draw[group] == null) ? {} : this.draw[group];
+                if (typeof this.draw[group] !== 'object') {
                     // Invalid draw group
                     let msg = `Draw group '${group}' for layer ${this.full_name} is invalid, must be an object, `;
                     msg += `but was set to \`${group}: ${this.draw[group]}\` instead`;

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -382,6 +382,8 @@ export function calculateDraw(layer) {
 
 export function parseLayerTree(name, layer, parent, styles) {
 
+    layer = (layer == null) ? {} : layer;
+
     let properties = { name, layer, parent };
     let [whiteListed, nonWhiteListed] = groupProps(layer);
     let empty = isEmpty(nonWhiteListed);

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -9,6 +9,7 @@ import Material from '../material';
 import Light from '../light';
 import {RasterTileSource} from '../sources/raster';
 import log from '../utils/log';
+import mergeObjects from '../utils/merge';
 import Thread from '../utils/thread';
 import WorkerBroker from '../utils/worker_broker';
 
@@ -234,6 +235,11 @@ export var Style = {
     preprocess (draw) {
         // Preprocess first time
         if (!draw.preprocessed) {
+            // Apply draw defaults
+            if (this.draw) {
+                mergeObjects(draw, this.draw);
+            }
+
             draw = this._preprocess(draw); // optional subclass implementation
             if (!draw) {
                 return;

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -134,6 +134,11 @@ export class StyleManager {
         style.defines = Object.assign({}, ...sources.map(x => x.defines).filter(x => x)); // internal defines (not user-defined)
         style.material = Object.assign({}, ...sources.map(x => x.material).filter(x => x));
 
+        let draws = sources.map(x => x.draw).filter(x => x); // draw defaults
+        if (draws.length > 0) {
+            style.draw = mergeObjects({}, ...draws);
+        }
+
         // Mix shader properties
         this.mixShaders(style, styles, sources);
         return style;


### PR DESCRIPTION
Allows a rendering style to include defaults for `draw` parameters (that can then be overridden or supplemented as normal when the style is used in a draw group under `layers`).  See #489 for background.

Example, setting a default `size` for icons:

```
styles:
  # setting up style with default draw size
  icons:
    base: points
    texture: icons
    draw:
      size: 16px # default size

layers:
  ...
  draw:
    # drawing style with default size, plus setting sprite
    icons:
      sprite: coffee
```

This new capability does raise an unusual syntax issue though, which is that in some cases, the style definition may now include *all* the required draw parameters, but a draw group referencing that style must still be added in `layers` to invoke the actual draw operation.

With current Tangram JS behavior (unsure about ES), a `null` draw group will fail validation, and nothing will be drawn. Therefore, adding an all-default draw group requires this syntax:

```
layers:
  ...
  draw:
    icons: {} # draw with defaults
```

This branch also **relaxes** the handling of `null` draw groups, so that they *are* registered as valid draw groups (assuming they satisfy all required parameters after draw group defaults and merging are applied). This makes the following alternative syntax also valid:

```
layers:
  ...
  draw:
    icons: # draw with defaults
```

While both the empty object and `null` syntax are a bit awkward, I thought it was slightly better to provide this more streamlined option, and simply treat `null` draw groups as empty objects.

A more complex example is included in the bundled demo, for colored transit lines (based on OSM tags in Mapzen tiles):

```
styles:
     transit-lines:
         base: lines
         blend: overlay
         blend_order: -2
         shaders:
             blocks:
                 filter: |
                     color.rgb *= 1.25; // pump up the colors
                     color.a = 0.5;     // translucent
         draw: # default draw parameters
             color: function() { return feature.colour || 'gray'; }
             width: 6px
             outline:
                 color: [.8, .8, .8]
                 width: 1px
             interactive: true
```