### PR TITLE
Make source map filename configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # build & test artifacts
 node_modules
+dist/tangram.debug.temp.js.map
 
 # a make target for npm install
 .npm

--- a/build/quine.js
+++ b/build/quine.js
@@ -1,16 +1,20 @@
 var through = require('through2');
 
-var source_variable = '__worker_src__'; // variable name used to refer to the Tangram source code
-var source_origin = '__worker_src_origin__'; // variable name used to refer to URL origin of source code (e.g., "http://localhost:8000/dist/tangram.debug.js")
+function makePrefix(sourceMapFile) {
+    var source_var = '__worker_src__';               // variable name used to refer to the Tangram source code
+    var source_origin_var = '__worker_src_origin__'; // variable name used to refer to URL origin of source code (e.g., "http://localhost:8000/dist/tangram.debug.js")
+    var source_map_var = '__worker_src_map__';       // variable name used to refer to the filename of the source map (e.g. "tangram.debug.js.map")
 
-// prepend this code - wraps Tangram source in a function and later calls arguments.callee.toString to get source
-var prefix = '(function(){';
-    prefix += 'var target = (typeof module !== "undefined" && module.exports) || (typeof window !== "undefined");';
-    prefix += 'if (target) {';
-    prefix += 'var ' + source_variable + ' = arguments.callee.toString();';
-    prefix += 'var ' + source_origin + ' = document.currentScript !== undefined ? document.currentScript.src : \'\';';
-    prefix += '};';
-
+    // prepend this code - wraps Tangram source in a function and later calls arguments.callee.toString to get source
+    var prefix = '(function(){';
+        prefix += 'var target = (typeof module !== "undefined" && module.exports) || (typeof window !== "undefined");';
+        prefix += 'if (target) {';
+        prefix += 'var ' + source_var + ' = arguments.callee.toString();';
+        prefix += 'var ' + source_origin_var + ' = document.currentScript !== undefined ? document.currentScript.src : \'\';';
+        prefix += 'var ' + source_map_var + ' = \'' + sourceMapFile + '\';';
+        prefix += '};';
+    return prefix;
+}
 
 // append the function closing
 var postfix = '})();';
@@ -20,10 +24,11 @@ module.exports = function (browserify, opts) {
     browserify.on("bundle", function(){
         var prefixed = false;
         var sourceMap = '';
+        var sourceMapFile = opts._ ? opts._[0] : '';
 
         var wrap = through.obj(function(buf, enc, next) {
             if(!prefixed) {
-                this.push(prefix);
+                this.push(makePrefix(sourceMapFile));
                 prefixed = true;
             }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build-bundle": "$(npm bin)/browserify src/module.js -t [ babelify --presets [ es2015 ] ] -t brfs --debug -s Tangram -p browserify-derequire -p './build/quine.js' -p [ mapstraction 'dist/tangram.debug.js.map' ] -o dist/tangram.debug.js",
     "build-minify": "$(npm bin)/uglifyjs dist/tangram.debug.js -c warnings=false -m -o dist/tangram.min.js && npm run build-size",
     "build-size": "gzip dist/tangram.min.js -c | wc -c | awk '{kb=$1/1024; print kb}' OFMT='%.0fk minified+gzipped'",
-    "watch": "$(npm bin)/budo src/module.js:dist/tangram.debug.js --port 8000 --cors --live -- -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram -p './build/quine.js' -p [ mapstraction 'dist/tangram.debug.js.map' ]"
+    "watch": "$(npm bin)/budo src/module.js:dist/tangram.debug.js --port 8000 --cors --live -- -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram -p [ './build/quine.js' 'tangram.debug.temp.js.map' ] -p [ mapstraction 'dist/tangram.debug.temp.js.map' ]"
   },
   "author": {
     "name": "Mapzen",

--- a/src/scene.js
+++ b/src/scene.js
@@ -246,9 +246,12 @@ export default class Scene {
         /* jshint -W117 */
         // ignore uninitialized worker src variable (defined in parent scope)
         if (typeof __worker_src__ !== "undefined"){
-            // load from source object using browserify shim (preferred)
-            var src_map_url = '\n//#' + ' sourceMappingURL=' + __worker_src_origin__ + '.map';
-            worker_url = URLs.createObjectURL(new Blob(['(' + __worker_src__ + ')()' + src_map_url], { type: 'application/javascript' }));
+            let source = '(' + __worker_src__ + ')()';
+            if (__worker_src_origin__) {
+                let origin = __worker_src_origin__.slice(0, __worker_src_origin__.lastIndexOf('/')+1);
+                source += '\n//#' + ' sourceMappingURL=' + origin + __worker_src_map__;
+            }
+            worker_url = URLs.createObjectURL(new Blob([source], { type: 'application/javascript' }));
         }
         /* jshint +W117 */
 


### PR DESCRIPTION
This makes the source map filename used for workers a parameter passed to the `quine.js` plugin. This addresses two issues:

- Fixes an issue where the source maps would not be correct for worker threads if the Tangram bundle was renamed to a different filename, since it was relying on the origin (via `document.currentScript`) to construct the source map URL for workers.
- Allows the `budo` live-reload process to write to a temp source map name (which is in `.gitignore`), preventing it from conflicting with the official build filenames in `dist/`.

The downside is that the source map name has to be explicitly passed in to the plugin, but this was already true for the call to `mapstraction`.