### PR TITLE
Adds the ability to query features from tile data

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -4,6 +4,7 @@ import debugSettings from './utils/debug_settings';
 import * as URLs from './utils/urls';
 import WorkerBroker from './utils/worker_broker';
 import subscribeMixin from './utils/subscribe';
+import sliceObject from './utils/slice';
 import Context from './gl/context';
 import Texture from './gl/texture';
 import ShaderProgram from './gl/shader_program';
@@ -752,9 +753,13 @@ export default class Scene {
         return WorkerBroker.postMessage(this.workers, 'self.queryFeatures', { filter, tile_keys }).then(results => {
             let features = [];
             let keys = {};
+
+            unique = (typeof unique === 'string') ? [unique] : unique;
+            const uniqueify = obj => JSON.stringify(Array.isArray(unique) ? sliceObject(obj, unique) : obj);
+
             results.forEach(r => r.forEach(feature => {
                 if (unique) {
-                    let str = JSON.stringify(feature.properties);
+                    let str = uniqueify(feature.properties);
                     if (keys[str]) {
                         return;
                     }

--- a/src/scene.js
+++ b/src/scene.js
@@ -746,6 +746,26 @@ export default class Scene {
             catch(error => Promise.resolve({ error }));
     }
 
+    // Query features within visible tiles, with optional filter conditions
+    queryFeatures({ filter, unique = false } = {}) {
+        let tile_keys = this.tile_manager.getRenderableTiles().map(t => t.key);
+        return WorkerBroker.postMessage(this.workers, 'self.queryFeatures', { filter, tile_keys }).then(results => {
+            let features = [];
+            let keys = {};
+            results.forEach(r => r.forEach(feature => {
+                if (unique) {
+                    let str = JSON.stringify(feature.properties);
+                    if (keys[str]) {
+                        return;
+                    }
+                    keys[str] = true;
+                }
+                features.push(feature);
+            }));
+            return features;
+        });
+    }
+
     // Rebuild all tiles, without re-parsing the config or re-compiling styles
     // sync: boolean of whether to sync the config object to the worker
     // sources: optional array of data sources to selectively rebuild (by default all our rebuilt)

--- a/src/scene.js
+++ b/src/scene.js
@@ -748,15 +748,15 @@ export default class Scene {
     }
 
     // Query features within visible tiles, with optional filter conditions
-    queryFeatures({ filter, unique = false } = {}) {
+    queryFeatures({ filter, unique = true, visible = null } = {}) {
         filter = Utils.serializeWithFunctions(filter);
         let tile_keys = this.tile_manager.getRenderableTiles().map(t => t.key);
-        return WorkerBroker.postMessage(this.workers, 'self.queryFeatures', { filter, tile_keys }).then(results => {
+        return WorkerBroker.postMessage(this.workers, 'self.queryFeatures', { filter, visible, tile_keys }).then(results => {
             let features = [];
             let keys = {};
 
-            unique = (typeof unique === 'string') ? [unique] : unique;
-            const uniqueify = obj => JSON.stringify(Array.isArray(unique) ? sliceObject(obj, unique) : obj);
+            unique = (typeof unique === 'string') ? [unique] : unique; // single property name, or list of property names
+            const uniqueify = obj => unique && JSON.stringify(Array.isArray(unique) ? sliceObject(obj, unique) : obj);
 
             results.forEach(r => r.forEach(feature => {
                 if (unique) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -757,11 +757,14 @@ export default class Scene {
             let groups = {};
 
             // Optional uniqueify criteria
-            unique = (typeof unique === 'string') ? [unique] : unique; // single property name, or list of property names
+            // Valid values: true, false/null, single property name, or array of property names
+            unique = (typeof unique === 'string') ? [unique] : unique;
             const uniqueify = unique && (obj => JSON.stringify(Array.isArray(unique) ? sliceObject(obj, unique) : obj));
 
             // Optional grouping criteria
-            const group = group_by && (obj => { // single property name, or list of property names
+            // Valid values: false/null, single property name, or array of property names
+            group_by = (typeof group_by === 'string' || Array.isArray(group_by)) && group_by;
+            const group = group_by && (obj => {
                 return Array.isArray(group_by) ? JSON.stringify(sliceObject(obj, group_by)) : obj[group_by];
             });
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -774,7 +774,7 @@ export default class Scene {
     // Rebuild all tiles, without re-parsing the config or re-compiling styles
     // sync: boolean of whether to sync the config object to the worker
     // sources: optional array of data sources to selectively rebuild (by default all our rebuilt)
-    rebuild({ sync = true, sources = null, serialize_funcs, profile = false, fade_in = false } = {}) {
+    rebuild({ new_generation = true, sources = null, serialize_funcs, profile = false, fade_in = false } = {}) {
         return new Promise((resolve, reject) => {
             // Skip rebuild if already in progress
             if (this.building) {
@@ -786,7 +786,7 @@ export default class Scene {
                 }
 
                 // Save queued request
-                let options = { sync, sources, serialize_funcs, profile, fade_in };
+                let options = { new_generation, sources, serialize_funcs, profile, fade_in };
                 this.building.queued = { resolve, reject, options };
                 log('trace', `Scene.rebuild(): queuing request`);
                 return;
@@ -800,10 +800,17 @@ export default class Scene {
                 this._profile('Scene.rebuild');
             }
 
-            // Update config (in case JS objects were manipulated directly)
-            if (sync) {
-                this.syncConfigToWorker({ serialize_funcs });
+            // Increment generation to ensure style/tile building stay in sync
+            // (skipped if calling function already incremented)
+            if (new_generation) {
+                this.generation = ++Scene.generation;
+                for (let style in this.styles) {
+                    this.styles[style].setGeneration(this.generation);
+                }
             }
+
+            // Update config (in case JS objects were manipulated directly)
+            this.syncConfigToWorker({ serialize_funcs });
             this.resetFeatureSelection(sources);
             this.resetTime();
 
@@ -1071,7 +1078,7 @@ export default class Scene {
 
         // Optionally rebuild geometry
         let done = rebuild ?
-            this.rebuild(Object.assign({ serialize_funcs, fade_in }, typeof rebuild === 'object' && rebuild)) :
+            this.rebuild(Object.assign({ new_generation: false, serialize_funcs, fade_in }, typeof rebuild === 'object' && rebuild)) :
             this.syncConfigToWorker({ serialize_funcs }); // rebuild() also syncs config
 
         // Finish by updating bounds and re-rendering

--- a/src/scene.js
+++ b/src/scene.js
@@ -767,7 +767,7 @@ export default class Scene {
 
             results.forEach(r => r.forEach(feature => {
                 if (uniqueify) {
-                    let str = uniqueify(feature.properties);
+                    let str = uniqueify(feature);
                     if (keys[str]) {
                         return;
                     }

--- a/src/scene.js
+++ b/src/scene.js
@@ -749,6 +749,7 @@ export default class Scene {
 
     // Query features within visible tiles, with optional filter conditions
     queryFeatures({ filter, unique = false } = {}) {
+        filter = Utils.serializeWithFunctions(filter);
         let tile_keys = this.tile_manager.getRenderableTiles().map(t => t.key);
         return WorkerBroker.postMessage(this.workers, 'self.queryFeatures', { filter, tile_keys }).then(results => {
             let features = [];

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -230,7 +230,11 @@ Object.assign(self, {
         let features = [];
         let tiles = tile_keys.map(t => self.tiles[t]).filter(t => t);
 
-        filter = Utils.stringsToFunctions(filter, StyleParser.wrapFunction);
+        // Compile feature filter
+        if (filter != null) {
+            filter = ['{', '['].indexOf(filter[0]) > -1 ? JSON.parse(filter) : filter; // de-serialize if looks like an object
+            filter = Utils.stringsToFunctions(filter, StyleParser.wrapFunction);
+        }
         filter = buildFilter(filter, FilterOptions);
 
         tiles.forEach(tile => {

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -226,7 +226,7 @@ Object.assign(self, {
     },
 
     // Query features within visible tiles, with optional filter conditions
-    queryFeatures ({ filter, tile_keys }) {
+    queryFeatures ({ filter, visible, tile_keys }) {
         let features = [];
         let tiles = tile_keys.map(t => self.tiles[t]).filter(t => t);
 
@@ -241,6 +241,13 @@ Object.assign(self, {
             for (let layer in tile.source_data.layers) {
                 let data = tile.source_data.layers[layer];
                 data.features.forEach(feature => {
+                    // Optionally check if feature is visible (e.g. was rendered for current generation)
+                    if ((visible === true && feature.generation !== self.generation) ||
+                        (visible === false && feature.generation === self.generation)) {
+                        return;
+                    }
+
+                    // Apply feature filter
                     let context = StyleParser.getFeatureParseContext(feature, tile, self.global);
                     context.source = tile.source;  // add data source name
                     context.layer = layer;         // add data source layer name

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -365,7 +365,7 @@ export class LayerTree extends Layer {
 
 }
 
-const FilterOptions = {
+export const FilterOptions = {
     // Handle unit conversions on filter ranges
     rangeTransform(val) {
         if (typeof val === 'string' && val.trim().slice(-3) === 'px2') {

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -122,13 +122,6 @@ Object.assign(Points, {
             return;
         }
 
-        // Called here because otherwise it will be delayed until the feature queue is parsed,
-        // and we want the preprocessing done before we evaluate text style below
-        draw = this.preprocess(draw);
-        if (!draw) {
-            return;
-        }
-
         // Point styling
         let style = {};
         style.color = this.parseColor(draw.color, context);

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -163,10 +163,8 @@ export var Style = {
         }
 
         let style = this.parseFeature(feature, draw, context);
-
-        // Skip feature?
         if (!style) {
-            return;
+            return; // skip feature
         }
 
         // First feature in this render style?
@@ -251,23 +249,26 @@ export var Style = {
                 return;
             }
 
-            // Feature selection (only if style supports it)
-            var selectable = false;
-            style.interactive = this.introspection || draw.interactive;
-            if (this.selection) {
-                selectable = StyleParser.evalProperty(style.interactive, context);
+            // Subclass implementation
+            style = this._parseFeature(feature, draw, context);
+            if (!style) {
+                return; // skip feature
             }
 
-            // If feature is marked as selectable
-            if (selectable) {
+            // Feature selection (only if feature is marked as interactive, and style supports it)
+            if (this.selection) {
+                style.interactive = StyleParser.evalProperty(this.introspection || draw.interactive, context);
+            }
+            else {
+                style.interactive = false;
+            }
+
+            if (style.interactive === true) {
                 style.selection_color = FeatureSelection.makeColor(feature, context.tile, context);
             }
             else {
                 style.selection_color = FeatureSelection.defaultColor;
             }
-
-            // Subclass implementation
-            style = this._parseFeature(feature, draw, context);
 
             return style;
         }

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -174,7 +174,9 @@ export var Style = {
             this.tile_data[tile.key].vertex_data = this.vertex_layout.createVertexData();
         }
 
-        this.buildGeometry(feature.geometry, style, this.tile_data[tile.key].vertex_data, context);
+        if (this.buildGeometry(feature.geometry, style, this.tile_data[tile.key].vertex_data, context) > 0) {
+            feature.generation = this.generation; // track scene generation that feature was rendered for
+        }
     },
 
     buildGeometry (geometry, style, vertex_data, context) {
@@ -228,6 +230,8 @@ export var Style = {
                 }
             });
         }
+
+        return geom_count;
     },
 
     parseFeature (feature, draw, context) {

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -17,6 +17,7 @@ StyleParser.wrapFunction = function (func) {
         var global = context.global;
         var $zoom = context.zoom;
         var $layer = context.layer;
+        var $source = context.source;
         var $geometry = context.geometry;
         var $meters_per_pixel = context.meters_per_pixel;
 

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -75,13 +75,6 @@ Object.assign(TextStyle, {
             return;
         }
 
-        // Called here because otherwise it will be delayed until the feature queue is parsed,
-        // and we want the preprocessing done before we evaluate text style below
-        draw = this.preprocess(draw);
-        if (!draw) {
-            return;
-        }
-
         let type = feature.geometry.type;
         draw.can_articulate = (type === "LineString" || type === "MultiLineString");
 

--- a/src/utils/slice.js
+++ b/src/utils/slice.js
@@ -1,0 +1,5 @@
+export default function sliceObject (obj, keys) {
+    let sliced = {};
+    keys.forEach(k => sliced[k] = obj[k]);
+    return sliced;
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -118,7 +118,11 @@ Utils.requestAnimationFramePolyfill = function () {
 
 // Stringify an object into JSON, but convert functions to strings
 Utils.serializeWithFunctions = function (obj) {
-    var serialized = JSON.stringify(obj, function(k, v) {
+    if (typeof obj === 'function') {
+        return obj.toString();
+    }
+
+    let serialized = JSON.stringify(obj, function(k, v) {
         // Convert functions to strings
         if (typeof v === 'function') {
             return v.toString();

--- a/src/utils/worker_broker.js
+++ b/src/utils/worker_broker.js
@@ -102,6 +102,10 @@ WorkerBroker.addTarget = function (name, target) {
     targets[name] = target;
 };
 
+WorkerBroker.removeTarget = function (name) {
+    delete targets[name];
+};
+
 // Given a dot-notation-style method name, e.g. 'Object.object.method',
 // find the object to call the method on from the list of registered targets
 function findTarget (method) {


### PR DESCRIPTION
This PR adds a `Scene.queryFeatures()` method for directly querying tile data (separate from the existing [`Scene.getFeatureAt()`](https://mapzen.com/documentation/tangram/Javascript-API/#getfeatureatpixel) method, which returns a single feature at a given pixel location).

## Syntax

The query method has the following signature and default parameters:
`queryFeatures({ filter = null, visible = null, unique = true, group_by = null, geometry = false })`

- `queryFeatures()` will query the features from tiles that **currently intersect the map viewport**.
  - The method returns a promise with an array of matching features, e.g. `queryFeatures().then(features => console.log(features));` will print the matching features to the console. (An array is the default return type, see `group_by` below for an alternate format.)
  - Each returned result will have a `properties` field for that feature. See the `geometry` option below to include feature geometry with the results.
  - Optional parameters described below will further limit the set of features returned.
  - Because tiles usually include some area outside the viewport, the `queryFeatures()` method can be thought of as roughly querying the visible area, but results may include some nearby features as well. This effect can also be caused tile over-zooming, for data sources with a [`max_zoom`](https://mapzen.com/documentation/tangram/sources/#max_zoom).
- `filter`
  - An optional filter object with [the same syntax](https://mapzen.com/documentation/tangram/Filters-Overview/) used for selecting features for styling in `layers`. If no `filter` is provided, all features will be returned (subject to other parameters defined below).
  - Example: `scene.queryFeatures({ filter: { $layer: 'pois', kind: 'restaurant' } })` will return all restaurants in the `pois` layer. 
  - Filters used with this method support an additional parameter, `$source`, which can be used to specify a data source name to filter features by. For example, `filter: { $source: 'mapzen' }` will only return features from the `mapzen` data source. (This parameter is not relevant for filters in `layers` because the data source is already explicitly selected by the `data` block.)
- `visible`
  - By default, *all* features in the tile source data will be returned, regardless of whether they were rendered in the scene or not.
  - If `visible: true`, the query will be restricted only to *features that were rendered* in the scene. Note that this means the feature matched a visible `draw` group within `layers`, and was not culled by collision detection (in the case of points or labels). It does not guarantee, however, that the feature is visible from any given view position; it may be drawn but underneath another feature with a higher `order` value, or it may be behind another 3d object such as a building.
    - Example: `scene.queryFeatures({ filter: { $layer: 'landuse', $geometry: 'polygon' }, visible: true })` will return all visible landuse polygons.
  - If `visible: false`, the query will be restricted only to *features that were NOT rendered* in the scene. This is useful for providing feedback on data that is related to the scene but which you don't want to actually visualize, or for understanding which features were not drawn due to collision (lack of available space on screen).
    - Example: `scene.queryFeatures({ filter: { $layer: 'pois' }, visible: false })` will return all POIs that were not drawn. 
- `unique`
  - The `unique` parameter indicates whether (and how) duplicate features should be included in the results. Valid values are `true` (default), `false`/`null`, a string providing a single feature property (`id`), or an array of feature properties (`['kind', 'operator']`)
  - The default value, `true`, will limit features to those that are entirely unique, meaning it will exclude features with identical properties (and if the `geometry: true` option described below is also set, features with identical geometry will be excluded as well). This is useful for avoiding duplicate features that may be included in multiple tiles, such as building polygons in Mapzen's vector tiles.
  - A `false` or `null` value will return *all* features, without any regard to their properties or geometry.
  - A single string, or array of strings, will only return features that are unique with regards to the named feature properties (and geometry if `geometry: true`). For example, `unique: id` will avoid features with duplicate ids in the results, and `unique: ['kind', 'operator']` will only return a single feature for each unique combination of `kind` and `operator` property values.
- `group_by`
  - The `group_by` parameter can be used to group results by one or more unique property values. Valid values are `false`/`null` (the default), a string providing a single feature property (`kind`), or an array of feature properties (`['kind', 'kind_detail']`).
  - When grouping properties are specified, the `queryFeatures()` results will be an object (still returned via a promise), where each key is a unique value according to the grouping criteria, and the value of each key is an array of results for that key.
  - When a *single* property is provided for grouping, the results key will be the value of that property. 
    - Example: `queryFeatures({ filter: { $layer: 'pois' }, group_by: 'kind' })` will return results like:
      - `{ station: Array(8), jewelry: Array(19), bus_stop: Array(5)... }`
  - When *multiple* properties are provided the grouping, the results key will be a *stringified object for each unique combination of values*.
    - Example: `queryFeatures({ filter: { $layer: 'pois' }, group_by: ['kind', 'kind_detail'] })` will return results like:
      ```
      {
        '{"kind":"restaurant","kind_detail":"chinese"}': Array(8),
        '{"kind":"restaurant","kind_detail":"french"}': Array(4),
        '{"kind":"restaurant","kind_detail":"indian"}': Array(3),
        ...
      }
      ```
    - The caller can optionally use `JSON.parse()` to parse these stringified grouping keys for additional processing.
- `geometry`
  - By default, `queryFeatures()` does not return feature geometry, nor consider geometry when determining if a feature is unique (see `unique` parameter above). Only `type` and `properties` will be returned in the query results.
  - When `geometry: true`, an additional `geometry` property will also be returned, containing the feature's geometry (as a GeoJSON [`geometry`](https://tools.ietf.org/html/rfc7946#section-3.1) object).
  - Including feature geometry in the result can be useful for further visualizations outside of Tangram, such as with Leaflet markets or SVG paths, or even direct exports of raw GeoJSON.

## Use Cases

Here are a few examples of ways the `queryFeatures()` parameters can be used.

**Get a list of unique subway lines in tile data**
```
scene.queryFeatures({ filter: { $layer: 'transit', kind: 'subway' }, group_by: 'ref' }).then(results => {
  console.log(Object.keys(results));
});

--->
["1", "2", "3", "4", "5", "6", "W", "R", "J", "Z", "PATH", "E", "C", "A", "D", "B", "Q", "N"]
```

**Get a count of visible POIs by kind, each time new tiles are rendered**
```
scene.subscribe({
  view_complete: function() { // when new tiles are rendered
    scene.queryFeatures({ filter: { $layer: 'pois' }, visible: true, group_by: 'kind' }).then(results => {
      for (let key in results) { 
        results[key] = results[key].length;
      }
      console.log(results);
    });
  }
});

--->
{
  "station": 6,
  "cafe": 20,
  "bank": 5,
  "restaurant": 34,
  "convenience": 10,
  "place_of_worship": 5,
  "bus_stop": 5,
  "hotel": 10,
  "museum": 1,
  "pub": 3,
  "bar": 2,
  "hospital": 1
}
```

**Add Leaflet markers for visible restaurant POIs**
```
scene.queryFeatures({ filter: { $layer: 'pois', kind: 'restaurant' }, visible: true, geometry: true }).then(results => {
  results.forEach(feature => {
    L.marker([feature.geometry.coordinates[1], feature.geometry.coordinates[0]]).addTo(map);
  });
});
```
![screen shot 2017-06-12 at 1 43 48 pm](https://user-images.githubusercontent.com/16733/27047203-368c1a0c-4f75-11e7-87d5-7608b6ef68da.png)

**Add Leaflet polylines (SVG) for major roads**
```
scene.queryFeatures({ filter: { $layer: 'roads', kind: 'major_road' }, unique: false, visible: true, geometry: true }).then(results => {
  results.forEach(feature => L.geoJSON(feature, {
    style: function () {
        return { color: 'red' };
    }
  }).addTo(map))
});
```
![screen shot 2017-06-12 at 1 48 01 pm](https://user-images.githubusercontent.com/16733/27047385-e9c44be4-4f75-11e7-90e0-c6be3d70ec94.png)
