### PR TITLE
Add support for 512px (and beyond) tile sizes

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -39,7 +39,7 @@ export default class DataSource {
         // overzoom will apply for zooms higher than this
         this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
 
-        this.zoom_bias = 1; // TODO: MAKE CONFIGURABLE
+        this.zoom_bias = config.zoom_bias || 0;
         this.max_coord_zoom = this.max_zoom + this.zoom_bias;
 
         // no tiles will be requested or displayed outside of these min/max values

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -39,6 +39,9 @@ export default class DataSource {
         // overzoom will apply for zooms higher than this
         this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
 
+        this.zoom_bias = 1; // TODO: MAKE CONFIGURABLE
+        this.max_coord_zoom = this.max_zoom + this.zoom_bias;
+
         // no tiles will be requested or displayed outside of these min/max values
         this.min_display_zoom = (config.min_display_zoom != null) ? config.min_display_zoom : 0;
         this.max_display_zoom = (config.max_display_zoom != null) ? config.max_display_zoom : null;

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -39,7 +39,7 @@ export default class DataSource {
         // overzoom will apply for zooms higher than this
         this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
 
-        this.zoom_bias = config.zoom_bias || 0;
+        this.setTileSize(config.tile_size);
         this.max_coord_zoom = this.max_zoom + this.zoom_bias;
 
         // no tiles will be requested or displayed outside of these min/max values
@@ -140,6 +140,20 @@ export default class DataSource {
     // Sub-classes must implement
     _load(dest) {
         throw new MethodNotImplemented('_load');
+    }
+
+    // Set the internal tile size in pixels, e.g. '256px' (default), '512px', etc.
+    // Must be a power of 2, and greater than or equal to 256
+    setTileSize (tile_size) {
+        this.tile_size = tile_size || 256;
+        if (typeof this.tile_size !== 'number' || this.tile_size < 256 || !Utils.isPowerOf2(this.tile_size)) {
+            log({ level: 'warn', once: true },
+                `Data source '${this.name}': 'tile_size' parameter must be a number that is a power of 2 greater than or equal to 256, but was '${tile_size}'`);
+            this.tile_size = 256;
+        }
+
+        // # of zoom levels bigger than 256px tiles - 8 in place of log2(256)
+        this.zoom_bias = Math.log2(this.tile_size) - 8;
     }
 
     // Infer winding for data source from first ring of provided geometry

--- a/src/tile.js
+++ b/src/tile.js
@@ -79,7 +79,7 @@ export default class Tile {
 
     static normalizedCoordinate (coords, source, style_zoom) {
         if (source.zoom_bias) {
-            coords = Tile.coordinateAtZoom(coords, coords.z - source.zoom_bias); // TODO: what about z0?
+            coords = Tile.coordinateAtZoom(coords, Math.max(0, coords.z - source.zoom_bias)); // zoom can't go below zero
         }
         return Tile.coordinateWithMaxZoom(coords, source.max_zoom);
     }

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -262,7 +262,7 @@ export default class TileManager {
                     source,
                     coords,
                     worker: this.scene.getWorkerForDataSource(source),
-                    style_zoom: this.view.styleZoom(coords.z),
+                    style_zoom: this.view.baseZoom(coords.z),
                     view: this.view
                 });
 

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -255,7 +255,7 @@ export default class TileManager {
                 continue;
             }
 
-            let key = Tile.key(coords, source, this.view.tile_zoom);
+            let key = Tile.normalizedKey(coords, source, this.view.tile_zoom);
             if (key && !this.hasTile(key)) {
                 log('trace', `load tile ${key}, distance from view center: ${coords.center_dist}`);
                 let tile = new Tile({

--- a/src/tile_pyramid.js
+++ b/src/tile_pyramid.js
@@ -82,10 +82,10 @@ export default class TilePyramid {
         }
 
         // First check overzoomed tiles at same coordinate zoom
-        if (style_zoom > source.max_zoom) {
+        if (style_zoom > source.max_coord_zoom) {
             let source_tiles = this.sourceTiles(coords, source);
             if (source_tiles) {
-                for (let z = style_zoom - 1; z >= source.max_zoom; z--) {
+                for (let z = style_zoom - 1; z >= source.max_coord_zoom; z--) {
                     if (source_tiles[z] && source_tiles[z].loaded) {
                         return source_tiles[z];
                     }
@@ -95,7 +95,7 @@ export default class TilePyramid {
                     }
                 }
             }
-            style_zoom = source.max_zoom;
+            style_zoom = source.max_coord_zoom;
         }
 
         // Check tiles at next zoom up
@@ -115,7 +115,7 @@ export default class TilePyramid {
         let descendants = [];
 
         // First check overzoomed tiles at same coordinate zoom
-        if (style_zoom >= source.max_zoom) {
+        if (style_zoom >= source.max_coord_zoom) {
             let source_tiles = this.sourceTiles(coords, source);
             if (source_tiles) {
                 let search_max_zoom = Math.max(Geo.default_view_max_zoom, style_zoom + this.max_proxy_descendant_depth);
@@ -140,7 +140,7 @@ export default class TilePyramid {
                     descendants.push(child_tiles[style_zoom]);
                 }
                 // didn't find child, try next level
-                else if (level <= this.max_proxy_descendant_depth && child.z <= source.max_zoom) {
+                else if (level <= this.max_proxy_descendant_depth && child.z <= source.max_coord_zoom) {
                     descendants.push(...this.getDescendants({ coords: child, source, style_zoom }, level + 1));
                 }
             }

--- a/src/view.js
+++ b/src/view.js
@@ -37,7 +37,6 @@ export default class View {
         this.buffer = 0;
         this.continuous_zoom = (typeof options.continuousZoom === 'boolean') ? options.continuousZoom : true;
         this.wrap = (options.wrapView === false) ? false : true;
-        this.tile_simplification_level = 0; // level-of-detail downsampling to apply to tile loading
         this.preserve_tiles_within_zoom = 1;
 
         this.reset();
@@ -138,7 +137,7 @@ export default class View {
         }
 
         let last_tile_zoom = this.tile_zoom;
-        let tile_zoom = this.tileZoom(zoom);
+        let tile_zoom = this.baseZoom(zoom);
         if (!this.continuous_zoom) {
             zoom = tile_zoom;
         }
@@ -163,16 +162,6 @@ export default class View {
     // Choose the base zoom level to use for a given fractional zoom
     baseZoom (zoom) {
         return Math.floor(zoom);
-    }
-
-    // For a given view zoom, what tile zoom should be loaded?
-    tileZoom (view_zoom) {
-        return Math.max(this.baseZoom(view_zoom) - this.tile_simplification_level, 0);
-    }
-
-    // For a given tile zoom, what style zoom should be used?
-    styleZoom (tile_zoom) {
-        return this.baseZoom(tile_zoom) + this.tile_simplification_level;
     }
 
     setPanning (panning) {

--- a/test/tile_pyramid.js
+++ b/test/tile_pyramid.js
@@ -18,7 +18,7 @@ describe('TilePyramid', function() {
             style_zoom = coords.z;
             source = {
                 name: 'test',
-                max_zoom: 18
+                max_coord_zoom: 18
             };
 
             tile = {
@@ -42,6 +42,7 @@ describe('TilePyramid', function() {
         });
 
         it('creates one entry for an overzoomed tile', () => {
+            tile = Object.assign({}, tile);
             tile.coords = Tile.coordinateAtZoom(coords, 18);
             tile.style_zoom = 20;
             pyramid.addTile(tile);
@@ -51,11 +52,12 @@ describe('TilePyramid', function() {
         });
 
         it('creates additional entries for overzoomed tiles', () => {
+            tile = Object.assign({}, tile);
             tile.coords = Tile.coordinateAtZoom(coords, 18);
-
             tile.style_zoom = 19;
             pyramid.addTile(tile);
 
+            tile = Object.assign({}, tile);
             tile.style_zoom = 20;
             pyramid.addTile(tile);
 
@@ -71,6 +73,7 @@ describe('TilePyramid', function() {
 
         it('gets tile ancestor', () => {
             pyramid.addTile(tile);
+            tile = Object.assign({}, tile);
             tile.coords = Tile.coordinateAtZoom(tile.coords, tile.coords.z + 2);
             tile.style_zoom = tile.coords.z;
             let ancestor = pyramid.getAncestor(tile);
@@ -79,6 +82,7 @@ describe('TilePyramid', function() {
 
         it('gets tile descendant', () => {
             pyramid.addTile(tile);
+            tile = Object.assign({}, tile);
             tile.coords = Tile.coordinateAtZoom(tile.coords, tile.coords.z - 2);
             tile.style_zoom = tile.coords.z;
             let descendants = pyramid.getDescendants(tile);


### PR DESCRIPTION
See https://github.com/tangrams/tangram-es/issues/1435 for details

Data sources can enable larger tile sizes:

```
sources:
  mapzen:
    type: ...
    url: ...
    tile_size: 512px
```

`tile_size` must be a power of 2 greater than or equal to 256, and can optionally include `px` units.