### PR TITLE
Add translucent blend mode

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -62,15 +62,15 @@ textures:
 styles:
     buildings:
         base: polygons
+        blend: translucent
         shaders:
             blocks:
                 color: |
-                    // Modify lighting
-                    material.ambient.rgb = vec3(2.);
-                    material.diffuse.rgb = vec3(.5);
-
                     // Shade by building height
-                    color.rgb = vec3(min((worldPosition().z*.0005 + .65), .8));
+                    color.rgb *= vec3((worldPosition().z*.0005 + .9));
+
+                    // Add translucency at higher zoom
+                    color.a = clamp(mix(1., 0., (u_map_position.z - 15.) * .25), .5, 1.);
 
     icons:
         base: points

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -666,6 +666,7 @@ export var Style = {
     // Render state settings by blend mode
     render_states: {
         opaque: { depth_test: true, depth_write: true },
+        translucent: { depth_test: true, depth_write: true },
         add: { depth_test: true, depth_write: false },
         multiply: { depth_test: true, depth_write: false },
         inlay: { depth_test: true, depth_write: false },
@@ -675,10 +676,11 @@ export var Style = {
     // Default sort order for blend modes
     default_blend_orders: {
         opaque: 0,
-        add: 1,
-        multiply: 2,
-        inlay: 3,
-        overlay: 4
+        translucent: 1,
+        add: 2,
+        multiply: 3,
+        inlay: 4,
+        overlay: 5
     },
 
     // Comparison function for sorting styles by blend

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -676,10 +676,10 @@ export var Style = {
     // Default sort order for blend modes
     default_blend_orders: {
         opaque: 0,
-        translucent: 1,
-        add: 2,
-        multiply: 3,
-        inlay: 4,
+        add: 1,
+        multiply: 2,
+        inlay: 3,
+        translucent: 4,
         overlay: 5
     },
 


### PR DESCRIPTION
This is the JS equivalent of https://github.com/tangrams/tangram-es/pull/1615.

Adds a `blend: translucent` mode, that provides alpha blending for front-facing polygons (still culls back-faces). 

This branch adds a stencil buffer to our GL context, which is used to prevent repeated/overlapping polygons (e.g. buildings that may be repeated across tiles, or features rendered in proxy tiles) from drawing multiple times and causing undesirable compounding of the alpha channel.

![tangram-1503958930990](https://user-images.githubusercontent.com/16733/29796232-0939028c-8c1e-11e7-8da4-ff8de0859785.png)

![tangram-1503959021840](https://user-images.githubusercontent.com/16733/29796228-079d9690-8c1e-11e7-9eee-bffa51fc6366.png)
