### PR TITLE
Fix #541 RTL curved labels when segments end on neutral character

### DIFF
--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -596,12 +596,12 @@ function isTextShaped(s){
 
 // Right-to-left / bi-directional text handling
 // Taken from http://stackoverflow.com/questions/12006095/javascript-how-to-check-if-character-is-rtl
-let rtlDirCheck = new RegExp('^[\u0000-\u0040\u005B-\u0060\u007B-\u00BF\u00D7\u00F7\u02B9-\u02FF\u2000-\u2BFF\u2010-\u2029\u202C\u202F-\u2BFF\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]+$');
+let rtlDirCheck = new RegExp('^[\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u00BF\u00D7\u00F7\u02B9-\u02FF\u2000-\u2BFF\u2010-\u2029\u202C\u202F-\u2BFF\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]+$');
 function isTextRTL(s){
     return rtlDirCheck.test(s);
 }
 
-let neutralDirCheck = new RegExp('[\u0000-\u0040\u005B-\u0060\u007B-\u00BF\u00D7\u00F7\u02B9-\u02FF\u2000-\u2BFF\u2010-\u2029\u202C\u202F-\u2BFF]$');
+let neutralDirCheck = new RegExp('[\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u00BF\u00D7\u00F7\u02B9-\u02FF\u2000-\u2BFF\u2010-\u2029\u202C\u202F-\u2BFF]$');
 function isTextNeutral(s){
     return neutralDirCheck.test(s);
 }


### PR DESCRIPTION
We detect if a broken up text segment ends on a neutral character. In this case we draw the characters individually (as separate glyphs) instead of clustering them. This should resolve the issue with curved labels for RTL text, but not for multi-line labels, which will require a different approach. This fixes part of the issue in #541.

Spaces:
![www gifcreator me_joyyqh](https://cloud.githubusercontent.com/assets/796394/24928702/520d37d6-1ed1-11e7-8349-3b4c8b5ac9e1.gif)

Punctuation:
![www gifcreator me_0tjsdn](https://cloud.githubusercontent.com/assets/796394/24928703/5227bf84-1ed1-11e7-86c5-43e873eaae71.gif)