### PR TITLE
Rename layer `visible` -> `enabled` & don't allow descendant layers to override

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -212,10 +212,10 @@ Enjoy!
                         }
                     }
 
-                    scene.config.layers.earth.visible = true; // some custom shaders may need to render earth
+                    scene.config.layers.earth.fill.enabled = true; // some custom shaders may need to render earth
                 }
                 else {
-                    scene.config.layers.earth.visible = false; // don't need earth layer in default style
+                    scene.config.layers.earth.fill.enabled = false; // don't need earth layer in default style
                 }
             }
 
@@ -236,21 +236,21 @@ Enjoy!
             },
             'rainbow': {
                 setup: function (style) {
-                    scene.config.layers.earth.draw.polygons.color = '#333';
+                    scene.config.layers.earth.fill.draw.polygons.color = '#333';
                     scene.config.layers.roads.draw.lines.color = '#777';
-                    scene.config.layers.pois.visible = false;
-                    scene.config.layers.buildings.draw.polygons.style = style;
-                    scene.config.layers.buildings.extruded.draw.polygons.style = style;
+                    scene.config.layers.pois.enabled = false;
+                    scene.config.layers.buildings.polygons.draw.polygons.style = style;
+                    scene.config.layers.buildings.polygons.extruded.draw.polygons.style = style;
                 }
             },
             'popup': {
                 setup: function (style) {
-                    scene.config.layers.buildings.extruded.draw.polygons.style = style;
+                    scene.config.layers.buildings.polygons.extruded.draw.polygons.style = style;
                 }
             },
             'elevator': {
                 setup: function (style) {
-                    scene.config.layers.buildings.extruded.draw.polygons.style = style;
+                    scene.config.layers.buildings.polygons.extruded.draw.polygons.style = style;
                 }
             },
             'halftone': {
@@ -258,19 +258,19 @@ Enjoy!
                     scene.config.scene.background.color = 'black';
 
                     var layers = scene.config.layers;
-                    layers.earth.draw.polygons.style = 'halftone_polygons';
+                    layers.earth.fill.draw.polygons.style = 'halftone_polygons';
                     layers.water.draw.polygons.style = 'halftone_polygons';
                     layers.landuse.areas.draw.polygons.style = 'halftone_polygons';
-                    layers.buildings.draw.polygons.style = 'halftone_polygons';
-                    layers.buildings.extruded.draw.polygons.style = 'halftone_polygons';
-                    layers.buildings.draw.polygons.color = 'Style.color.pseudoRandomColor()';
+                    layers.buildings.polygons.draw.polygons.style = 'halftone_polygons';
+                    layers.buildings.polygons.extruded.draw.polygons.style = 'halftone_polygons';
+                    layers.buildings.polygons.draw.polygons.color = 'Style.color.pseudoRandomColor()';
                     layers.roads.draw.lines.style = 'halftone_lines';
-                    layers.pois.visible = false;
+                    layers.pois.enabled = false;
 
-                    var visible_layers = ['landuse', 'water', 'roads', 'buildings'];
+                    var enabled_layers = ['landuse', 'water', 'roads', 'buildings'];
                     Object.keys(layers).forEach(function(l) {
-                        if (visible_layers.indexOf(l) === -1) {
-                            layers[l].visible = false;
+                        if (enabled_layers.indexOf(l) === -1) {
+                            layers[l].enabled = false;
                         }
                     });
                 }
@@ -278,28 +278,28 @@ Enjoy!
             'windows': {
                 camera: 'isometric', // force isometric
                 setup: function (style) {
-                    scene.config.layers.earth.draw.polygons.color = '#333';
+                    scene.config.layers.earth.fill.draw.polygons.color = '#333';
                     scene.config.layers.roads.draw.lines.color = '#777';
-                    scene.config.layers.pois.visible = false;
+                    scene.config.layers.pois.enabled = false;
 
-                    scene.config.layers.buildings.draw.polygons.style = style;
-                    scene.config.layers.buildings.extruded.draw.polygons.style = style;
-                    // scene.config.layers.pois.visible = false;
+                    scene.config.layers.buildings.polygons.draw.polygons.style = style;
+                    scene.config.layers.buildings.polygons.extruded.draw.polygons.style = style;
+                    // scene.config.layers.pois.enabled = false;
                 }
             },
             'envmap': {
                 setup: function (style) {
-                    scene.config.layers.earth.draw.polygons.color = '#333';
+                    scene.config.layers.earth.fill.draw.polygons.color = '#333';
                     scene.config.layers.roads.draw.lines.color = '#777';
 
-                    scene.config.layers.buildings.draw.polygons.style = style;
-                    scene.config.layers.buildings.extruded.draw.polygons.style = style;
+                    scene.config.layers.buildings.polygons.draw.polygons.style = style;
+                    scene.config.layers.buildings.polygons.extruded.draw.polygons.style = style;
 
                     var envmaps = {
-                        'Sunset': 'images/sunset.jpg',
-                        'Chrome': 'images/LitSphere_test_02.jpg',
-                        'Matte Red': 'images/matball01.jpg',
-                        'Color Wheel': 'images/wheel.png'
+                        'Sunset': 'demos/images/sunset.jpg',
+                        'Chrome': 'demos/images/LitSphere_test_02.jpg',
+                        'Matte Red': 'demos/images/matball01.jpg',
+                        'Color Wheel': 'demos/images/wheel.png'
                     };
 
                     this.state.envmap = envmaps['Sunset'];
@@ -414,11 +414,11 @@ Enjoy!
                 return;
             }
 
-            layer_controls[l] = !(layer.scene.config.layers[l].visible == false);
+            layer_controls[l] = !(layer.scene.config.layers[l].enabled == false);
             layer_gui.
                 add(layer_controls, l).
                 onChange(function(value) {
-                    layer.scene.config.layers[l].visible = value;
+                    layer.scene.config.layers[l].enabled = value;
                     layer.scene.rebuild();
                 });
         });

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -184,15 +184,17 @@ layers:
 
     earth:
         data: { source: mapzen }
-        visible: false
-        draw:
-            polygons:
-                order: global.feature_order
-                color: '#f0ebeb'
 
-        continents:
+        fill:
+            filter: { $geometry: polygon }
+            enabled: false
+            draw:
+                polygons:
+                    order: global.feature_order
+                    color: '#f0ebeb'
+
+        labels:
             filter: { kind: continent, $geometry: point }
-            visible: true
             draw:
                 text:
                     text_source: global.language_text_source
@@ -257,7 +259,6 @@ layers:
 
         oceans:
             filter: { kind: ocean }
-            visible: true
             draw:
                 text:
                     font:
@@ -267,7 +268,6 @@ layers:
 
         seas:
             filter: { kind: sea, $zoom: { min: 7 } }
-            visible: true
             draw:
                 text:
                     font:
@@ -626,29 +626,29 @@ layers:
 
     boundaries:
         data: { source: mapzen}
-        visible: false
         draw:
             lines:
+                visible: false
                 order: global.feature_order
                 width: 2px
                 color: wheat
 
         country:
             filter: { kind: country }
-            visible: true
             draw:
                 lines:
+                    visible: true
                     color: [0.824, 0.651, 0.329, 1.00]
             water:
                 filter: { maritime_boundary: true }
-                visible: false
+                draw: { lines: { visible: false } }
 
         region:
             filter: { kind: [region, macroregion] }
-            visible: true
+            draw: { lines: { visible: true } }
             water:
                 filter: { maritime_boundary: true }
-                visible: false
+                draw: { lines: { visible: false } }
 
     places:
         data: { source: mapzen }
@@ -659,7 +659,6 @@ layers:
                 kind: locality
                 kind_detail: city
                 $zoom: { max: 11 }
-            visible: true
             draw:
                 points:
                     size: 8px
@@ -681,6 +680,7 @@ layers:
         text-only:
             draw:
                 text:
+                    visible: false
                     text_source: global.language_text_source
                     priority: 1
                     font:
@@ -689,7 +689,6 @@ layers:
                         fill: [0, 0, 0, .8]
                         stroke: { color: white, width: 4 }
                         transform: uppercase
-            visible: false
 
             countries:
                 filter:
@@ -697,10 +696,9 @@ layers:
                     any:
                         - { population: { min: 100000000 } }
                         - { $zoom: { min: 5, max: 8 }, population: { min: 1000000 } }
-                        # - population: { min: 10000000 }
-                visible: true
                 draw:
                     text:
+                        visible: true
                         buffer: 2px
                         font:
                             weight: bold
@@ -711,9 +709,9 @@ layers:
                     kind: region
                     kind_detail: [state, province]
                     $zoom: { min: 5, max: 9 }
-                visible: true
                 draw:
                     text:
+                        visible: true
                         buffer: 2px
                         font:
                             # weight: bold
@@ -731,9 +729,9 @@ layers:
                     kind: locality
                     kind_detail: city
                     $zoom: { min: 11 } # show city point labels below z11
-                visible: true
                 draw:
                     text:
+                        visible: true
                         font:
                             weight: bold
                             size: [[8, 11px], [12, 16px]]
@@ -743,9 +741,9 @@ layers:
                 filter:
                     - { kind: [neighbourhood, macrohood], $zoom: { min: 13 } }
                     - { kind: microhood, $zoom: { min: 15 } }
-                visible: true
                 draw:
                     text:
+                        visible: true
                         font:
                             size: [[13, 11px], [14, 11px], [15, 13px]]
                             style: italic


### PR DESCRIPTION
As discussed in https://github.com/tangrams/tangram-docs/issues/198:

- Renames the layer-level `visible` property to `enabled`, to prevent confusion with the *`draw` group-level `visible` property*, which continues to exist as-is.
  - Provides backwards compatibility for the previous `visible` property name: if the `enabled` parameter is undefined for a given layer, any value for `visible` will be used instead.
- Changes the Tangram JS treatment of the layer `enabled` (nee `visible`) parameter to match that of Tangram ES: once set by a layer, the parameter *cannot* be overridden by any descendant layers.
  - This provides a mechanism to cull large portions of the layer tree, with the guarantee that they will stay hidden. This is especially useful as more optional overlay-style layers are added to the map (bike, transit, etc.), allowing the engine to efficiently cull these when they are off.
  - For cases where it's useful for sub-layers to control visibility, the `draw` group-level `visible` property continues to provide this fine-grained control; since all `draw` group properties are merged, and descendant layer `draw` groups can override any properties defined by ancestors, this behavior continues to work as-is.
