### PR TITLE
Improve the Windows dev/build experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "test-local": "./node_modules/karma/bin/karma start --browsers Chrome --single-run",
     "karma-start": "./node_modules/karma/bin/karma start --browsers Chrome --no-watch",
     "karma-run": "./node_modules/karma/bin/karma run --browsers Chrome",
-    "lint": "$(npm bin)/jshint src/ && jshint test/",
+    "lint": "./node_modules/.bin/jshint src/ && jshint test/",
     "build": "npm run build-bundle && npm run build-minify",
-    "build-bundle": "$(npm bin)/browserify src/module.js -t [ babelify --presets [ es2015 ] ] -t brfs --debug -s Tangram -p browserify-derequire -p [ './build/quine.js' 'tangram.debug.js.map' ] -p [ mapstraction 'dist/tangram.debug.js.map' ] -o dist/tangram.debug.js",
-    "build-minify": "$(npm bin)/uglifyjs dist/tangram.debug.js -c warnings=false -m | sed -e 's/tangram.debug.js.map//g' > dist/tangram.min.js && npm run build-size",
+    "build-bundle": "./node_modules/.bin/browserify src/module.js -t [ babelify --presets [ es2015 ] ] -t brfs --debug -s Tangram -p browserify-derequire -p [ ./build/quine.js tangram.debug.js.map ] -p [ mapstraction ./dist/tangram.debug.js.map ] -o ./dist/tangram.debug.js",
+    "build-minify": "./node_modules/.bin/uglifyjs dist/tangram.debug.js -c warnings=false -m | sed -e 's/tangram.debug.js.map//g' > dist/tangram.min.js && npm run build-size",
     "build-size": "gzip dist/tangram.min.js -c | wc -c | awk '{kb=$1/1024; print kb}' OFMT='%.0fk minified+gzipped'",
-    "watch": "$(npm bin)/budo src/module.js:dist/tangram.debug.js --port 8000 --cors --live -- -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram -p [ './build/quine.js' 'tangram.debug.temp.js.map' ] -p [ mapstraction 'dist/tangram.debug.temp.js.map' ]"
+    "watch": "./node_modules/.bin/budo src/module.js:dist/tangram.debug.js --port 8000 --cors --live -- -t [ babelify --presets [ es2015 ] ] -t brfs -s Tangram -p [ ./build/quine.js tangram.debug.temp.js.map ] -p [ mapstraction ./dist/tangram.debug.temp.js.map ]"
   },
   "author": {
     "name": "Mapzen",


### PR DESCRIPTION
Tangram has not been buildable on Windows, mostly do to some small syntax issues (see #569).

This PR makes a couple adjustments that improves the experience. The following flows have been tested on Windows 10:

- Live reload (`npm start`) on PowerShell (in Windows and bash modes), Bash for Windows, and Git Bash.
- Full package build (`npm run build`) on PowerShell (bash mode only, relies on unix pipes/commands), Bash for Windows, and Git Bash.
