### PR TITLE
Add background color parameter for screenshots

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -1142,9 +1142,9 @@ export default class Scene {
     // Take a screenshot
     // Asynchronous because we have to wait for next render to capture buffer
     // Returns a promise
-    screenshot () {
+    screenshot ({ background = 'white' } = {}) {
         this.requestRedraw();
-        return this.media_capture.screenshot();
+        return this.media_capture.screenshot({background});
     }
 
     startVideoCapture () {


### PR DESCRIPTION
Adds an optional background color that will be blended with any translucent pixels in the scene when capturing a screenshot. In normal browser presentation, these pixels are blended with whatever HTML content is behind them. With this optional parameter, users have more control to achieve similar when capturing a screenshot.

The existing `scene.screenshot()` method signature is expanded to support a `background` parameter:

`scene.screenshot ({ background = 'white' }`

The `background` parameter defaults to `white`. This is because while the Tangram scene's default background is `transparent`, it is always viewed against an opaque browser background (which itself defaults to white, absent any user styling). As such, a default screenshot background color of white is most likely to match the user's expectations. However, the background can still be set to `transparent`, or to any other color format accepted by Tangram (`red`, `[0.5, 0.5, 0]`, etc.).

Example of capturing a screenshot with an explicit transparent background, then opening it in a new window:

`scene.screenshot({ background: 'transparent' }).then(s => window.open(s.url))`
