### PR TITLE
Use @mapbox/vector-tile

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "pbf": "1.3.7",
     "strip-comments": "0.3.2",
     "topojson-client": "tangrams/topojson-client#read-only",
-    "vector-tile": "1.3.0"
+    "@mapbox/vector-tile": "1.3.0"
   },
   "devDependencies": {
     "babelify": "7.3.0",

--- a/src/sources/mvt.js
+++ b/src/sources/mvt.js
@@ -2,7 +2,7 @@ import DataSource, {NetworkTileSource} from './data_source';
 import Geo from '../geo';
 
 import Pbf from 'pbf';
-import {VectorTile, VectorTileFeature} from 'vector-tile';
+import {VectorTile, VectorTileFeature} from '@mapbox/vector-tile';
 
 /**
  Mapbox Vector Tile format


### PR DESCRIPTION
npm WARN deprecated vector-tile@1.3.0: This module has moved: please install @mapbox/vector-tile instead