### PR TITLE
Add optional pixel radius for feature selection

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -143,7 +143,7 @@ function extendLeaflet(options) {
 
                 // Setup feature selection
                 this.setupSelectionEventHandlers(map);
-                this.setSelectionEvents(this.options.events);
+                this.setSelectionEvents(this.options.events, { radius: this.options.selectionRadius });
 
                 // Add GL canvas to layer container
                 this.scene.container = this.getContainer();
@@ -415,10 +415,11 @@ function extendLeaflet(options) {
             // Tie Leaflet event handlers to Tangram feature selection
             setupSelectionEventHandlers (map) {
                 this._selection_events = {};
+                this._selection_radius = null; // optional radius
 
                 this.hooks.click = (event) => {
                     if (typeof this._selection_events.click === 'function') {
-                        this.scene.getFeatureAt(event.containerPoint).
+                        this.scene.getFeatureAt(event.containerPoint, { radius: this._selection_radius }).
                             then(selection => {
                                 let results = Object.assign({}, selection, { leaflet_event: event });
                                 this._selection_events.click(results);
@@ -429,7 +430,7 @@ function extendLeaflet(options) {
 
                 this.hooks.mousemove = (event) => {
                     if (typeof this._selection_events.hover === 'function') {
-                        this.scene.getFeatureAt(event.containerPoint).
+                        this.scene.getFeatureAt(event.containerPoint, { radius: this._selection_radius }).
                             then(selection => {
                                 let results = Object.assign({}, selection, { leaflet_event: event });
                                 this._selection_events.hover(results);
@@ -450,8 +451,9 @@ function extendLeaflet(options) {
             // Set user-defined handlers for feature selection events
             // Currently only one handler can be defined for each event type
             // Event types are: `click`, `hover` (leaflet `mousemove`)
-            setSelectionEvents (events) {
+            setSelectionEvents (events, { radius } = {}) {
                 this._selection_events = Object.assign(this._selection_events, events);
+                this._selection_radius = (radius !== undefined) ? radius : this._selection_radius;
             },
 
             // Track the # of layers in the map pane

--- a/src/scene.js
+++ b/src/scene.js
@@ -729,19 +729,29 @@ export default class Scene {
     }
 
     // Request feature selection at given pixel. Runs async and returns results via a promise.
-    getFeatureAt(pixel) {
+    getFeatureAt(pixel, { radius } = {}) {
         if (!this.initialized) {
             log('debug', "Scene.getFeatureAt() called before scene was initialized");
             return Promise.resolve();
         }
 
-        // Point scaled to [0..1] range
-        var point = {
-            x: pixel.x * Utils.device_pixel_ratio / this.view.size.device.width,
-            y: pixel.y * Utils.device_pixel_ratio / this.view.size.device.height
+        // Scale point and radius to [0..1] range
+        let point = {
+            x: pixel.x / this.view.size.css.width,
+            y: pixel.y / this.view.size.css.height
         };
 
-        return this.selection.getFeatureAt(point).
+        if (radius > 0) {
+            radius  = {
+                x: radius / this.view.size.css.width,
+                y: radius / this.view.size.css.height
+            };
+        }
+        else {
+            radius = null;
+        }
+
+        return this.selection.getFeatureAt(point, { radius }).
             then(selection => Object.assign(selection, { pixel })).
             catch(error => Promise.resolve({ error }));
     }

--- a/src/selection.js
+++ b/src/selection.js
@@ -17,16 +17,13 @@ export default class FeatureSelection {
         this.feature = null; // currently selected feature
         this.read_delay = 0; // delay time from selection render to framebuffer sample, to avoid CPU/GPU sync lock
         this.read_delay_timer = null; // current timer (setTimeout) for delayed selection reads
-
-        this.pixel = new Uint8Array(4);
-        this.pixel32 = new Float32Array(this.pixel.buffer);
+        this.pixels = null; // allocated lazily on request
 
         // Frame buffer for selection
         // TODO: initiate lazily in case we don't need to do any selection
         this.fbo = this.gl.createFramebuffer();
         this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.fbo);
         this.fbo_size = { width: 256, height: 256 }; // TODO: make configurable / adaptive based on canvas size
-        this.fbo_size.aspect = this.fbo_size.width / this.fbo_size.height;
 
         // Texture for the FBO color attachment
         var fbo_texture = Texture.create( this.gl, 'selection_fbo', { filtering: 'nearest' });
@@ -66,7 +63,7 @@ export default class FeatureSelection {
 
     // Request feature selection
     // Runs asynchronously, schedules selection buffer to be updated
-    getFeatureAt(point) {
+    getFeatureAt(point, { radius }) {
         // ensure requested point is in canvas bounds
         if (!point || point.x < 0 || point.y < 0 || point.x > 1 || point.y > 1) {
             return Promise.resolve({ feature: null, changed: false });
@@ -78,6 +75,7 @@ export default class FeatureSelection {
             this.requests[this.selection_request_id] = {
                 id: this.selection_request_id,
                 point,
+                radius,
                 resolve,
                 reject
             };
@@ -135,14 +133,73 @@ export default class FeatureSelection {
                 }
 
                 // Check selection map against FBO
+                let feature_key, worker_id = 255;
+                let {point, radius} = request;
+                let diam_px;
+
+                if (!radius) {
+                    radius = { x: 0, y: 0 };
+                    diam_px = { x: 1, y: 1 };
+                }
+                else {
+                    // diameter in selection buffer pixels
+                    let max_radius = Math.min(this.fbo_size.width, this.fbo_size.height);
+                    diam_px = {
+                        x: Math.min(Math.ceil(radius.x * 2 * this.fbo_size.width), max_radius),
+                        y: Math.min(Math.ceil(radius.y * 2 * this.fbo_size.height), max_radius)
+                    };
+                }
+
+                // allocate or resize
+                if (this.pixels == null || this.pixels.byteLength < diam_px.x * diam_px.y * 4) {
+                    this.pixels = new Uint8Array(diam_px.x * diam_px.y * 4);
+                }
+
+                // clear pixels
+                if (this.pixels.fill instanceof Function) {
+                    this.pixels.fill(0); // native typed array fill
+                }
+                else {
+                    for (let p=0; p < this.pixels.length; p++) {
+                        this.pixels[p] = 0;
+                    }
+                }
+
+                // capture pixels
                 gl.readPixels(
-                    Math.floor(request.point.x * this.fbo_size.width),
-                    Math.floor((1 - request.point.y) * this.fbo_size.height),
-                    1, 1, gl.RGBA, gl.UNSIGNED_BYTE, this.pixel);
-                var feature_key = (this.pixel[0] + (this.pixel[1] << 8) + (this.pixel[2] << 16) + (this.pixel[3] << 24)) >>> 0;
+                    Math.round(((point.x - radius.x) * this.fbo_size.width)),
+                    Math.round((1 - point.y - radius.y) * this.fbo_size.height),
+                    diam_px.x, diam_px.y, gl.RGBA, gl.UNSIGNED_BYTE, this.pixels);
+
+                // first check center pixel (avoid scanning all pixels if cursor is directly on a feature)
+                let p = (Math.round(diam_px.y / 2) * diam_px.x + Math.round(diam_px.x / 2)) * 4;
+                let v = this.pixels[p] + (this.pixels[p+1] << 8) + (this.pixels[p+2] << 16); // feature id in RGB channels
+                if (v > 0) {
+                    feature_key = (v + (this.pixels[p+3] << 24)) >>> 0; // worker id in alpha channel
+                    worker_id = this.pixels[p+3];
+                }
+                else {
+                    // scan all pixels for feature closest to cursor
+                    let min_dist = -1 >>> 0;
+                    p = 0;
+                    for (let y=0; y < diam_px.y; y++) {
+                        for (let x=0; x < diam_px.x; x++, p += 4) {
+                            v = this.pixels[p] + (this.pixels[p+1] << 8) + (this.pixels[p+2] << 16); // feature id in RGB channels
+                            if (v > 0) { // non-zero value indicates a feature
+                                // check to see if closer than last found feature
+                                let dist = (x - diam_px.x/2) * (x - diam_px.x/2) + (y - diam_px.y/2) * (y - diam_px.y/2);
+                                if (dist <= min_dist) {
+                                    // get worker id from alpha channel
+                                    feature_key = (v + (this.pixels[p+3] << 24)) >>> 0;
+                                    worker_id = this.pixels[p+3];
+                                    min_dist = dist;
+                                }
+                            }
+                        }
+                    }
+                }
 
                 // If feature found, ask appropriate web worker to lookup feature
-                var worker_id = this.pixel[3];
                 if (worker_id !== 255) { // 255 indicates an empty selection buffer pixel
                     if (this.workers[worker_id] != null) {
                         WorkerBroker.postMessage(


### PR DESCRIPTION
This PR adds an optional pixel radius when requesting features at/near a pixel location. Previously, feature selection only returned a feature at the *exact* pixel location provided, but there are common use cases where a larger radius is useful, such as:

- Mobile devices where input is not always so precise
- Features such as thin lines may be difficult to select

The following methods are affected:

- Direct scene interface:
  - `scene.getFeatureAt(pixel, { radius })`
- Leaflet layer interface for setting selection handlers
  -  `layer.setSelectionEvents (events, { radius })`
- Leaflet layer instantiation: 
   ```
   layer = Tangram.leafletLayer({
      scene: 'path/to/scene.yaml',
      events: {
         click: clickHandler,
      },
      selectionRadius: 10
   };
   ```

In all cases, `radius` or `selectionRadius` is an optional value in pixels (default matches existing behavior, where radius is zero). When using a radius, **the feature closest to the center point** will be returned. (As with existing feature selection, only features marked as `interactive: true` will register.)
