### PR TITLE
Support CSV and other formats with data source `preprocess` option

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -23,6 +23,12 @@ export default class DataSource {
             });
         }
 
+        // Optional function to preprocess source data
+        this.preprocess = config.preprocess;
+        if (typeof this.preprocess === 'function') {
+            this.preprocess.bind(this);
+        }
+
         // Optional function to transform source data
         this.transform = config.transform;
         if (typeof this.transform === 'function') {
@@ -252,6 +258,12 @@ export class NetworkSource extends DataSource {
                 dest.debug.response_size = body.length || body.byteLength;
                 dest.debug.network = +new Date() - dest.debug.network;
                 dest.debug.parsing = +new Date();
+
+                // Apply optional data transform on raw network response
+                if (typeof this.preprocess === 'function') {
+                    body = this.preprocess(body);
+                }
+
                 this.parseSourceData(dest, source_data, body);
                 dest.debug.parsing = +new Date() - dest.debug.parsing;
                 resolve(dest);

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -264,9 +264,13 @@ export class NetworkSource extends DataSource {
                     body = this.preprocess(body);
                 }
 
-                this.parseSourceData(dest, source_data, body);
-                dest.debug.parsing = +new Date() - dest.debug.parsing;
-                resolve(dest);
+                // Return data immediately, or after user-returned promise resolves
+                body = (body instanceof Promise) ? body : Promise.resolve(body);
+                body.then(body => {
+                    this.parseSourceData(dest, source_data, body);
+                    dest.debug.parsing = +new Date() - dest.debug.parsing;
+                    resolve(dest);
+                });
             }).catch((error) => {
                 source_data.error = error.stack;
                 resolve(dest); // resolve request but pass along error

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -112,8 +112,8 @@ export class GeoJSONSource extends NetworkSource {
     }
 
     parseSourceData (tile, source, response) {
-        let parsed_response = JSON.parse(response);
-        let layers = this.getLayers(parsed_response);
+        let data = typeof response === 'string' ? JSON.parse(response) : response;
+        let layers = this.getLayers(data);
         source.layers = this.preprocessLayers(layers);
     }
 
@@ -229,7 +229,7 @@ export class GeoJSONTileSource extends NetworkTileSource {
     }
 
     parseSourceData (tile, source, response) {
-        let data = JSON.parse(response);
+        let data = typeof response === 'string' ? JSON.parse(response) : response;
         this.prepareGeoJSON(data, tile, source);
     }
 

--- a/src/sources/topojson.js
+++ b/src/sources/topojson.js
@@ -11,7 +11,7 @@ import * as topojson from 'topojson-client';
 export class TopoJSONSource extends GeoJSONSource {
 
     parseSourceData (tile, source, response) {
-        let data = JSON.parse(response);
+        let data = typeof response === 'string' ? JSON.parse(response) : response;
         data = this.toGeoJSON(data);
 
         let layers = this.getLayers(data);
@@ -69,7 +69,7 @@ export class TopoJSONTileSource extends GeoJSONTileSource {
     }
 
     parseSourceData (tile, source, response) {
-        let data = JSON.parse(response);
+        let data = typeof response === 'string' ? JSON.parse(response) : response;
         data = TopoJSONSource.prototype.toGeoJSON(data);
         this.prepareGeoJSON(data, tile, source);
     }


### PR DESCRIPTION
To enable support for formats that may contain geographic data, but not be formatted in the commonly supported formats (GeoJSON, MVT, etc.), this PR adds a data source `preprocess` option. This parameter can define a JS function to mutate the **raw** network response fetched by a data source, before it is processed further. This is similar to the existing `transform` function, with the difference that `transform` is called *after* initial response parsing (e.g. decoding TopoJSON and MVT to GeoJSON-style data).

The `preprocess` function should return data in the format expected by the data source type, e.g. if `type: GeoJSON`, then `preprocess` should return a GeoJSON object.

For example, given a Who's On First CSV export (which contains geographic data in the form of census interior points) formatted like this:

```
name_eng_x_variant,uscensus_aland,uscensus_awater,uscensus_cd115fp,uscensus_cdsessn,uscensus_funcstat,uscensus_geoid,uscensus_intptlat,uscensus_intptlon,uscensus_lsad,uscensus_lsy,uscensus_mtfcc,uscensus_namelsad,uscensus_sldlst,uscensus_sldust,uscensus_statefp,wof_abbreviation,wof_association,wof_belongsto,wof_breaches,wof_categories,wof_concordances,wof_concordances_sources,wof_constituency,wof_country,wof_created,wof_geomhash,wof_hierarchy,wof_id,wof_lastmodified,wof_name,wof_parent_id,wof_path,wof_placetype,wof_placetype_id,wof_placetype_names,wof_repo,wof_subdivision,wof_superseded_by,wof_supersedes,wof_tags
,8016461395.0,408281421.0,null,null,N,36115,+44.6404010,-074.1531364,L3,2016,G5220,Assembly District 115,115,null,36,null,state-house,"[102191575,85633793,85688543]",[],[],null,[],region,us,1481487733,6cdeb8e408b110a903cfa09f169127fc,"[{""continent_id"":102191575,""country_id"":85633793,""region_id"":85688543}]",1108771377,1481487733,New York Assembly District 115,85688543,110/877/137/7/1108771377.geojson,constituency,1108746739,[],whosonfirst-data-constituency-us-ny,null,[],[],[]
,2096846209.0,18904910.0,null,null,N,36124,+42.1485630,-076.4279918,L3,2016,G5220,Assembly District 124,124,null,36,null,state-house,"[102191575,85633793,85688543]",[],[],null,[],region,us,1481487736,62c624e9313c3aced2ad496c1a616d35,"[{""continent_id"":102191575,""country_id"":85633793,""region_id"":85688543}]",1108771397,1481487736,New York Assembly District 124,85688543,110/877/139/7/1108771397.geojson,constituency,1108746739,[],whosonfirst-data-constituency-us-ny,null,[],[],[]
,1227673529.0,781123966.0,null,null,N,36055,+43.1085124,-077.4895172,LU,2016,G5210,State Senate District 55,null,055,36,null,state-senate,"[102191575,85633793,85688543]",[],[],null,[],region,us,1481487766,1e43fde4d5e7da384bd94e3b3007b975,"[{""continent_id"":102191575,""country_id"":85633793,""region_id"":85688543}]",1108771579,1481487766,New York State Senate District 55,85688543,110/877/157/9/1108771579.geojson,constituency,1108746739,[],whosonfirst-data-constituency-us-ny,null,[],[],[]
```

We can use the `preprocess` function to remap those columns into a GeoJSON collection of points:

```
    csv:
        type: GeoJSON
        url: ny-us-constituencies.csv
        preprocess: |
            function (data) {
                var rows = data.split('\n');
                return {
                    type: 'FeatureCollection',
                    features: rows.map(function(row) {
                        row = row.split(',');
                        return {
                            type 'Feature',
                            geometry: {
                                type: 'Point',
                                coordinates: [row[8], row[7]] // census intptlon & intptlat fields
                            },
                            properties: {
                                name: row[12] // district name
                            }
                        }
                    })
                };
            }
```

Additional notes:
- `preprocess` has access to the same externally loaded `scripts` as the `transform` function.
- `preprocess` can return an immediate response, or a `Promise` which resolves with a response, allowing for the potential use of async operations (while the initial tests are with CSV files, theoretically the functionality could be applied to shapefiles and other format parsing as well).
- While it is possible to combine both `preprocess` and `transform` functions in a single data source (if both are defined, both will execute), in practice there are probably few cases where it would be useful.
