### PR TITLE
Correcting error typo in filter.js

### DIFF
--- a/src/styles/filter.js
+++ b/src/styles/filter.js
@@ -114,7 +114,7 @@ function parseFilter(filter, options) {
         } else if (value == null) {
             filterAST.push(nullValue(key, value));
         } else {
-            throw new Error('Unknown Query sytnax: ' + value);
+            throw new Error('Unknown Query syntax: ' + value);
         }
     }
 


### PR DESCRIPTION
As I'm playing around with the (super easy-to-use! really wonderful) tangram library, in the context of playing around with the new Walkabout mapping layer, I'm consistently seeing this error message and my eyes can't help but fixate on the typo. I realize this is not the most helpful kind of PR to receive, but I figured I'd post it anyways!