### PR TITLE
Oriented offsets for boundary lines

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -522,11 +522,6 @@ layers:
     pois:
         data: { source: mapzen }
 
-        # all POIs are interactive
-        draw:
-            icons:
-                interactive: true
-
         parks:
             filter:
                 kind: [park, cemetery, graveyard]
@@ -573,6 +568,7 @@ layers:
             draw:
                 icons:
                     size: [[13, 12px], [15, 18px]]
+                    interactive: true
                     priority: 6
 
             # add text label at higher zoom

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -134,6 +134,13 @@ styles:
             emission:
                 texture: images/sunset.jpg
                 mapping: spheremap
+    uv:
+        base: lines
+        texcoords: true
+        shaders:
+            blocks:
+                color: |
+                    color.rgb = vec3(v_texcoord.x, v_texcoord.y, 0.);
 
 sources:
     mapzen:
@@ -184,7 +191,6 @@ layers:
 
     earth:
         data: { source: mapzen }
-
         fill:
             filter: { $geometry: polygon }
             enabled: false
@@ -206,7 +212,34 @@ layers:
                         stroke: { color: white, width: 4 }
                         transform: uppercase
 
-
+    # region:
+    #     filter:
+    #         any:
+    #             - kind: [region,macroregion]
+    #             - kind_detail: [3,4]
+    #     draw:
+    #         lines:
+    #             # style: uvs
+    #             color: global.region_boundary
+    #             width: [[0, 0.5px], [2, 1.0px], [5, 1.25px], [6, 1.5px], [7, 1.75px], [8, 2.0px], [9, 3.5px], [14, 5.5px], [16, 6.5px], [17, 16m]]
+    #             width: 10px
+    #     labels-z9-up:
+    #         # filter: { name: true, $zoom: { min: 9 }, not: { maritime_boundary: true } }
+    #         draw:
+    #             text-blend-order:
+    #                 priority: 1
+    #                 # visible: true
+    #                 # text_source: global.ux_language_text_source_boundary_lines
+    #                 text_source: 'name:right'
+    #                 offset: [0, 12px]
+    #                 anchor: top
+    #                 font:
+    #                     # family: Varela
+    #                     size: 12px
+    #                     weight: 200
+    #                     fill: [0.4,0.4,0.4]
+    #                     # stroke: { color: global.text_stroke, width: 4 }
+    #                     transform: uppercase
     landuse:
         data: { source: mapzen }
         filter:
@@ -639,17 +672,35 @@ layers:
                 lines:
                     visible: true
                     color: [0.824, 0.651, 0.329, 1.00]
-            water:
-                filter: { maritime_boundary: true }
-                draw: { lines: { visible: false } }
 
         region:
             filter: { kind: [region, macroregion] }
-            draw: { lines: { visible: true } }
-            water:
-                filter: { maritime_boundary: true }
-                draw: { lines: { visible: false } }
-
+            visible: true
+            draw:
+                lines:
+                    style: uv
+                    width: 5px
+                points:
+                    color: red
+                    size: 5px
+                text1:
+                    style: text
+                    text_source: 'name:right'
+                    offset: [0, 10px]
+                    font:
+                        size: 12px
+                        weight: 200
+                        fill: [.4,.4,.4]
+                        transform: uppercase
+                text2:
+                    style: text
+                    text_source: 'name:left'
+                    offset: [0, 10px]
+                    font:
+                        size: 12px
+                        weight: 200
+                        fill: [.4,.4,.4]
+                        transform: uppercase
     places:
         data: { source: mapzen }
 

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -650,6 +650,27 @@ layers:
                 filter: { maritime_boundary: true }
                 draw: { lines: { visible: false } }
 
+        labels:
+            filter: { kind: [region, macroregion, country] }
+            draw:
+                text:
+                    interactive: true
+                    text_source: global.language_text_source
+                    font:
+                        family: Montserrat
+                        transform: uppercase
+                        fill: black
+
+            # dual-sided border labels where available
+            dual:
+                filter: { 'name:left': true, 'name:right': true }
+                draw:
+                    text:
+                        priority: 1
+                        text_source:
+                            left: ['name:left:en', 'name:left']
+                            right: ['name:right:en', 'name:right']
+
     places:
         data: { source: mapzen }
 

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -134,13 +134,6 @@ styles:
             emission:
                 texture: images/sunset.jpg
                 mapping: spheremap
-    uv:
-        base: lines
-        texcoords: true
-        shaders:
-            blocks:
-                color: |
-                    color.rgb = vec3(v_texcoord.x, v_texcoord.y, 0.);
 
 sources:
     mapzen:
@@ -191,6 +184,7 @@ layers:
 
     earth:
         data: { source: mapzen }
+
         fill:
             filter: { $geometry: polygon }
             enabled: false
@@ -212,34 +206,7 @@ layers:
                         stroke: { color: white, width: 4 }
                         transform: uppercase
 
-    # region:
-    #     filter:
-    #         any:
-    #             - kind: [region,macroregion]
-    #             - kind_detail: [3,4]
-    #     draw:
-    #         lines:
-    #             # style: uvs
-    #             color: global.region_boundary
-    #             width: [[0, 0.5px], [2, 1.0px], [5, 1.25px], [6, 1.5px], [7, 1.75px], [8, 2.0px], [9, 3.5px], [14, 5.5px], [16, 6.5px], [17, 16m]]
-    #             width: 10px
-    #     labels-z9-up:
-    #         # filter: { name: true, $zoom: { min: 9 }, not: { maritime_boundary: true } }
-    #         draw:
-    #             text-blend-order:
-    #                 priority: 1
-    #                 # visible: true
-    #                 # text_source: global.ux_language_text_source_boundary_lines
-    #                 text_source: 'name:right'
-    #                 offset: [0, 12px]
-    #                 anchor: top
-    #                 font:
-    #                     # family: Varela
-    #                     size: 12px
-    #                     weight: 200
-    #                     fill: [0.4,0.4,0.4]
-    #                     # stroke: { color: global.text_stroke, width: 4 }
-    #                     transform: uppercase
+
     landuse:
         data: { source: mapzen }
         filter:
@@ -659,6 +626,7 @@ layers:
 
     boundaries:
         data: { source: mapzen}
+        visible: false
         draw:
             lines:
                 visible: false
@@ -672,35 +640,17 @@ layers:
                 lines:
                     visible: true
                     color: [0.824, 0.651, 0.329, 1.00]
+            water:
+                filter: { maritime_boundary: true }
+                visible: false
 
         region:
             filter: { kind: [region, macroregion] }
             visible: true
-            draw:
-                lines:
-                    style: uv
-                    width: 5px
-                points:
-                    color: red
-                    size: 5px
-                text1:
-                    style: text
-                    text_source: 'name:right'
-                    offset: [0, 10px]
-                    font:
-                        size: 12px
-                        weight: 200
-                        fill: [.4,.4,.4]
-                        transform: uppercase
-                text2:
-                    style: text
-                    text_source: 'name:left'
-                    offset: [0, 10px]
-                    font:
-                        size: 12px
-                        weight: 200
-                        fill: [.4,.4,.4]
-                        transform: uppercase
+            water:
+                filter: { maritime_boundary: true }
+                visible: false
+
     places:
         data: { source: mapzen }
 
@@ -740,6 +690,7 @@ layers:
                         fill: [0, 0, 0, .8]
                         stroke: { color: white, width: 4 }
                         transform: uppercase
+            visible: false
 
             countries:
                 filter:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -522,6 +522,11 @@ layers:
     pois:
         data: { source: mapzen }
 
+        # all POIs are interactive
+        draw:
+            icons:
+                interactive: true
+
         parks:
             filter:
                 kind: [park, cemetery, graveyard]
@@ -568,7 +573,6 @@ layers:
             draw:
                 icons:
                     size: [[13, 12px], [15, 18px]]
-                    interactive: true
                     priority: 6
 
             # add text label at higher zoom
@@ -622,7 +626,6 @@ layers:
 
     boundaries:
         data: { source: mapzen}
-        visible: false
         draw:
             lines:
                 visible: false
@@ -638,14 +641,14 @@ layers:
                     color: [0.824, 0.651, 0.329, 1.00]
             water:
                 filter: { maritime_boundary: true }
-                visible: false
+                draw: { lines: { visible: false } }
 
         region:
             filter: { kind: [region, macroregion] }
-            visible: true
+            draw: { lines: { visible: true } }
             water:
                 filter: { maritime_boundary: true }
-                visible: false
+                draw: { lines: { visible: false } }
 
     places:
         data: { source: mapzen }
@@ -686,7 +689,6 @@ layers:
                         fill: [0, 0, 0, .8]
                         stroke: { color: white, width: 4 }
                         transform: uppercase
-            visible: false
 
             countries:
                 filter:

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -15,6 +15,9 @@ let LabelLine = {
     // Given a label's bounding box size and size broken up into individual segments
     // return a label that fits along a line geometry
     create : function(segment_size, total_size, line, layout){
+
+        // if (layout.text === 'Montana') debugger
+
         // The passes done for fitting a label, and provided tolerances for each pass
         const passes = [
             { type: 'straight', tolerance : (layout.no_curving) ? LINE_EXCEED_STRAIGHT_NO_CURVE : LINE_EXCEED_STRAIGHT },
@@ -62,8 +65,9 @@ class LabelLineBase {
         let current_line = [line[0]];
         let current_length = 0;
         let max_length = 0;
-        let orientation = 1;
+        let orientation = 0;
         let longest_line = current_line;
+        let longest_orientation = orientation;
 
         for (let i = 1; i < line.length; i++) {
             let pt = line[i];
@@ -78,6 +82,7 @@ class LabelLineBase {
                     if (current_length > max_length){
                         longest_line = current_line;
                         max_length = current_length;
+                        longest_orientation = orientation;
                     }
                 }
                 else {
@@ -86,6 +91,7 @@ class LabelLineBase {
                     if (current_length > max_length){
                         longest_line = current_line;
                         max_length = current_length;
+                        longest_orientation = 1;
                     }
                     orientation = 1;
                 }
@@ -107,17 +113,22 @@ class LabelLineBase {
                     if (current_length > max_length){
                         longest_line = current_line;
                         max_length = current_length;
+                        longest_orientation = -1;
                     }
                     orientation = -1;
                 }
             }
             else {
                 // vertical line (doesn't change previous orientation)
+                orientation = (prev_pt[1] < pt[1]) ? 1 : -1;
+
                 current_length += length;
                 if (current_length > max_length){
                     longest_line = current_line;
                     max_length = current_length;
+                    longest_orientation = orientation;
                 }
+
                 if (orientation === -1){
                     current_line.unshift(pt);
                 }
@@ -125,10 +136,14 @@ class LabelLineBase {
                     current_line.push(pt);
                     orientation = 1;
                 }
+
+                if (longest_orientation === 0) {
+                    longest_orientation = orientation;
+                }
             }
         }
 
-        return longest_line;
+        return [longest_line, longest_orientation];
     }
 
     // Adds each segment to the collision pass as its own bounding box
@@ -184,7 +199,6 @@ class LabelLineBase {
 
         // apply offset, x positive, y pointing down
         if (offset && (offset[0] !== 0 || offset[1] !== 0)) {
-            offset = Vector.rot(offset, angle);
             p0 += offset[0] * upp;
             p1 -= offset[1] * upp;
         }
@@ -207,18 +221,17 @@ class LabelLineStraight extends LabelLineBase {
     fit (size, line, layout, tolerance){
         let upp = layout.units_per_pixel;
 
-        line = LabelLineBase.splitLineByOrientation(line);
-        let line_lengths = getLineLengths(line);
+        let [oriented_line, orientation] = LabelLineBase.splitLineByOrientation(line);
+        // let oriented_line = line;
+        // let orientation = 1;
 
-        let curr_angle = getAngleForSegment(line[0], line[1]);
+        let line_lengths = getLineLengths(oriented_line);
+
+        let curr_angle = getAngleForSegment(oriented_line[0], oriented_line[1]);
         let label_length = size[0] * upp;
 
-        if (curr_angle <= Math.PI/2) {
-            curr_angle += 2 * Math.PI;
-        }
-
-        for (let i = 0; i < line.length - 1; i++){
-            let curr = line[i];
+        for (let i = 0; i < oriented_line.length - 1; i++){
+            let curr = oriented_line[i];
 
             let curve_tolerance = 0;
             let length = 0;
@@ -226,18 +239,14 @@ class LabelLineStraight extends LabelLineBase {
             let prev_angle;
 
             // Look ahead to further line segments within an angle tolerance
-            while (ahead_index < line.length){
-                let ahead_curr = line[ahead_index - 1];
-                let ahead_next = line[ahead_index];
+            while (ahead_index < oriented_line.length){
+                let ahead_curr = oriented_line[ahead_index - 1];
+                let ahead_next = oriented_line[ahead_index];
 
                 let next_angle = getAngleForSegment(ahead_curr, ahead_next);
 
-                if (next_angle <= Math.PI/2) {
-                    next_angle += 2 * Math.PI;
-                }
-
                 if (ahead_index !== i + 1){
-                    curve_tolerance += next_angle - prev_angle;
+                    curve_tolerance += getAbsAngleDiff(next_angle, prev_angle);
                 }
 
                 if (Math.abs(curve_tolerance) > STRAIGHT_ANGLE_TOLERANCE){
@@ -250,9 +259,24 @@ class LabelLineStraight extends LabelLineBase {
                     let currMid = Vector.mult(Vector.add(curr, ahead_next), 0.5);
 
                     // TODO: modify angle if line chosen within curve_angle_tolerance
+
+                    if (this.layout.text === "Colorado") console.log(orientation)
+
                     this.angle = -next_angle;
+                    this.angle_offset = this.angle;
+
+                    if (orientation === -1){
+                        this.angle_offset += Math.PI;
+                    }
+
+                    if (layout.direction === 'left'){
+                        this.angle_offset += Math.PI;
+                    }
+
                     this.position = currMid;
-                    this.updateBBoxes(size);
+                    this.offset = Vector.rot(this.offset, this.angle_offset);
+
+                    this.updateBBoxes(this.position, size, this.angle, this.offset);
                     if (this.inTileBounds()) {
                         return true;
                     }
@@ -267,7 +291,7 @@ class LabelLineStraight extends LabelLineBase {
     }
 
     // Calculate bounding boxes
-    updateBBoxes(size) {
+    updateBBoxes(position, size, angle, offset) {
         let upp = this.layout.units_per_pixel;
 
         // reset bounding boxes
@@ -277,7 +301,7 @@ class LabelLineStraight extends LabelLineBase {
         let width = (size[0] + 2 * this.layout.buffer[0]) * upp * Label.epsilon;
         let height = (size[1] + 2 * this.layout.buffer[1]) * upp * Label.epsilon;
 
-        let obb = LabelLineBase.createOBB(this.position, width, height, this.angle, this.offset, upp);
+        let obb = LabelLineBase.createOBB(position, width, height, angle, offset, upp);
         let aabb = obb.getExtent();
 
         this.obbs.push(obb);
@@ -301,9 +325,9 @@ class LabelLineCurved extends LabelLineBase {
 
     fit (size, line, layout){
         let upp = layout.units_per_pixel;
-        line = LabelLineBase.splitLineByOrientation(line);
+        let [oriented_line, orientation] = LabelLineBase.splitLineByOrientation(line);
 
-        let line_lengths = getLineLengths(line);
+        let line_lengths = getLineLengths(oriented_line);
         let label_lengths = size.map(function(size){ return size[0] * upp; });
 
         let total_line_length = line_lengths.reduce(function(prev, next){ return prev + next; }, 0);
@@ -315,20 +339,20 @@ class LabelLineCurved extends LabelLineBase {
 
         // starting position
         let height = size[0][1] * upp;
-        let [start_index, end_index] = LabelLineCurved.checkTileBoundary(line, line_lengths, height, this.offset, upp);
+        let [start_index, end_index] = LabelLineCurved.checkTileBoundary(oriented_line, line_lengths, height, this.offset, upp);
 
         // need two line segments for a curved label
         if (end_index - start_index < 2){
             return false;
         }
 
-        let anchor_index = LabelLineCurved.curvaturePlacement(line, total_line_length, line_lengths, total_label_length, start_index, end_index);
+        let anchor_index = LabelLineCurved.curvaturePlacement(oriented_line, total_line_length, line_lengths, total_label_length, start_index, end_index);
 
         if (anchor_index === -1 || end_index - anchor_index < 2){
             return false;
         }
 
-        let anchor = line[anchor_index];
+        let anchor = oriented_line[anchor_index];
         this.position = anchor;
 
         // Can be made faster since we are computing every segment for every zoom stop
@@ -341,7 +365,7 @@ class LabelLineCurved extends LabelLineBase {
             for (var j = 0; j < STOPS.length; j++){
                 let stop = STOPS[j];
 
-                let [new_line, line_lengths] = LabelLineCurved.scaleLine(stop, line);
+                let [new_line, line_lengths] = LabelLineCurved.scaleLine(stop, oriented_line);
                 anchor = new_line[anchor_index];
 
                 let {positions, offsets, angles, pre_angles} = LabelLineCurved.placeAtIndex(anchor_index, new_line, line_lengths, label_lengths);
@@ -394,7 +418,7 @@ class LabelLineCurved extends LabelLineBase {
         while (start < end){
             let angle = getAngleForSegment(line[start], line[start + 1]);
             let position = Vector.add(Vector.rot([start_width/2, 0], angle), line[start]);
-            let obb = LabelLineBase.createOBB(position, start_width, height, -angle, offset, upp);
+            let obb = LabelLineBase.createOBB(position, start_width, height, -angle, -angle, offset, upp);
             let aabb = obb.getExtent();
             let in_tile = Label.prototype.inTileBounds.call({ aabb });
             if (in_tile) {
@@ -409,7 +433,7 @@ class LabelLineCurved extends LabelLineBase {
         while (end > start){
             let angle = getAngleForSegment(line[end - 1], line[end]);
             let position = Vector.add(Vector.rot([-end_width/2, 0], angle), line[end]);
-            let obb = LabelLineBase.createOBB(position, end_width, height, -angle, offset, upp);
+            let obb = LabelLineBase.createOBB(position, end_width, height, -angle, -angle, offset, upp);
             let aabb = obb.getExtent();
             let in_tile = Label.prototype.inTileBounds.call({ aabb });
             if (in_tile) {
@@ -650,13 +674,13 @@ class LabelLineCurved extends LabelLineBase {
 
     // Modify the LabelLineStraight method to include a distiction between an offset angle, and rotation angle
     // as these may be different. (Offset angle is constant for the entire label, while rotation angles are not.)
-    static createOBB (position, width, height, offset, angle, angle_curve, upp) {
+    static createOBB (position, width, height, offset, angle_offset, angle_curve, upp) {
         let p0 = position[0];
         let p1 = position[1];
 
         // apply offset, x positive, y pointing down
         if (offset && (offset[0] !== 0 || offset[1] !== 0)) {
-            offset = Vector.rot(offset, angle);
+            offset = Vector.rot(offset, angle_offset);
             p0 += offset[0] * upp;
             p1 -= offset[1] * upp;
         }
@@ -689,4 +713,22 @@ function getLineLengths(line){
         lengths.push(length);
     }
     return lengths;
+}
+
+function getAbsAngleDiff(angle1, angle2){
+    let small, big;
+    if (angle1 > angle2){
+        small = angle2;
+        big = angle1;
+    }
+    else {
+        small = angle1;
+        big = angle2;
+    }
+
+    while (big - small > Math.PI){
+        small += 2 * Math.PI;
+    }
+
+    return Math.abs(big - small);
 }

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -325,7 +325,17 @@ class LabelLineCurved extends LabelLineBase {
 
     fit (size, line, layout){
         let upp = layout.units_per_pixel;
-        let [oriented_line] = LabelLineBase.splitLineByOrientation(line);
+        let [oriented_line, flipped] = LabelLineBase.splitLineByOrientation(line);
+
+        let offset = this.offset.slice();
+
+        if (flipped){
+            this.offset[1] *= -1;
+        }
+
+        if (layout.direction == 'left'){
+            this.offset[1] *= -1;
+        }
 
         let line_lengths = getLineLengths(oriented_line);
         let label_lengths = size.map(function(size){ return size[0] * upp; });
@@ -380,12 +390,21 @@ class LabelLineCurved extends LabelLineBase {
                 if (stop === 0){
                     for (let i = 0; i < positions.length; i++){
                         let position = positions[i];
-                        let offset_angle = angles[i];
+
                         let pre_angle = pre_angles[i];
                         let width = label_lengths[i];
-                        let angle_curve = pre_angle + offset_angle;
+                        let angle_curve = pre_angle + angles[i];
+                        let angle_offset = this.angle;
 
-                        let obb = LabelLineCurved.createOBB(position, width, height, this.offset, this.angle, angle_curve, upp);
+                        if (flipped){
+                            angle_offset += Math.PI;
+                        }
+
+                        if (layout.direction === 'left'){
+                            angle_offset += Math.PI;
+                        }
+
+                        let obb = LabelLineCurved.createOBB(position, width, height, offset, angle_offset, angle_curve, upp);
                         let aabb = obb.getExtent();
 
                         this.obbs.push(obb);

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -226,7 +226,7 @@ class LabelLineStraight extends LabelLineBase {
             this.offset[1] *= -1;
         }
 
-        if (layout.direction == 'left'){
+        if (layout.orientation == 'left'){
             this.offset[1] *= -1;
         }
 
@@ -269,7 +269,7 @@ class LabelLineStraight extends LabelLineBase {
                         angle_offset += Math.PI;
                     }
 
-                    if (layout.direction === 'left'){
+                    if (layout.orientation === 'left'){
                         angle_offset += Math.PI;
                     }
 
@@ -333,7 +333,7 @@ class LabelLineCurved extends LabelLineBase {
             this.offset[1] *= -1;
         }
 
-        if (layout.direction == 'left'){
+        if (layout.orientation == 'left'){
             this.offset[1] *= -1;
         }
 
@@ -400,7 +400,7 @@ class LabelLineCurved extends LabelLineBase {
                             angle_offset += Math.PI;
                         }
 
-                        if (layout.direction === 'left'){
+                        if (layout.orientation === 'left'){
                             angle_offset += Math.PI;
                         }
 

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -10,6 +10,7 @@ const STRAIGHT_ANGLE_TOLERANCE = 0.1;       // multiple "almost straight" segmen
 const CURVE_MIN_TOTAL_COST = 1.3;           // curved line total curvature tolerance (sum)
 const CURVE_MIN_AVG_COST = 0.4;             // curved line average curvature tolerance (mean)
 const CURVE_MAX_ANGLE = 1;                  // curved line singular curvature tolerance (value)
+const ORIENTED_LABEL_OFFSET_FACTOR = 1.2;   // multiply offset by this amount to avoid linked label collision
 
 let LabelLine = {
     // Given a label's bounding box size and size broken up into individual segments
@@ -218,6 +219,10 @@ class LabelLineStraight extends LabelLineBase {
 
         [line, flipped] = LabelLineBase.splitLineByOrientation(line);
 
+        if (typeof layout.orientation === 'number'){
+            this.offset[1] += ORIENTED_LABEL_OFFSET_FACTOR * (size[1] - layout.vertical_buffer);
+        }
+
         let offset = this.offset.slice();
 
         if (flipped){
@@ -326,6 +331,10 @@ class LabelLineCurved extends LabelLineBase {
         let flipped;
 
         [line, flipped] = LabelLineBase.splitLineByOrientation(line);
+
+        if (typeof layout.orientation === 'number'){
+            this.offset[1] += ORIENTED_LABEL_OFFSET_FACTOR * (size[1] - layout.vertical_buffer);
+        }
 
         let offset = this.offset.slice();
 

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -216,6 +216,13 @@ Object.assign(Points, {
             draw.text.visible !== false && // explicitly handle `visible` property for nested text
             this.parseTextFeature(feature, draw.text, context, tile);
 
+        if (Array.isArray(tf)) {
+            tf = null; // NB: boundary labels not supported for point label attachments, should log warning
+            log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}': ` +
+                `cannot use boundary labels (e.g. 'text_source: { left: ..., right: ... }') for 'text' labels attached to 'points'; ` +
+                `provided 'text_source' value was '${JSON.stringify(draw.text.text_source)}'`);
+        }
+
         if (tf) {
             tf.layout.parent = style; // parent point will apply additional anchor/offset to text
 

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -230,15 +230,7 @@ Object.assign(Points, {
             Collision.addStyle(this.collision_group_text, tile.key);
         }
 
-        // Queue the feature for processing
-        if (!this.tile_data[tile.key] || !this.queues[tile.key]) {
-            this.startData(tile);
-        }
-
-        this.queues[tile.key].push({
-            feature, draw, context, style,
-            text_feature: tf
-        });
+        this.queueFeature({ feature, draw, context, style, text_feature: tf }, tile); // queue the feature for later processing
 
         // Register with collision manager
         Collision.addStyle(this.collision_group_points, tile.key);
@@ -263,6 +255,14 @@ Object.assign(Points, {
         let sprite = StyleParser.evalProperty(draw.sprite, context);
         let sprite_info = this.getSpriteInfo(sprite) || this.getSpriteInfo(draw.sprite_default);
         return sprite_info;
+    },
+
+    // Queue features for deferred processing (collect all features first so we can do collision on the whole group)
+    queueFeature (q, tile) {
+        if (!this.tile_data[tile.key] || !this.queues[tile.key]) {
+            this.startData(tile);
+        }
+        this.queues[tile.key].push(q);
     },
 
     // Override

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -128,10 +128,10 @@ void main() {
             shape += rotate2D(offset, theta);   // offset if specified in the scene file
         }
         else {
-            shape = rotate2D(shape + offset, theta);
+            shape = rotate2D(shape, theta) + offset;
         }
     #else
-        shape = rotate2D(shape + offset, theta);
+        shape = rotate2D(shape, theta) + offset;
     #endif
 
     #ifdef TANGRAM_MULTI_SAMPLER

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -128,10 +128,10 @@ void main() {
             shape += rotate2D(offset, theta);   // offset if specified in the scene file
         }
         else {
-            shape = rotate2D(shape, theta) + offset;
+            shape = rotate2D(shape + offset, theta);
         }
     #else
-        shape = rotate2D(shape, theta) + offset;
+        shape = rotate2D(shape + offset, theta);
     #endif
 
     #ifdef TANGRAM_MULTI_SAMPLER

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -88,6 +88,7 @@ export default class CanvasText {
 
                         text_info.isRTL = rtl;
                         text_info.no_curving = bidi || shaped;
+                        text_info.vertical_buffer = this.vertical_text_buffer;
 
                         if (rtl) {
                             segments.reverse();

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -92,15 +92,32 @@ Object.assign(TextStyle, {
             return;
         }
 
-        q.feature = feature;
-        q.context = context;
-        q.layout.vertex = false; // vertex placement option not applicable to standalone labels
+        // text can be an array if a `left` or `right` orientation key is defined for the text source
+        // in which case, push both text sources to the queue
+        if (q instanceof Array){
+            q.forEach(function(q){
+                q.feature = feature;
+                q.context = context;
+                q.layout.vertex = false; // vertex placement option not applicable to standalone labels
 
-        // Queue the feature for processing
-        if (!this.tile_data[tile.key] || !this.queues[tile.key]) {
-            this.startData(tile);
+                // Queue the feature for processing
+                if (!this.tile_data[tile.key]) {
+                    this.startData(tile);
+                }
+                this.queues[tile.key].push(q);
+            }.bind(this));
         }
-        this.queues[tile.key].push(q);
+        else {
+            q.feature = feature;
+            q.context = context;
+            q.layout.vertex = false; // vertex placement option not applicable to standalone labels
+
+            // Queue the feature for processing
+            if (!this.tile_data[tile.key] || !this.queues[tile.key]) {
+                this.startData(tile);
+            }
+            this.queues[tile.key].push(q);
+        }
 
         // Register with collision manager
         Collision.addStyle(this.name, tile.key);
@@ -186,7 +203,6 @@ Object.assign(TextStyle, {
             if (text_info.text_settings.can_articulate){
                 var sizes = text_info.size.map(function(size){ return size.collision_size; });
                 fq.layout.no_curving = text_info.no_curving;
-                fq.layout.text = fq.text;
                 feature_labels = this.buildLabels(sizes, fq.feature.geometry, fq.layout, text_info.total_size.collision_size);
             }
             else {

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -186,6 +186,7 @@ Object.assign(TextStyle, {
             if (text_info.text_settings.can_articulate){
                 var sizes = text_info.size.map(function(size){ return size.collision_size; });
                 fq.layout.no_curving = text_info.no_curving;
+                fq.layout.text = fq.text;
                 feature_labels = this.buildLabels(sizes, fq.feature.geometry, fq.layout, text_info.total_size.collision_size);
             }
             else {

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -200,6 +200,9 @@ Object.assign(TextStyle, {
             let fq = feature_queue[f];
             let text_info = this.texts[tile_key][fq.text_settings_key][fq.text];
             let feature_labels;
+
+            fq.layout.vertical_buffer = text_info.vertical_buffer;
+
             if (text_info.text_settings.can_articulate){
                 var sizes = text_info.size.map(function(size){ return size.collision_size; });
                 fq.layout.no_curving = text_info.no_curving;

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -99,24 +99,14 @@ Object.assign(TextStyle, {
                 q.feature = feature;
                 q.context = context;
                 q.layout.vertex = false; // vertex placement option not applicable to standalone labels
-
-                // Queue the feature for processing
-                if (!this.tile_data[tile.key]) {
-                    this.startData(tile);
-                }
-                this.queues[tile.key].push(q);
+                this.queueFeature(q, tile); // queue the feature for later processing
             });
         }
         else {
             q.feature = feature;
             q.context = context;
             q.layout.vertex = false; // vertex placement option not applicable to standalone labels
-
-            // Queue the feature for processing
-            if (!this.tile_data[tile.key] || !this.queues[tile.key]) {
-                this.startData(tile);
-            }
-            this.queues[tile.key].push(q);
+            this.queueFeature(q, tile); // queue the feature for later processing
         }
 
         // Register with collision manager

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -95,7 +95,7 @@ Object.assign(TextStyle, {
         // text can be an array if a `left` or `right` orientation key is defined for the text source
         // in which case, push both text sources to the queue
         if (q instanceof Array){
-            q.forEach(function(q){
+            q.forEach(q => {
                 q.feature = feature;
                 q.context = context;
                 q.layout.vertex = false; // vertex placement option not applicable to standalone labels
@@ -105,7 +105,7 @@ Object.assign(TextStyle, {
                     this.startData(tile);
                 }
                 this.queues[tile.key].push(q);
-            }.bind(this));
+            });
         }
         else {
             q.feature = feature;

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -283,21 +283,20 @@ export const TextLabels = {
         // used to fudge width value as text may overflow bounding box if it has italic, bold, etc style
         layout.italic = (text_settings.style !== 'normal');
 
-        var source = draw.text_source || 'name';
+        // used to determine orientation of text if the text_source is a value like "name:left"
+        let text_source = draw.text_source || 'name';
 
-        if (typeof source === 'string') {
-            text = source;
-        } else if (typeof source === 'function') {
-            text = source(context);
+        if (typeof text_source === 'function') {
+            text_source = text_source(context);
         }
 
-        text = text.split(':');
-        if (text instanceof Array && text.length > 1) {
-            if (text[1] === 'right') {
-                layout.direction = 'right';
+        let oriented_text = text_source.split(':');
+        if (oriented_text instanceof Array && oriented_text.length > 1) {
+            if (oriented_text[1] === 'right') {
+                layout.orientation = 'right';
             }
-            else if (text[1] === 'left'){
-                layout.direction = 'left';
+            else if (oriented_text[1] === 'left'){
+                layout.orientation = 'left';
             }
         }
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -283,6 +283,24 @@ export const TextLabels = {
         // used to fudge width value as text may overflow bounding box if it has italic, bold, etc style
         layout.italic = (text_settings.style !== 'normal');
 
+        var source = draw.text_source || 'name';
+
+        if (typeof source === 'string') {
+            text = source;
+        } else if (typeof source === 'function') {
+            text = source(context);
+        }
+
+        text = text.split(':');
+        if (text instanceof Array && text.length > 1) {
+            if (text[1] === 'right') {
+                layout.direction = 'right';
+            }
+            else if (text[1] === 'left'){
+                layout.direction = 'left';
+            }
+        }
+
         return layout;
     }
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -48,7 +48,9 @@ export const TextLabels = {
             let results = [];
             for (let key in text){
                 let current_text = text[key];
-                if (!current_text) continue;
+                if (!current_text) {
+                    continue;
+                }
 
                 let layout = this.computeTextLayout({}, feature, draw, context, tile, current_text, text_settings, key);
                 if (!sizes[current_text]) {

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -46,13 +46,19 @@ export const TextLabels = {
 
         if (text instanceof Object){
             let results = [];
+
+            // add both left/right text elements to repeat group to improve repeat culling
+            // avoids one component of a boundary label (e.g. Colorado) being culled too aggressively when it also
+            // appears in nearby boundary labels (e.g. Colorado/Utah & Colorado/New Mexico repeat as separate groups)
+            let repeat_group_prefix = text.left + '-' + text.right; // NB: should be all text keys, not just left/right
+
             for (let key in text){
                 let current_text = text[key];
                 if (!current_text) {
                     continue;
                 }
 
-                let layout = this.computeTextLayout({}, feature, draw, context, tile, current_text, text_settings, key);
+                let layout = this.computeTextLayout({}, feature, draw, context, tile, current_text, text_settings, repeat_group_prefix, key);
                 if (!sizes[current_text]) {
                     // first label with this text/style/tile combination, make a new label entry
                     sizes[current_text] = {
@@ -305,7 +311,7 @@ export const TextLabels = {
     },
 
     // Additional text-specific layout settings
-    computeTextLayout (target, feature, draw, context, tile, text, text_settings, orientation) {
+    computeTextLayout (target, feature, draw, context, tile, text, text_settings, repeat_group_prefix, orientation) {
         let layout = target || {};
 
         // common settings w/points
@@ -319,8 +325,8 @@ export const TextLabels = {
 
         // repeat rules include the text
         if (layout.repeat_distance) {
-            if (text instanceof Array){
-                text = text.join('-');
+            if (repeat_group_prefix) {
+                layout.repeat_group += '/' + repeat_group_prefix;
             }
             layout.repeat_group += '/' + text;
         }

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -95,6 +95,23 @@ export const TextLabels = {
         let text;
         let source = draw.text_source || 'name';
 
+        if (source != null && typeof source === 'object') {
+            // left/right boundary labels
+            text = {};
+            for (let key in source) {
+                text[key] = this.parseTextSourceValue(source[key], feature, context);
+            }
+        }
+        else {
+            // single label
+            text = this.parseTextSourceValue(source, feature, context);
+        }
+
+        return text;
+    },
+
+    parseTextSourceValue (source, feature, context) {
+        let text;
         if (Array.isArray(source)) {
             for (let s=0; s < source.length; s++) {
                 if (typeof source[s] === 'string') {
@@ -104,25 +121,17 @@ export const TextLabels = {
                 }
 
                 if (text) {
-                    break; // stop if we found a text property
+                    return text; // stop if we found a text property
                 }
             }
         }
         else if (typeof source === 'string') {
             text = feature.properties[source];
-        } else if (source instanceof Function) {
+        }
+        else if (source instanceof Function) {
             text = source(context);
         }
-        else if (source instanceof Object){
-            text = {};
-            for (let key in source){
-                if (typeof source[key] === 'string') {
-                    text[key] = feature.properties[source[key]];
-                } else if (source[key] instanceof Function) {
-                    text[key] = source[key](context);
-                }
-            }
-        }
+
         return text;
     },
 


### PR DESCRIPTION
(cleaned up and rebased version of previous PR https://github.com/tangrams/tangram/pull/506)

This PR addresses #471 where we were not previously using the orientation of a line to modify an offset of a label. This allows a line label to remain on a specific side (inside or outside) of a polygon as it is placed around the polygon's boundary.

The offset will follow the geometry orientation if both an offset is specified and the text_source is given as an object with a `left`, and/or `right` key. For example

```
draw:
  text:
    text_source:
      left: 'name:left'
      right: ‘name:right'
    offset : [0, 10px]
```

![tangram-1489439469844](https://cloud.githubusercontent.com/assets/796394/23875515/eec9fefc-07f6-11e7-81f0-e8a0ea46063d.png)
