### PR TITLE
Add optional `file_type` for scene.load()

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -159,8 +159,13 @@ function extendLeaflet(options) {
                 });
 
                 // Use leaflet's existing event system as the callback mechanism
-                this.scene.load(this.options.scene,
-                    { config_path: this.options.sceneBasePath, blocking: false }).then(() => {
+                this.scene.load(
+                    this.options.scene,
+                    {
+                        base_path: this.options.sceneBasePath,
+                        file_type: this.options.sceneFileType,
+                        blocking: false
+                    }).then(() => {
 
                     this._updating_tangram = true;
 

--- a/src/scene_bundle.js
+++ b/src/scene_bundle.js
@@ -192,7 +192,8 @@ export class ZipSceneBundle extends SceneBundle {
 }
 
 export function createSceneBundle(url, path, parent, type = null) {
-    if (type === 'zip' || (typeof url === 'string' && !URLs.isLocalURL(url) && URLs.extensionForURL(url) === 'zip')) {
+    if ((type != null && type === 'zip') ||
+        (typeof url === 'string' && !URLs.isLocalURL(url) && URLs.extensionForURL(url) === 'zip')) {
         return new ZipSceneBundle(url, path, parent);
     }
     return new SceneBundle(url, path, parent);

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -10,9 +10,9 @@ var SceneLoader;
 export default SceneLoader = {
 
     // Load scenes definitions from URL & proprocess
-    loadScene(url, path = null) {
+    loadScene(url, { path, type } = {}) {
         let errors = [];
-        return this.loadSceneRecursive({ url, path }, null, errors).
+        return this.loadSceneRecursive({ url, path, type }, null, errors).
             then(result => this.finalize(result)).
             then(({ config, bundle }) => {
                 if (!config) {


### PR DESCRIPTION
This adds an optional `file_type` for the `scene.load()` method (and `sceneFileType` for the Tangram Leaflet layer constructor). This allows for zip files to be loaded without .zip extension (previously, the filename had to end in '.zip' to trigger zip-loading).

This is useful for cases like loading a blob URL that contains a zipped scene file (see #565). For example:

`scene.load(zip_blob_url, { file_type: 'zip' });`

or 
```
layer = Tangram.leafletLayer({
   scene: zip_blob_url,
   sceneFileType: 'zip',
   ...
});
```

This also updates internal naming of `scene.config_path` to more intuitive `scene.base_path`. The existing `scene.config_path` accessor will be maintained for now, but eventually deprecated. Options to `scene.load()` should also be passed as an object, e.g.:

`scene.load(scene_url, { base_path: 'https://site.com/scene/resources/' });

(The previous [public documented API](https://mapzen.com/documentation/tangram/Javascript-API/#loadscene_url-base_path) only had a single second argument, which was used for base path - this is still backwards compatible but should be discouraged.)