### PR TITLE
Dynamic line dash patterns

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -29,7 +29,6 @@ cameras:
         active: false
 
 scene:
-    animated: true
     background:
         color: '#f0ebeb'
 
@@ -85,7 +84,7 @@ styles:
             blocks:
                 filter: |
                     color.rgb *= 1.25; // pump up the colors
-                    color.a = 0.5;     // translucent
+                    color.a *= 0.5;     // translucent
         draw: # default draw parameters
             color: function() { return feature.colour_name; }
             width: 6px

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -77,10 +77,6 @@ styles:
         base: points
         texture: icons
 
-    dashed:
-        base: lines
-        dash: [2, 1]
-
     transit-lines:
         base: lines
         blend: overlay
@@ -346,7 +342,7 @@ layers:
             filter: { kind: path }
             draw:
                 lines:
-                    style: dashed
+                    dash: [2, 1]
                     color: white
                     width: [[15, 0px], [18, 3px]]
                     outline:
@@ -366,7 +362,7 @@ layers:
             filter: { kind: ferry }
             draw:
                 lines:
-                    style: dashed
+                    dash: [2, 1]
                     color: '#8db3ce'
                     width: [[14, 1px], [18, 2px]]
                     outline:

--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -647,8 +647,9 @@ layers:
             lines:
                 visible: false
                 order: global.feature_order
-                width: 2px
+                width: 2.5px
                 color: wheat
+                dash: [1, 1, 3, 1]
 
         country:
             filter: { kind: country }
@@ -678,6 +679,7 @@ layers:
                 draw:
                     text:
                         priority: 1
+                        offset: [0, 2px]
                         text_source:
                             left: ['name:left:en', 'name:left']
                             right: ['name:right:en', 'name:right']

--- a/src/scene.js
+++ b/src/scene.js
@@ -1112,11 +1112,15 @@ export default class Scene {
 
         this.config = SceneLoader.applyGlobalProperties(this.config, this.config_globals_applied);
         if (normalize) {
+            // normalize whole scene
             SceneLoader.normalize(this.config, this.config_bundle);
+        }
+        else {
+            // just normalize top-level textures - necessary for adding base path to globals
+            SceneLoader.normalizeTextures(this.config, this.config_bundle);
         }
         this.trigger(load_event ? 'load' : 'update', { config: this.config });
 
-        SceneLoader.hoistTextures(this.config); // move inline textures into global texture set
         this.style_manager.init();
         this.view.reset();
         this.createLights();

--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -43,8 +43,9 @@ export default SceneLoader = {
         let bundle = createSceneBundle(url, path, parent, type);
 
         return bundle.load().then(config => {
+            this.normalize(config, bundle);
             if (config.import == null) {
-                return this.normalize(config, bundle);
+                return { config, bundle };
             }
 
             // accept single entry or array
@@ -69,7 +70,7 @@ export default SceneLoader = {
                     then(results => {
                         let configs = results.map(r => r.config);
                         config = mergeObjects({}, ...configs, config);
-                        return this.normalize(config, bundle);
+                        return { config, bundle };
                     });
         }).catch(error => {
             // Collect scene load errors as we go

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -5,7 +5,7 @@ import mergeObjects from '../utils/merge';
 import {buildFilter} from './filter';
 
 // N.B.: 'visible' is legacy compatibility for 'enabled'
-export const reserved = ['filter', 'draw', 'visible', 'enabled', 'data'];
+const reserved = ['filter', 'draw', 'visible', 'enabled', 'data'];
 
 let layer_cache = {};
 export function layerCache () {
@@ -375,7 +375,7 @@ export const FilterOptions = {
     }
 };
 
-function isReserved(key) {
+export function isReserved(key) {
     return reserved.indexOf(key) > -1;
 }
 

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -136,7 +136,7 @@ Object.assign(Polygons, {
         return this.vertex_template;
     },
 
-    buildPolygons(polygons, style, vertex_data, context) {
+    buildPolygons(polygons, style, mesh, context) {
         let vertex_template = this.makeVertexTemplate(style);
         let options = {
             texcoord_index: this.vertex_layout.index.a_texcoord,
@@ -151,7 +151,7 @@ Object.assign(Polygons, {
             return buildExtrudedPolygons(
                 polygons,
                 style.z, style.height, style.min_height,
-                vertex_data, vertex_template,
+                mesh.vertex_data, vertex_template,
                 this.vertex_layout.index.a_normal,
                 127, // scale normals to signed bytes
                 options
@@ -161,7 +161,7 @@ Object.assign(Polygons, {
         else {
             return buildPolygons(
                 polygons,
-                vertex_data, vertex_template,
+                mesh.vertex_data, vertex_template,
                 options
             );
         }

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -13,9 +13,16 @@ varying vec3 v_normal;
 varying vec4 v_color;
 varying vec4 v_world_position;
 
+#ifdef TANGRAM_EXTRUDE_LINES
+    uniform bool u_has_line_texture;
+    uniform sampler2D u_texture;
+    uniform float u_texture_ratio;
+    uniform vec4 u_dash_background_color;
+#endif
+
 #define TANGRAM_NORMAL v_normal
 
-#ifdef TANGRAM_TEXTURE_COORDS
+#if defined(TANGRAM_TEXTURE_COORDS) || defined(TANGRAM_EXTRUDE_LINES)
     varying vec2 v_texcoord;
 #endif
 
@@ -46,21 +53,28 @@ void main (void) {
     #endif
 
     // Apply line texture
-    #ifdef TANGRAM_LINE_TEXTURE
-        vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / u_texture_ratio));
-        vec4 _line_color = texture2D(u_texture, _line_st);
+    #ifdef TANGRAM_EXTRUDE_LINES
+        if (u_has_line_texture) {
+            vec2 _line_st = vec2(v_texcoord.x, fract(v_texcoord.y / u_texture_ratio));
+            vec4 _line_color = texture2D(u_texture, _line_st);
 
-        if (_line_color.a < TANGRAM_ALPHA_TEST) {
-            #ifdef TANGRAM_LINE_BACKGROUND_COLOR
-                color.rgb = TANGRAM_LINE_BACKGROUND_COLOR;
-            #elif !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
-                discard; // use discard when alpha blending is unavailable
-            #else
-                color.a = 0.; // use alpha channel when blending is available
-            #endif
-        }
-        else {
-            color *= _line_color;
+            if (_line_color.a < TANGRAM_ALPHA_TEST) {
+                #if !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY) // TODO: should be for opaque blend only?
+                    // use discard when alpha blending is unavailable
+                    if (u_dash_background_color.a == 0.) {
+                        discard;
+                    }
+                    color = u_dash_background_color;
+                #else
+                    // use alpha channel when blending is available
+                    color = vec4(u_dash_background_color.rgb, color.a * step(TANGRAM_EPSILON, u_dash_background_color.a));
+                #endif
+
+
+            }
+            else {
+                color *= _line_color;
+            }
         }
     #endif
 

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -33,6 +33,8 @@ attribute vec4 a_color;
     // x: zoom scaling factor for line width
     // y: zoom scaling factor for line offset
     attribute vec2 a_scaling;
+
+    uniform float u_v_scale_adjust;
 #endif
 
 varying vec4 v_position;
@@ -41,7 +43,7 @@ varying vec4 v_color;
 varying vec4 v_world_position;
 
 // Optional texture UVs
-#ifdef TANGRAM_TEXTURE_COORDS
+#if defined(TANGRAM_TEXTURE_COORDS) || defined(TANGRAM_EXTRUDE_LINES)
     attribute vec2 a_texcoord;
     varying vec2 v_texcoord;
 #endif
@@ -71,7 +73,7 @@ void main() {
     #ifdef TANGRAM_TEXTURE_COORDS
         v_texcoord = a_texcoord;
         #ifdef TANGRAM_EXTRUDE_LINES
-            v_texcoord.y *= TANGRAM_V_SCALE_ADJUST;
+            v_texcoord.y *= u_v_scale_adjust;
         #endif
     #endif
 

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -163,20 +163,20 @@ export var Style = {
 
     getTileMesh (tile, variant) {
         let meshes = this.tile_data[tile.id].meshes;
-        if (meshes[variant] == null) {
-            meshes[variant] = {
+        if (meshes[variant.key] == null) {
+            meshes[variant.key] = {
                 variant,
                 vertex_data: this.vertexLayoutForMeshVariant(variant).createVertexData()
             };
         }
-        return meshes[variant];
+        return meshes[variant.key];
     },
 
     vertexLayoutForMeshVariant (variant) {
         return this.vertex_layout;
     },
 
-    default_mesh_variant: 0,
+    default_mesh_variant: { key: 0 },
     meshVariantTypeForDraw (draw) {
         return this.default_mesh_variant;
     },
@@ -196,31 +196,31 @@ export var Style = {
             return; // skip feature
         }
 
-        let vertex_data = this.getTileMesh(tile, this.meshVariantTypeForDraw(style)).vertex_data;
-        if (this.buildGeometry(feature.geometry, style, vertex_data, context) > 0) {
+        let mesh = this.getTileMesh(tile, this.meshVariantTypeForDraw(style));
+        if (this.buildGeometry(feature.geometry, style, mesh, context) > 0) {
             feature.generation = this.generation; // track scene generation that feature was rendered for
         }
     },
 
-    buildGeometry (geometry, style, vertex_data, context) {
+    buildGeometry (geometry, style, mesh, context) {
         let geom_count;
         if (geometry.type === 'Polygon') {
-            geom_count = this.buildPolygons([geometry.coordinates], style, vertex_data, context);
+            geom_count = this.buildPolygons([geometry.coordinates], style, mesh, context);
         }
         else if (geometry.type === 'MultiPolygon') {
-            geom_count = this.buildPolygons(geometry.coordinates, style, vertex_data, context);
+            geom_count = this.buildPolygons(geometry.coordinates, style, mesh, context);
         }
         else if (geometry.type === 'LineString') {
-            geom_count = this.buildLines([geometry.coordinates], style, vertex_data, context);
+            geom_count = this.buildLines([geometry.coordinates], style, mesh, context);
         }
         else if (geometry.type === 'MultiLineString') {
-            geom_count = this.buildLines(geometry.coordinates, style, vertex_data, context);
+            geom_count = this.buildLines(geometry.coordinates, style, mesh, context);
         }
         else if (geometry.type === 'Point') {
-            geom_count = this.buildPoints([geometry.coordinates], style, vertex_data, context);
+            geom_count = this.buildPoints([geometry.coordinates], style, mesh, context);
         }
         else if (geometry.type === 'MultiPoint') {
-            geom_count = this.buildPoints(geometry.coordinates, style, vertex_data, context);
+            geom_count = this.buildPoints(geometry.coordinates, style, mesh, context);
         }
 
         // Optionally collect per-layer stats

--- a/src/tile.js
+++ b/src/tile.js
@@ -446,6 +446,13 @@ export default class Tile {
                     }
                 }
 
+                // Sort mesh variants by explicit render order (if present)
+                meshes[s].sort((a, b) => {
+                    // Sort variant order ascending if present, then all null values (where order is unspecified)
+                    let ao = a.variant.order, bo = b.variant.order;
+                    return (ao == null ? 1 : (bo == null ? -1 : (ao < bo ? -1 : 1)));
+                });
+
                 // Assign texture ownership to tiles
                 // Note that it's valid for a single texture to be referenced from multiple styles
                 // (e.g. same raster texture attached to multiple sources). This means the same

--- a/src/tile.js
+++ b/src/tile.js
@@ -438,6 +438,7 @@ export default class Tile {
                         mesh_options.variant = mesh_variant.variant;
 
                         let mesh = styles[s].makeMesh(mesh_variant.vertex_data, mesh_variant.vertex_elements, mesh_options);
+                        mesh.variant = mesh_options.variant;
                         meshes[s] = meshes[s] || [];
                         meshes[s].push(mesh);
                         this.debug.buffer_size += mesh.buffer_size;

--- a/src/tile.js
+++ b/src/tile.js
@@ -447,11 +447,13 @@ export default class Tile {
                 }
 
                 // Sort mesh variants by explicit render order (if present)
-                meshes[s].sort((a, b) => {
-                    // Sort variant order ascending if present, then all null values (where order is unspecified)
-                    let ao = a.variant.order, bo = b.variant.order;
-                    return (ao == null ? 1 : (bo == null ? -1 : (ao < bo ? -1 : 1)));
-                });
+                if (meshes[s]) {
+                    meshes[s].sort((a, b) => {
+                        // Sort variant order ascending if present, then all null values (where order is unspecified)
+                        let ao = a.variant.order, bo = b.variant.order;
+                        return (ao == null ? 1 : (bo == null ? -1 : (ao < bo ? -1 : 1)));
+                    });
+                }
 
                 // Assign texture ownership to tiles
                 // Note that it's valid for a single texture to be referenced from multiple styles


### PR DESCRIPTION
This PR relaxes the requirement that the `dash` pattern for `lines` styles be bound to a single pattern defined at the `styles` level.

With this change, a scene author can freely re-assign (or un-assign) the dash pattern that the style is bound to, within a `draw` group, using the `dash` parameter.

For example:

```
layers:
  roads:
    data: ...
    draw:
      lines: # by default, draw roads with NO dash pattern
        width: 5px
        color: white
        ...

      paths:
        filter: { kind: path }
        draw:
          lines:
            dash: [2, 1] # draw paths with a dash pattern
            ...

      ferries:
        filter: { kind: ferry }
        draw:
          lines:
            dash: [1, 3, 1] # draw ferries with a different dash pattern
            ...
```

This change is fully backwards compatible with existing `styles`: if a style has set a `dash` pattern set, this simply becomes the default value, but that value can then be overridden if desired within layers. The dash pattern can also be *removed* in a sub-layer `draw` by setting `dash: null`.

This is a companion PR to #588, which applies similar changes to point textures.