### PR TITLE
Make curved labels in more languages

### DIFF
--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -568,19 +568,19 @@ CanvasText.texcoord_cache = {};
 // Contextual Shaping Languages - Unicode ranges
 const context_langs = {
     Arabic: "\u0600-\u06FF",
-    Bengali: "\u0980-\u09FF",
-    Devanagari: "\u0900-\u097F",
-    Mongolian: "\u1800-\u18AF",
-    Tibetan: "\u0F00-\u0FFF"
+    Mongolian: "\u1800-\u18AF"
 };
 
 const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
+"\u0900-\u0903\u093A-\u094C\u094E\u094F\u0951-\u0957\u0962\u0963" + // Devanagari
+"\u0981-\u0983\u09BC\u09BE-\u09CC\u09D7\u09E2\u09E3" + // Bengali
 "\u0A01-\u0A03\u0A3C-\u0A4C\u0A51" + // Gurmukhi
 "\u0A81-\u0A83\u0ABC\u0ABE-\u0ACC\u0AE2\u0AE3" + // Gujarati
 "\u0B01-\u0B03\u0B3C\u0B3E-\u0B4C\u0B56\u0B57\u0B62\u0B63" + // Oriya
 "\u0B82\u0BBE-\u0BCD\u0BD7" + // Tamil
 "\u0C00-\u0C03\u0C3E-\u0C4C\u0C55\u0C56\u0C62\u0C63" + // Telugu
 "\u0D82\u0D83\u0DCA-\u0DDF\u0DF2\u0DF3" + // Sinhala
+"\u0F18\u0F19\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F83\u0F86\u0F87\u0F8D-\u0FBC\u0FC6" + // Tibetan
 "\u102B-\u1038\u103A-\u103E\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F\u109A-\u109D" + // Burmese
 "\u1A55-\u1A5E\u1A61-\u1A7C" + // Tai Tham
 "\u1DC0-\u1DFF" + // Combining Diacritical Marks Supplement
@@ -589,7 +589,7 @@ const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
 "\u0C80-\u0C83\u0CBC\u0CBE-\u0CCC\u0CD5\u0CD6\u0CE2\u0CE3" + // Kannada
 "\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD" + // Lao
 "]";
-const combo_characters = "[\u094D\u09CD\u1039\u17D2\u0A4D\u0ACD\u0C4D\u0CCD\u0B4D\u1A60\u1A7F\u0DCA]";
+const combo_characters = "[\u094D\u09CD\u0A4D\u0ACD\u0B4D\u0C4D\u0CCD\u0F84\u1039\u17D2\u1A60\u1A7F]";
 const graphemeRegex = new RegExp("^.(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\W(?:" + accents_and_vowels + "+)?)?");
 
 let reg_ex_shaping = '[';
@@ -641,7 +641,7 @@ function splitLabelText(text, rtl){
         let testText = text;
         let graphemeCount = 0;
 
-        for (graphemeCount; graphemeCount < codon_length && testText.length > 0; graphemeCount++) {
+        for (graphemeCount; graphemeCount < codon_length && testText.length; graphemeCount++) {
             let graphemeCluster = (graphemeRegex.exec(testText) || testText)[0];
             segment += graphemeCluster;
             testText = testText.substring(graphemeCluster.length);

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -580,7 +580,7 @@ const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
 "\u0B01-\u0B03\u0B3C\u0B3E-\u0B4C\u0B56\u0B57\u0B62\u0B63" + // Oriya
 "\u0B82\u0BBE-\u0BCD\u0BD7" + // Tamil
 "\u0C00-\u0C03\u0C3E-\u0C4C\u0C55\u0C56\u0C62\u0C63" + // Telugu
-"\u0D82-\u0D83\u0DCF-\u0DDF\u0DF2\u0DF3" + // Sinhala
+"\u0D82\u0D83\u0DCA-\u0DDF\u0DF2\u0DF3" + // Sinhala
 "\u102B-\u1038\u103A-\u103E\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F\u109A-\u109D" + // Burmese
 "\u1A55-\u1A5E\u1A61-\u1A7C" + // Tai Tham
 "\u1DC0-\u1DFF" + // Combining Diacritical Marks Supplement

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -569,7 +569,6 @@ CanvasText.texcoord_cache = {};
 const context_langs = {
     Arabic: "\u0600-\u06FF",
     Bengali: "\u0980-\u09FF",
-    Burmese: "\u1000-\u109F",
     Devanagari: "\u0900-\u097F",
     Khmer: "\u1780-\u17FF",
     Gujarati: "\u0A80-\u0AFF",
@@ -582,6 +581,9 @@ const context_langs = {
     Telugu: "\u0C00-\u0C7F",
     Tibetan: "\u0F00-\u0FFF"
 };
+
+const accents_and_vowels = "[:\u0300-\u036F\u0902\u093E-\u0944\u0947\u0948\u094B\u094C\u0962\u0963\u0981\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB\u09CC\u09D7\u09E2\u09E3\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u102B-\u1032\u1036-\u1038\u103A-\u103E\u1056-\u1059\u1AB0-\u1AFF\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]";
+const combo_characters = "[\u094D\u09CD\u1039]";
 
 let reg_ex_shaping = '[';
 for (let key in context_langs){
@@ -628,7 +630,20 @@ function splitLabelText(text, rtl){
 
     let segments = [];
     while (text.length){
-        let segment = text.substring(0, codon_length);
+        let segment = '';
+        let testText = text;
+        let graphemeCount = 0;
+
+        for (graphemeCount; graphemeCount < codon_length; graphemeCount++) {
+            let graphemeRegex = new RegExp(testText[0] + "(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\w(" + accents_and_vowels + ")?)?");
+            let graphemeCluster = testText.match(graphemeRegex);
+            if (graphemeCluster) {
+                segment += graphemeCluster[0];
+            } else {
+                break;
+            }
+            testText = testText.substring(graphemeCluster[0].length);
+        }
 
         // if RTL, check to see if segment starts or ends on a neutral character
         // in which case we need to add the neutral segments separately

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -590,8 +590,7 @@ const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
 "\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD" + // Lao
 "]";
 const combo_characters = "[\u094D\u09CD\u1039\u17D2\u0A4D\u0ACD\u0C4D\u0CCD\u0B4D\u1A60\u1A7F\u0DCA]";
-const graphemeRegex = new RegExp(".(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\w(" + accents_and_vowels + ")?)?");
-
+const graphemeRegex = new RegExp("^.(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\W(?:" + accents_and_vowels + "+)?)?");
 
 let reg_ex_shaping = '[';
 for (let key in context_langs){
@@ -642,12 +641,10 @@ function splitLabelText(text, rtl){
         let testText = text;
         let graphemeCount = 0;
 
-        for (graphemeCount; graphemeCount < codon_length; graphemeCount++) {
-            let graphemeCluster = graphemeRegex.exec(testText);
-            if (graphemeCluster) {
-                segment += graphemeCluster[0];
-                testText = testText.substring(graphemeCluster[0].length);
-            }
+        for (graphemeCount; graphemeCount < codon_length && testText.length > 0; graphemeCount++) {
+            let graphemeCluster = (graphemeRegex.exec(testText) || testText)[0];
+            segment += graphemeCluster;
+            testText = testText.substring(graphemeCluster.length);
         }
 
         // if RTL, check to see if segment starts or ends on a neutral character

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -570,20 +570,26 @@ const context_langs = {
     Arabic: "\u0600-\u06FF",
     Bengali: "\u0980-\u09FF",
     Devanagari: "\u0900-\u097F",
-    Khmer: "\u1780-\u17FF",
-    Gujarati: "\u0A80-\u0AFF",
-    Gurmukhi: "\u0A00-\u0A7F",
-    Kannada: "\u0C80-\u0CFF",
-    Lao: "\u0E80-\u0EFF",
     Mongolian: "\u1800-\u18AF",
-    Oriya: "\u0B00-\u0B7F",
-    Tamil: "\u0B80-\u0BFF",
-    Telugu: "\u0C00-\u0C7F",
     Tibetan: "\u0F00-\u0FFF"
 };
 
-const accents_and_vowels = "[:\u0300-\u036F\u0902\u093E-\u0944\u0947\u0948\u094B\u094C\u0962\u0963\u0981\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB\u09CC\u09D7\u09E2\u09E3\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u102B-\u1032\u1036-\u1038\u103A-\u103E\u1056-\u1059\u1AB0-\u1AFF\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]";
-const combo_characters = "[\u094D\u09CD\u1039]";
+const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
+"\u0A01-\u0A03\u0A3C-\u0A4C\u0A51" + // Gurmukhi
+"\u0A81-\u0A83\u0ABC\u0ABE-\u0ACC\u0AE2\u0AE3" + // Gujarati
+"\u0B01-\u0B03\u0B3C\u0B3E-\u0B4C\u0B56\u0B57\u0B62\u0B63" + // Oriya
+"\u0B82\u0BBE-\u0BCD\u0BD7" + // Tamil
+"\u0C00-\u0C03\u0C3E-\u0C4C\u0C55\u0C56\u0C62\u0C63" + // Telugu
+"\u0D82-\u0D83\u0DCF-\u0DDF\u0DF2\u0DF3" + // Sinhala
+"\u102B-\u1038\u103A-\u103E\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F\u109A-\u109D" + // Burmese
+"\u1A55-\u1A5E\u1A61-\u1A7C" + // Tai Tham
+"\u1DC0-\u1DFF" + // Combining Diacritical Marks Supplement
+"\u20D0-\u20FF" + // Combining Diacritical Marks for Symbols
+"\u17B4-\u17D1\u17D3" + // Khmer
+"\u0C80-\u0C83\u0CBC\u0CBE-\u0CCC\u0CD5\u0CD6\u0CE2\u0CE3" + // Kannada
+"\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD" + // Lao
+"]";
+const combo_characters = "[\u094D\u09CD\u1039\u17D2\u0A4D\u0ACD\u0C4D\u0CCD\u0B4D\u1A60\u1A7F\u0DCA]";
 
 let reg_ex_shaping = '[';
 for (let key in context_langs){

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -590,6 +590,8 @@ const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
 "\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD" + // Lao
 "]";
 const combo_characters = "[\u094D\u09CD\u1039\u17D2\u0A4D\u0ACD\u0C4D\u0CCD\u0B4D\u1A60\u1A7F\u0DCA]";
+const graphemeRegex = new RegExp(".(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\w(" + accents_and_vowels + ")?)?");
+
 
 let reg_ex_shaping = '[';
 for (let key in context_langs){
@@ -641,14 +643,11 @@ function splitLabelText(text, rtl){
         let graphemeCount = 0;
 
         for (graphemeCount; graphemeCount < codon_length; graphemeCount++) {
-            let graphemeRegex = new RegExp(testText[0] + "(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\w(" + accents_and_vowels + ")?)?");
-            let graphemeCluster = testText.match(graphemeRegex);
+            let graphemeCluster = graphemeRegex.exec(testText);
             if (graphemeCluster) {
                 segment += graphemeCluster[0];
-            } else {
-                break;
+                testText = testText.substring(graphemeCluster[0].length);
             }
-            testText = testText.substring(graphemeCluster[0].length);
         }
 
         // if RTL, check to see if segment starts or ends on a neutral character

--- a/src/styles/text/canvas_text.js
+++ b/src/styles/text/canvas_text.js
@@ -579,18 +579,20 @@ const accents_and_vowels = "[:\u0300-\u036F" + // Combining Diacritical Marks
 "\u0B01-\u0B03\u0B3C\u0B3E-\u0B4C\u0B56\u0B57\u0B62\u0B63" + // Oriya
 "\u0B82\u0BBE-\u0BCD\u0BD7" + // Tamil
 "\u0C00-\u0C03\u0C3E-\u0C4C\u0C55\u0C56\u0C62\u0C63" + // Telugu
+"\u0C81-\u0C83\u0CBC\u0CBE-\u0CCC\u0CD5\u0CD6\u0CE2\u0CE3" + // Kannada
+"\u0D01-\u0D03\u0D3E-\u0D4C\u0D4E\u0D57\u0D62\u0D63" + // Malayalam
 "\u0D82\u0D83\u0DCA-\u0DDF\u0DF2\u0DF3" + // Sinhala
+"\u0E31\u0E34-\u0E3A\u0E47-\u0E4E" + // Thai
+"\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD" + // Lao
 "\u0F18\u0F19\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F83\u0F86\u0F87\u0F8D-\u0FBC\u0FC6" + // Tibetan
 "\u102B-\u1038\u103A-\u103E\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F\u109A-\u109D" + // Burmese
+"\u17B4-\u17D1\u17D3" + // Khmer
 "\u1A55-\u1A5E\u1A61-\u1A7C" + // Tai Tham
 "\u1DC0-\u1DFF" + // Combining Diacritical Marks Supplement
 "\u20D0-\u20FF" + // Combining Diacritical Marks for Symbols
-"\u17B4-\u17D1\u17D3" + // Khmer
-"\u0C80-\u0C83\u0CBC\u0CBE-\u0CCC\u0CD5\u0CD6\u0CE2\u0CE3" + // Kannada
-"\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD" + // Lao
 "]";
-const combo_characters = "[\u094D\u09CD\u0A4D\u0ACD\u0B4D\u0C4D\u0CCD\u0F84\u1039\u17D2\u1A60\u1A7F]";
-const graphemeRegex = new RegExp("^.(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\W(?:" + accents_and_vowels + "+)?)?");
+const combo_characters = "[\u094D\u09CD\u0A4D\u0ACD\u0B4D\u0C4D\u0CCD\u0D4D\u0F84\u1039\u17D2\u1A60\u1A7F]";
+const graphemeRegex = new RegExp("^.(?:" + accents_and_vowels + "+)?" + "(" + combo_characters + "\\W(?:" + accents_and_vowels + "+)?)*");
 
 let reg_ex_shaping = '[';
 for (let key in context_langs){


### PR DESCRIPTION
I saw Mapzen's [blog post](https://mapzen.com/blog/curved-labels) about curved labels awhile ago and was interested in how I could expand it to more languages

![screen shot 2017-05-04 at 11 17 12 am](https://cloud.githubusercontent.com/assets/643918/25719497/90732694-30be-11e7-96f9-8b34fc24574f.png)

Burmese (pictured above) has some text-shaping - for example the word "ဟို" is three chars long. But it's similar to how "ý" can be two chars. Burmese doesn't connect all letters like Arabic or Devanagari. By counting grapheme clusters instead of chars, we can prevent both writing systems from being split up irregularly. That's what this pull request fixes.

The RegEx is long because it includes other writing systems (at least Latin alphabet, Devanagari and Tamil), but I have not enabled or tested them in curved labels yet.

In the future it would be possible to use [Intl.Segmenter or a polyfill](https://gist.github.com/inexorabletash/8c4d869a584bcaa18514729332300356).

Arabic is another level of complexity (choosing the right initial/medial/final/isolated form) but it might be possible based on previous work [in OSM iD](https://gist.github.com/mapmeld/556b09ddec07a2044c76e1ef45f01c60) and [circular-arabic](https://github.com/mapmeld/circular-arabic).

Edit: fixed screenshot, always preview