### PR TITLE
Set the minimum NPM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "output": "",
     "output_map": ""
   },
+  "engines": {
+    "npm": ">=2.0.0"
+  },
   "scripts": {
     "start": "npm run watch",
     "test": "npm run lint && npm run build-bundle && npm run test-local",


### PR DESCRIPTION
#606 set an implicit NPM version requirement, this makes it explicit.

I'm not sure if NPM 1.x will error with this or not, but it at least sets the acceptable version range.