### PR TITLE
Adds debug option to collect per-layer stats

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -46,6 +46,9 @@ Enjoy!
             // webGLContextOptions: { // explicitly add/override WebGL context options
             //     antialias: false
             // },
+            // debug: {
+            //     layer_stats: true // enable to collect detailed layer stats, access w/`scene.debug.layerStats()`
+            // },
             logLevel: 'debug',
             attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors | <a href="https://mapzen.com/" target="_blank">Mapzen</a>'
         });

--- a/src/builders/points.js
+++ b/src/builders/points.js
@@ -34,6 +34,7 @@ export function buildQuadsForPoints (points, vertex_data, vertex_template,
         ];
     }
 
+    var geom_count = 0;
     let num_points = points.length;
     for (let p=0; p < num_points; p++) {
         let point = points[p];
@@ -92,5 +93,8 @@ export function buildQuadsForPoints (points, vertex_data, vertex_template,
         vertex_elements.push(element_offset + 0);
 
         element_offset += 4;
+        geom_count += 2;
     }
+
+    return geom_count;
 }

--- a/src/builders/polygons.js
+++ b/src/builders/polygons.js
@@ -21,6 +21,7 @@ export function buildPolygons (
         var [min_u, min_v, max_u, max_v] = texcoord_scale || default_uvs;
     }
 
+    var geom_count = 0;
     var num_polygons = polygons.length;
     for (var p=0; p < num_polygons; p++) {
         var element_offset = vertex_data.vertex_count;
@@ -59,7 +60,9 @@ export function buildPolygons (
         for (let i = 0; i < indices.length; i++){
             vertex_elements.push(element_offset + indices[i]);
         }
+        geom_count += indices.length/3;
     }
+    return geom_count;
 }
 
 // Tesselate and extrude a flat 2D polygon into a simple 3D model with fixed height and add to GL vertex buffer
@@ -82,7 +85,7 @@ export function buildExtrudedPolygons (
     var min_z = z + (min_height || 0);
     var max_z = z + height;
     vertex_template[2] = max_z;
-    buildPolygons(polygons, vertex_data, vertex_template, { texcoord_index, texcoord_scale, texcoord_normalize });
+    var geom_count = buildPolygons(polygons, vertex_data, vertex_template, { texcoord_index, texcoord_scale, texcoord_normalize });
 
     var vertex_elements = vertex_data.vertex_elements;
     var element_offset = vertex_data.vertex_count;
@@ -161,9 +164,11 @@ export function buildExtrudedPolygons (
                 vertex_elements.push(element_offset + 0);
 
                 element_offset += 4;
+                geom_count += 2;
             }
         }
     }
+    return geom_count;
 }
 
 // Triangulation using earcut

--- a/src/builders/polylines.js
+++ b/src/builders/polylines.js
@@ -78,7 +78,8 @@ export function buildPolylines (lines, width, vertex_data, vertex_template,
         v_scale,
         texcoord_index,
         texcoord_width,
-        texcoord_normalize
+        texcoord_normalize,
+        geom_count: 0
     };
 
     // Buffer for extra lines to process
@@ -93,6 +94,8 @@ export function buildPolylines (lines, width, vertex_data, vertex_template,
     for (let index = 0; index < extra_lines.length; index++) {
         buildPolyline(extra_lines[index], context, extra_lines);
     }
+
+    return context.geom_count;
 }
 
 function buildPolyline(line, context, extra_lines){
@@ -409,6 +412,7 @@ function indexPairs(num_pairs, context){
         vertex_elements.push(offset + 2 * i + 2);
         vertex_elements.push(offset + 2 * i + 3);
         vertex_elements.push(offset + 2 * i + 1);
+        context.geom_count += 2;
     }
 }
 

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -2,6 +2,7 @@ import Thread from './utils/thread';
 import Scene from './scene';
 import Geo from './geo';
 import debounce from './utils/debounce';
+import {mergeDebugSettings} from './utils/debug_settings';
 
 // Exports must appear outside a function, but will only be defined in main thread (below)
 export var LeafletLayer;
@@ -50,6 +51,7 @@ function extendLeaflet(options) {
                 options.showDebug = (!options.showDebug ? false : true);
 
                 L.setOptions(this, options);
+                this.updateTangramDebugSettings();
                 this.createScene();
                 this.hooks = {};
                 this._updating_tangram = false;
@@ -465,6 +467,10 @@ function extendLeaflet(options) {
 
                 map.on('layeradd layerremove overlayadd overlayremove', this._updateMapLayerCount);
                 this._updateMapLayerCount();
+            },
+
+            updateTangramDebugSettings () {
+                mergeDebugSettings(this.options.debug || {});
             }
 
         });

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,5 +1,6 @@
 import log from './utils/log';
 import Utils from './utils/utils';
+import debugSettings from './utils/debug_settings';
 import * as URLs from './utils/urls';
 import WorkerBroker from './utils/worker_broker';
 import subscribeMixin from './utils/subscribe';
@@ -13,6 +14,7 @@ import {StyleParser} from './styles/style_parser';
 import SceneLoader from './scene_loader';
 import View from './view';
 import Light from './light';
+import Tile from './tile';
 import TileManager from './tile_manager';
 import DataSource from './sources/data_source';
 import FeatureSelection from './selection';
@@ -1064,7 +1066,7 @@ export default class Scene {
             config: config_serialized,
             generation: this.generation,
             introspection: this.introspection
-        });
+        }, debugSettings);
     }
 
     // Listen to related objects
@@ -1236,6 +1238,16 @@ export default class Scene {
                     sizes[base] += style_sizes[style];
                 }
                 return sizes;
+            },
+
+            layerStats () {
+                if (debugSettings.layer_stats) {
+                    return Tile.debugSumLayerStats(scene.tile_manager.getRenderableTiles());
+                }
+                else {
+                    log('warn', `Enable the 'layer_stats' debug setting to collect layer stats`);
+                    return {};
+                }
             },
 
             renderableTilesCount () {

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -1,6 +1,7 @@
 /*jshint worker: true*/
 import Thread from './utils/thread';
 import Utils from './utils/utils';
+import {mergeDebugSettings} from './utils/debug_settings';
 import log from './utils/log';
 import WorkerBroker from './utils/worker_broker'; // jshint ignore:line
 import Tile from './tile';
@@ -38,8 +39,9 @@ Object.assign(self, {
     },
 
     // Starts a config refresh
-    updateConfig ({ config, generation, introspection }) {
+    updateConfig ({ config, generation, introspection }, debug) {
         config = JSON.parse(config);
+        mergeDebugSettings(debug);
 
         self.generation = generation;
         self.introspection = introspection;

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -307,7 +307,7 @@ Object.assign(Lines, {
         // Main line
         this.feature_style = this.inline_feature_style; // restore calculated style for inline
         let vertex_template = this.makeVertexTemplate(style);
-        buildPolylines(
+        return buildPolylines(
             lines,
             style.width,
             vertex_data,
@@ -329,10 +329,12 @@ Object.assign(Lines, {
     },
 
     buildPolygons(polygons, style, vertex_data, context) {
-        // Render polygons as individual lines
-        for (let p=0; p < polygons.length; p++) {
-            this.buildLines(polygons[p], style, vertex_data, context, { closed_polygon: true, remove_tile_edges: true });
-        }
+         // Render polygons as individual lines
+        let geom_count = 0;
+         for (let p=0; p < polygons.length; p++) {
+            geom_count += this.buildLines(polygons[p], style, vertex_data, context, { closed_polygon: true, remove_tile_edges: true });
+         }
+        return geom_count;
     }
 
 });

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -617,7 +617,7 @@ Object.assign(Points, {
     },
 
     buildQuad(points, size, angle, angles, pre_angles, sampler, offset, offsets, texcoord_scale, curve, vertex_data, vertex_template) {
-        buildQuadsForPoints(
+        return buildQuadsForPoints(
             points,
             vertex_data,
             vertex_template,
@@ -654,10 +654,10 @@ Object.assign(Points, {
     build (style, vertex_data) {
         let label = style.label;
         if (label.type === 'curved') {
-            this.buildArticulatedLabel(label, style, vertex_data);
+            return this.buildArticulatedLabel(label, style, vertex_data);
         }
         else {
-            this.buildLabel(label, style, vertex_data);
+            return this.buildLabel(label, style, vertex_data);
         }
     },
 
@@ -677,7 +677,7 @@ Object.assign(Points, {
 
         let offset = label.offset;
 
-        this.buildQuad(
+        return this.buildQuad(
             [label.position],               // position
             size,                           // size in pixels
             angle,                          // angle in radians
@@ -695,6 +695,7 @@ Object.assign(Points, {
     buildArticulatedLabel (label, style, vertex_data) {
         let vertex_template = this.makeVertexTemplate(style);
         let angle = label.angle;
+        let geom_count = 0;
 
         // pass for stroke
         for (let i = 0; i < label.num_segments; i++){
@@ -708,7 +709,7 @@ Object.assign(Points, {
             let offsets = label.offsets[i];
             let pre_angles = label.pre_angles[i];
 
-            this.buildQuad(
+            geom_count += this.buildQuad(
                 [position],                     // position
                 size,                           // size in pixels
                 angle,                          // angle in degrees
@@ -735,7 +736,7 @@ Object.assign(Points, {
             let offsets = label.offsets[i];
             let pre_angles = label.pre_angles[i];
 
-            this.buildQuad(
+            geom_count += this.buildQuad(
                 [position],                     // position
                 size,                           // size in pixels
                 angle,                          // angle in degrees
@@ -749,19 +750,21 @@ Object.assign(Points, {
                 vertex_data, vertex_template    // VBO and data for current vertex
             );
         }
+
+        return geom_count;
     },
 
     // Override to pass-through to generic point builder
     buildLines (lines, style, vertex_data, context) {
-        this.build(style, vertex_data);
+        return this.build(style, vertex_data);
     },
 
     buildPoints (points, style, vertex_data, context) {
-        this.build(style, vertex_data);
+        return this.build(style, vertex_data);
     },
 
     buildPolygons (points, style, vertex_data, context) {
-        this.build(style, vertex_data);
+        return this.build(style, vertex_data);
     },
 
     makeMesh (vertex_data, vertex_elements, options = {}) {

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -154,7 +154,7 @@ Object.assign(Polygons, {
 
         // Extruded polygons (e.g. 3D buildings)
         if (style.extrude && style.height) {
-            buildExtrudedPolygons(
+            return buildExtrudedPolygons(
                 polygons,
                 style.z, style.height, style.min_height,
                 vertex_data, vertex_template,
@@ -165,7 +165,7 @@ Object.assign(Polygons, {
         }
         // Regular polygons
         else {
-            buildPolygons(
+            return buildPolygons(
                 polygons,
                 vertex_data, vertex_template,
                 options

--- a/src/utils/debug_settings.js
+++ b/src/utils/debug_settings.js
@@ -1,10 +1,22 @@
-export default {
+let debugSettings;
+
+export default debugSettings = {
     // draws a blue rectangle border around the collision box of a label
     draw_label_collision_boxes: false,
+
     // draws a green rectangle border within the texture box of a label
     draw_label_texture_boxes: false,
+
     // suppreses fade-in of labels
     suppress_label_fade_in: false,
+
     // suppress animaton of label snap to pixel grid
-    suppress_label_snap_animation: false
+    suppress_label_snap_animation: false,
+
+    // collect feature/geometry stats on styling layers
+    layer_stats: false
 };
+
+export function mergeDebugSettings (settings) {
+    Object.assign(debugSettings, settings);
+}


### PR DESCRIPTION
Adds a `layer_stats` debug option, which will enable collection of feature and geometry stats per layer:

- Number of features that were built for each layer
- Number of GL geometries (triangles) that were built for each layer
  - GL geometry counts are further collected by rendering `style`, and grouped by style `base` (e.g. `polygons`, `lines` etc.)

These stats are collected in two formats:

- A flattened **list** that displays all of fully qualified layer names, e.g. `roads:path:bridge`
- A **tree** that aggregates counts at each level of the layer tree, with the ability to drill down into descendant levels

Counts for the tiles in the **current view** can be retrieved through `scene.debug.layerStats()` (a warning is logged if the `layer_stats` debug option is not enabled). This method returns an object with `list` and `tree` properties. Here's an example:

Flat `list` of layers:

<img width="431" alt="screen shot 2017-04-11 at 1 18 06 pm" src="https://cloud.githubusercontent.com/assets/16733/24929040/7837f3e6-1eb9-11e7-9175-9ca031625eba.png">

Opening stats for a specific layer:
<img width="224" alt="screen shot 2017-04-11 at 1 17 51 pm" src="https://cloud.githubusercontent.com/assets/16733/24929048/7aef34b4-1eb9-11e7-870e-74ff548fea9d.png">

Top-level of `tree`:

<img width="180" alt="screen shot 2017-04-11 at 1 20 20 pm" src="https://cloud.githubusercontent.com/assets/16733/24929190/0036378a-1eba-11e7-9f27-54a1ea2cbfd1.png">

Drilling down into child `layers`:

<img width="207" alt="screen shot 2017-04-11 at 1 22 49 pm" src="https://cloud.githubusercontent.com/assets/16733/24929218/10f4ec74-1eba-11e7-9ac0-c4e746b89b95.png">


