### PR TITLE
Skip style when raster textures fail to load

### DIFF
--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -26,9 +26,9 @@ export default class Texture {
         this.texcoords = {};    // sprite UVs ([0, 1] range)
         this.sizes = {};        // sprite sizes (pixel size)
 
-        // Default to a 1-pixel black texture so we can safely render while we wait for an image to load
+        // Default to a 1-pixel transparent black texture so we can safely render while we wait for an image to load
         // See: http://stackoverflow.com/questions/19722247/webgl-wait-for-texture-to-load
-        this.setData(1, 1, new Uint8Array([0, 0, 0, 255]), { filtering: 'nearest' });
+        this.setData(1, 1, new Uint8Array([0, 0, 0, 0]), { filtering: 'nearest' });
         this.loaded = false; // don't consider loaded when only placeholder data is present
 
         // Destroy previous texture if present

--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -29,6 +29,7 @@ export default class Texture {
         // Default to a 1-pixel black texture so we can safely render while we wait for an image to load
         // See: http://stackoverflow.com/questions/19722247/webgl-wait-for-texture-to-load
         this.setData(1, 1, new Uint8Array([0, 0, 0, 255]), { filtering: 'nearest' });
+        this.loaded = false; // don't consider loaded when only placeholder data is present
 
         // Destroy previous texture if present
         if (Texture.textures[this.name]) {


### PR DESCRIPTION
When one or more of a style's attached raster texture fail to load (404 or other error), throw out the style for that tile. This fixes the issue in #598, where unavailable raster tiles would cover up areas of the map underneath.