### PR TITLE
Do not apply shader blocks on `points`-based styles to attached `text`

### DIFF
--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -102,7 +102,6 @@ Object.assign(Lines, {
         // Specify a line texture (either directly, or rendered dash pattern from above)
         if (this.texture) {
             this.defines.TANGRAM_LINE_TEXTURE = true;
-            this.defines.TANGRAM_ALPHA_TEST = 0.5; // pixels below this threshold are transparent
             this.shaders.uniforms = this.shaders.uniforms || {};
             this.shaders.uniforms.u_texture = this.texture;
             this.shaders.uniforms.u_texture_ratio = 1;

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -35,15 +35,13 @@ Object.assign(Points, TextLabels);
 Object.assign(Points, {
     name: 'points',
     built_in: true,
+    vertex_shader_src: shaderSrc_pointsVertex,
+    fragment_shader_src: shaderSrc_pointsFragment,
     collision: true,  // style includes a collision pass
     blend: 'overlay', // overlays drawn on top of all other styles, with blending
 
     init(options = {}, extra_attributes = []) {
         Style.init.call(this, options);
-
-        // Base shaders
-        this.vertex_shader_src = shaderSrc_pointsVertex;
-        this.fragment_shader_src = shaderSrc_pointsFragment;
 
         var attribs = [
             { name: 'a_position', size: 4, type: gl.SHORT, normalized: false },

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -47,6 +47,7 @@ void main (void) {
     vec4 color = v_color;
 
     #ifdef TANGRAM_MULTI_SAMPLER
+    bool is_label = false;
     if (v_sampler == 0.) { // sprite sampler
     #endif
         #ifdef TANGRAM_TEXTURE_POINT
@@ -67,6 +68,7 @@ void main (void) {
     #ifdef TANGRAM_MULTI_SAMPLER
     }
     else { // label sampler
+        is_label = true;
         color = texture2D(u_label_texture, v_texcoord);
         color.rgb /= max(color.a, 0.001); // un-multiply canvas texture
     }
@@ -84,11 +86,17 @@ void main (void) {
         }
     #endif
 
-    #pragma tangram: color
+    #ifdef TANGRAM_MULTI_SAMPLER
+    // Don't apply shader blocks to text attached to point (N.B.: for compatibility with ES)
+    if (!is_label) {
+    #endif
+        #pragma tangram: color
+        #pragma tangram: filter
+    #ifdef TANGRAM_MULTI_SAMPLER
+    }
+    #endif
 
     color.a *= v_alpha_factor;
-
-    #pragma tangram: filter
 
     gl_FragColor = color;
 }

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -23,31 +23,30 @@ attribute vec4 a_outline_color;
 attribute vec2 a_texcoord;
 attribute vec2 a_offset;
 
-#define PI 3.14159265359
-
 #ifdef TANGRAM_CURVED_LABEL
     attribute vec4 a_offsets;
     attribute vec4 a_pre_angles;
     attribute vec4 a_angles;
 #endif
 
-#define TANGRAM_NORMAL vec3(0., 0., 1.)
-#define TANGRAM_PX_FADE_RANGE 2.
-
 varying vec4 v_color;
 varying vec2 v_texcoord;
 varying vec4 v_world_position;
 varying float v_alpha_factor;
-varying float v_aa_factor;
 
 #ifdef TANGRAM_SHADER_POINT
     varying float v_outline_edge;
     varying vec4 v_outline_color;
+    varying float v_aa_factor;
 #endif
 
 #ifdef TANGRAM_MULTI_SAMPLER
     varying float v_sampler;
 #endif
+
+#define PI 3.14159265359
+#define TANGRAM_NORMAL vec3(0., 0., 1.)
+#define TANGRAM_PX_FADE_RANGE 2.
 
 #pragma tangram: camera
 #pragma tangram: material
@@ -91,11 +90,11 @@ void main() {
     v_alpha_factor = 1.0;
     v_color = a_color;
     v_texcoord = a_texcoord;
-    v_aa_factor = 1. / length(a_shape.xy / 256.) * TANGRAM_PX_FADE_RANGE;
 
     #ifdef TANGRAM_SHADER_POINT
         v_outline_color = a_outline_color;
         v_outline_edge = a_outline_edge;
+        v_aa_factor = 1. / length(a_shape.xy / 256.) * TANGRAM_PX_FADE_RANGE;
     #endif
 
     // Position

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -8,16 +8,10 @@ import {buildPolygons, buildExtrudedPolygons} from '../../builders/polygons';
 import Geo from '../../geo';
 
 let fs = require('fs');
-const shaderSrc_polygonsVertex = fs.readFileSync(__dirname + '/polygons_vertex.glsl', 'utf8');
-const shaderSrc_polygonsFragment = fs.readFileSync(__dirname + '/polygons_fragment.glsl', 'utf8');
+export const shaderSrc_polygonsVertex = fs.readFileSync(__dirname + '/polygons_vertex.glsl', 'utf8');
+export const shaderSrc_polygonsFragment = fs.readFileSync(__dirname + '/polygons_fragment.glsl', 'utf8');
 
 export var Polygons = Object.create(Style);
-
-// export shaders for use in lines.js
-export {
-    shaderSrc_polygonsVertex,
-    shaderSrc_polygonsFragment
-};
 
 Object.assign(Polygons, {
     name: 'polygons',

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -61,6 +61,9 @@ export class StyleManager {
 
         // Increases precision for height values
         ShaderProgram.defines.TANGRAM_HEIGHT_SCALE = Geo.height_scale;
+
+        // Alpha discard threshold (substitute for alpha blending)
+        ShaderProgram.defines.TANGRAM_ALPHA_TEST = 0.5;
     }
 
     // Destroy all styles for a given GL context

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -8,12 +8,16 @@ import LabelPoint from '../../labels/label_point';
 import LabelLine from '../../labels/label_line';
 import gl from '../../gl/constants'; // web workers don't have access to GL context, so import all GL constants
 
+let fs = require('fs');
+const shaderSrc_textFragment = fs.readFileSync(__dirname + '/text_fragment.glsl', 'utf8');
+
 export let TextStyle = Object.create(Points);
 
 Object.assign(TextStyle, {
     name: 'text',
     super: Points,
     built_in: true,
+    fragment_shader_src: shaderSrc_textFragment,
 
     init(options = {}) {
         let extra_attributes = [
@@ -26,16 +30,13 @@ Object.assign(TextStyle, {
 
         // Set texture/point config (override parent Point class)
         this.defines.TANGRAM_TEXTURE_POINT = true;  // standalone text is always sampled from a texture
-        this.defines.TANGRAM_SHADER_POINT = false;  // standalone text neevr draws a shader point
+        this.defines.TANGRAM_SHADER_POINT = false;  // standalone text never draws a shader point
 
         // Indicate vertex shader should apply zoom-interpolated offsets and angles for curved labels
         this.defines.TANGRAM_CURVED_LABEL = true;
 
         // Disable dual point/text mode
         this.defines.TANGRAM_MULTI_SAMPLER = false;
-
-        // Manually un-multiply alpha, because Canvas text rasterization is pre-multiplied
-        this.defines.TANGRAM_UNMULTIPLY_ALPHA = true;
 
         // Fade out text when tile is zooming out, e.g. acting as proxy tiles
         this.defines.TANGRAM_FADE_ON_ZOOM_OUT = true;

--- a/src/styles/text/text_fragment.glsl
+++ b/src/styles/text/text_fragment.glsl
@@ -1,0 +1,48 @@
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform vec3 u_map_position;
+uniform vec4 u_tile_origin;
+uniform float u_meters_per_pixel;
+uniform float u_device_pixel_ratio;
+uniform float u_visible_time;
+
+uniform mat3 u_normalMatrix;
+uniform mat3 u_inverseNormalMatrix;
+
+uniform sampler2D u_texture;
+
+varying vec4 v_color;
+varying vec2 v_texcoord;
+varying vec4 v_world_position;
+varying float v_alpha_factor;
+
+#define TANGRAM_NORMAL vec3(0., 0., 1.)
+
+#pragma tangram: camera
+#pragma tangram: material
+#pragma tangram: lighting
+#pragma tangram: raster
+#pragma tangram: global
+
+void main (void) {
+    // Initialize globals
+    #pragma tangram: setup
+
+    vec4 color = v_color;
+    color *= texture2D(u_texture, v_texcoord);
+    color.rgb /= max(color.a, 0.001); // un-multiply canvas texture
+
+    #pragma tangram: color
+    #pragma tangram: filter
+
+    color.a *= v_alpha_factor;
+
+    // If blending is off, use alpha discard as a lower-quality substitute
+    #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
+        if (color.a < TANGRAM_ALPHA_TEST) {
+            discard;
+        }
+    #endif
+
+    gl_FragColor = color;
+}


### PR DESCRIPTION
In `points`-based styles, Tangram JS has been applying any shader blocks to any `text` attachments for that style, e.g.:

```
styles:
  tinted:
    base: points
    shaders:
      blocks:
        filter: color.r += 0.5;

layers:
  ...
    draw:
      tinted:
        ... # shader blocks applied to these points
        text:
           ... # shader blocks ALSO applied to this text
```
This branch changes that behavior so that these shader blocks **will not** be applied to the attached `text`. This is for two reasons:

- While it can be useful to apply shader blocks to text for some effects (which is still possible with the standalone `text` style), it can be problematic to require the *same* blocks apply to both the point and text portions; this recently arose when working on adding tinted icons to Refill.
- Tangram ES already does *not* apply these shader blocks, so this is an existing incompatibility. This branch brings the two to parity.

The better longer-term solution is to allow any attached `text` to specify an explicit style to use instead, simile to the `outline` block in `lines`-based styles. However, the current Tangram JS pipeline for processing combined points/text complicates this, so that work will be deferred.

The larger code footprint here is because the fragment shaders for `points` and `text` styles were previously shared (with several conditional `#define`-based branches), but have been split into two separate files. This improves comprehension, especially for the standalone `text` shader. Separating the vertex shader, which is still shared, may also be worthwhile, but the benefit did not seem as clear at this time due to the amount of logic still shared between the two (tradeoff of comprehension vs. duplicated code). Minor shader/setup simplification was included in that change as well.

