### PR TITLE
Array merge operator

### DIFF
--- a/src/scene_loader.js
+++ b/src/scene_loader.js
@@ -1,7 +1,7 @@
 import log from './utils/log';
 import GLSL from './gl/glsl';
 import * as URLs from './utils/urls';
-import mergeObjects from './utils/merge';
+import {mergeObjectsWithArrayMergeOp} from './utils/merge';
 import subscribeMixin from './utils/subscribe';
 import {createSceneBundle, isGlobal} from './scene_bundle';
 import {isReserved} from './styles/layer';
@@ -71,7 +71,7 @@ export default SceneLoader = {
                     then(results => {
                         results.forEach(r => this.normalize(r.config, r.bundle)); // first normalize imports
                         let configs = results.map(r => r.config);
-                        config = mergeObjects(...configs, config);
+                        config = mergeObjectsWithArrayMergeOp(...configs, config);
                         this.normalize(config, bundle); // last normalize parent, after merge
                         return { config, bundle };
                     });

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -2,6 +2,16 @@
 const array_merge_op = '...';
 
 export default function mergeObjects (dest, ...sources) {
+    return mergeObjectsWithOptions(null, dest, ...sources);
+}
+
+const with_array_merge_op = { array_merge_op: true };
+export function mergeObjectsWithArrayMergeOp (dest, ...sources) {
+    return mergeObjectsWithOptions(with_array_merge_op, dest, ...sources);
+}
+
+export function mergeObjectsWithOptions (options, dest, ...sources) {
+    let use_array_merge_op = options && options.array_merge_op; // optionally allow array merge operator
     for (let s=0; s < sources.length; s++) {
         let source = sources[s];
         if (!source) {
@@ -13,29 +23,31 @@ export default function mergeObjects (dest, ...sources) {
             // (e.g. don't merge arrays, those are treated as scalar values; null values will overwrite/erase
             // the previous destination value)
             let is_array = Array.isArray(value);
+
+            // Source value is a key/value mapping (non-array object)
             if (value !== null && typeof value === 'object' && !is_array) {
                 if (dest[key] !== null && typeof dest[key] === 'object' && !Array.isArray(dest[key])) {
-                    dest[key] = mergeObjects(dest[key], value);
+                    dest[key] = mergeObjectsWithOptions(options, dest[key], value);
                 }
                 else {
-                    dest[key] = mergeObjects({}, value); // destination not an object, overwrite
+                    dest[key] = mergeObjectsWithOptions(options, {}, value); // destination not an object, overwrite
                 }
             }
             // Overwrite the previous destination value if the source property is: a scalar (number/string),
             // an array (unless using array merge operator below), or a null value
             else if (value !== undefined) {
-                let merge_index = is_array && value.indexOf(array_merge_op); // special array merge syntax
-                if (is_array && dest[key] != null && merge_index > -1) {
+                let merge_index = (use_array_merge_op && is_array) ? value.indexOf(array_merge_op) : -1; // special array merge syntax
+                if (dest[key] != null && merge_index > -1) {
                     // If the source value includes the '...' operator, the previous destination value will be
                     // merged into the source value in its place.
                     //
                     // Example 1: append values
-                    //   dest: [1, 2 3]
+                    //   dest: [1, 2, 3]
                     //   source: ['...', 4, 5, 6]
                     //   -> merge result: [1, 2, 3, 4, 5, 6]
                     //
                     // Example 2: insert in middle
-                    //   dest: [1, 2 3]
+                    //   dest: [1, 2, 3]
                     //   source: ['a', '...', 'b']
                     //   -> merge result: ['a', 1, 2, 3, 'b']
                     //
@@ -52,8 +64,10 @@ export default function mergeObjects (dest, ...sources) {
                     let args = [merge_index, 1];                    // index at which to merge in new values (and delete operator string)
                     Array.prototype.push.apply(args, prev);         // add previous destination values to splice arguments
                     Array.prototype.splice.apply(dest[key], args);  // merge in previous destination values
+                    dest[key] = scrubArrayMergeOp(dest[key]);       // remove extraneous merge array operators
                 }
                 else {
+                    value = (merge_index > -1) ? scrubArrayMergeOp(value) : value; // remove unmatched/extraneous merge array operators
                     dest[key] = value; // just overwrite previous value
                 }
             }
@@ -62,4 +76,12 @@ export default function mergeObjects (dest, ...sources) {
 
     }
     return dest;
+}
+
+export function scrubArrayMergeOp (value) {
+    let index;
+    while ((index = value.indexOf(array_merge_op)) > -1) {
+        value.splice(index, 1);
+    }
+    return value;
 }

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -1,4 +1,6 @@
 // Deep/recursive merge of one or more source objects into a destination object
+const array_merge_op = '...';
+
 export default function mergeObjects (dest, ...sources) {
     for (let s=0; s < sources.length; s++) {
         let source = sources[s];
@@ -10,7 +12,8 @@ export default function mergeObjects (dest, ...sources) {
             // Recursively merge the source into the destination if it is a a non-null key/value object
             // (e.g. don't merge arrays, those are treated as scalar values; null values will overwrite/erase
             // the previous destination value)
-            if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+            let is_array = Array.isArray(value);
+            if (value !== null && typeof value === 'object' && !is_array) {
                 if (dest[key] !== null && typeof dest[key] === 'object' && !Array.isArray(dest[key])) {
                     dest[key] = mergeObjects(dest[key], value);
                 }
@@ -19,9 +22,40 @@ export default function mergeObjects (dest, ...sources) {
                 }
             }
             // Overwrite the previous destination value if the source property is: a scalar (number/string),
-            // an array, or a null value
+            // an array (unless using array merge operator below), or a null value
             else if (value !== undefined) {
-                dest[key] = value;
+                let merge_index = is_array && value.indexOf(array_merge_op); // special array merge syntax
+                if (is_array && dest[key] != null && merge_index > -1) {
+                    // If the source value includes the '...' operator, the previous destination value will be
+                    // merged into the source value in its place.
+                    //
+                    // Example 1: append values
+                    //   dest: [1, 2 3]
+                    //   source: ['...', 4, 5, 6]
+                    //   -> merge result: [1, 2, 3, 4, 5, 6]
+                    //
+                    // Example 2: insert in middle
+                    //   dest: [1, 2 3]
+                    //   source: ['a', '...', 'b']
+                    //   -> merge result: ['a', 1, 2, 3, 'b']
+                    //
+                    // Example 3: existing scalar value in destination is treated as a single-element array
+                    //   dest: 'x'
+                    //   source: [1, 2, 3, '...']
+                    //   -> merge result: [1, 2, 3, 'x']
+                    //
+                    if (!Array.isArray(dest[key])) {
+                        dest[key] = [dest[key]]; // convert destination to array
+                    }
+                    let prev = dest[key];                           // previous destination values, which will be merged
+                    dest[key] = value.slice(0);                     // copy source values
+                    let args = [merge_index, 1];                    // index at which to merge in new values (and delete operator string)
+                    Array.prototype.push.apply(args, prev);         // add previous destination values to splice arguments
+                    Array.prototype.splice.apply(dest[key], args);  // merge in previous destination values
+                }
+                else {
+                    dest[key] = value; // just overwrite previous value
+                }
             }
             // Undefined source properties are ignored
         }


### PR DESCRIPTION
Adds a special "array merge operator", `...`, to the scene merge process. This provides more flexibility in scene merging by allowing the scene author to choose how source and destination array values are merged.

**Functionality**
Object merge works by merging **source** nodes (e.g. those from a scene being imported with `import`) into **destination** nodes (the scene being merged into, which includes the `import` statement). In the existing merge behavior, any time a source node value is an **array**, it **overwrites** the destination node value (regardless of the destination node's type).

This PR modifies the behavior such that when the source node value is an array:
If the string `...` appears as **one of** the source node's array values, the destination node values are **inserted into** the source node array, at **the index of** the `...` operator (the `...` values are replaced). If the existing destination node value is a scalar, that single value is inserted into the source (as if it were a single-element array).

This syntax can be used to append, prepend, or insert values within the destination:

Example 1: append values
```
  dest: [1, 2, 3]
  source: [..., 4, 5, 6]
  -> merge result: [1, 2, 3, 4, 5, 6]
```

Example 2: insert in middle
```
  dest: [1, 2, 3]
  source: [a, ..., b]
  -> merge result: [a, 1, 2, 3, b]
```

Example 3: scalar value in source is treated as a single-element array
```
  dest: x
  source: [1, 2, 3, ...]
  -> merge result: [1, 2, 3, x]
```

The operator syntax choice is loosely inspired by the JS rest/spread operator, and C variadic arguments, though the context and usage is a bit different here.

**Motivation**
In many cases, such as color values, it is desirable to simply replace an array value. However, there are some cases where it can be awkward to "lose" the existing array, rather then being able to extend it. We accepted this limitation because we wanted to keep the merge behavior as generic as possible, but as scene imports have been used in many more contexts, the limitation is more apparent.

The array merge operator is an attempt to keep the behavior backwards compatible, while extending the capability in a generic fashion.

It can be used to better control the order of style mixing (using `mix`) and/or shader `blocks`. 

Additionally, to support more data visualization options, we are considering introducing a scene-level `scripts` option for importing external JS libraries (which would remain backwards compatible with the existing `scripts` parameter in `sources` -- which does not lend itself to source-agnostic data visualization scene fragments to be imported). Since the `scripts` parameter (both existing and proposed) is an array, relying on the current overwrite-only behavior is both error-prone and couples the source and destination scenes in an impractical way.


