### PR TITLE
apply %s, ratios, and density to textures in points

### DIFF
--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -468,6 +468,8 @@ Texture.getInfo = function (name) {
                 width: tex.width,
                 height: tex.height,
                 density: tex.density,
+                css_size: [ tex.width / tex.density, tex.height / tex.density ],
+                aspect: tex.width / tex.height,
                 sprites: tex.sprites,
                 texcoords: tex.texcoords,
                 sizes: tex.sizes,

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -151,29 +151,39 @@ Object.assign(Points, {
             return;
         }
 
-        // optional sprite
+        // optional sprite and texture
         let sprite_info;
         if (this.hasSprites(style)) {
+            // populate sprite_info object with used sprites
             sprite_info = this.parseSprite(style, draw, context);
+
             if (sprite_info) {
                 style.texcoords = sprite_info.texcoords;
             }
             else {
+                // sprites are defined, but none are used
                 log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}' uses a texture '${style.texture}' with defined sprites, but no sprite is specified. Skipping features in layer`);
                 return;
             }
+        } else if (draw.sprite) {
+            // sprite specified in the draw layer but no sprites defined in the texture
+            log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}': ` +
+            `a sprite '${draw.sprite}' is specified but no sprites are defined in texture '${draw.texture}', skipping features in layer`);
+            return;
         }
 
         // point size defined explicitly, or defaults to sprite size, or generic fallback
         style.size = draw.size;
         if (!style.size) {
+            // a 'size' property has not been set in the draw layer -
+            // use the sprite size if it exists and a generic fallback if it doesn't
             style.size = (sprite_info && sprite_info.css_size) || [DEFAULT_POINT_SIZE, DEFAULT_POINT_SIZE];
         }
         else {
-            style.size = StyleParser.evalCachedPointSizeProperty(draw.size, sprite_info, context);
+            style.size = StyleParser.evalCachedPointSizeProperty(draw.size, sprite_info, Texture.textures[style.texture], context);
             if (style.size == null) {
-                // the StyleParser couldn't evaluate a sprite size - this means no sprite was defined,
-                // use the texture size
+                // the StyleParser couldn't evaluate a sprite size -
+                // this means no sprite was defined, use the texture size
                 let tex = Texture.textures[style.texture];
                 let factor = (draw.size.value.indexOf('%') > -1 ? parseFloat(draw.size.value) : 1.0) / 100.0;
                 style.size = [(tex.width * factor), (tex.height * factor)];
@@ -258,10 +268,11 @@ Object.assign(Points, {
         return style.texture && Texture.textures[style.texture] && Texture.textures[style.texture].sprites;
     },
 
+    // Generate a sprite_info object
     getSpriteInfo (style, sprite) {
         let info = Texture.textures[style.texture].sprites[sprite] && Texture.getSpriteInfo(style.texture, sprite);
         if (sprite && !info) {
-            // track misisng sprites (per texture)
+            // track missing sprites (per texture)
             this.texture_missing_sprites[style.texture] = this.texture_missing_sprites[style.texture] || {};
             if (!this.texture_missing_sprites[style.texture][sprite]) { // only log each missing sprite once
                 log('debug', `Style: in style '${this.name}', could not find sprite '${sprite}' for texture '${style.texture}'`);
@@ -274,7 +285,9 @@ Object.assign(Points, {
         return info;
     },
 
+    // Check a sprite name against available sprites and return a sprite_info object
     parseSprite (style, draw, context) {
+        // check for functions
         let sprite = StyleParser.evalProperty(draw.sprite, context);
         let sprite_info = this.getSpriteInfo(style, sprite) || this.getSpriteInfo(style, draw.sprite_default);
         return sprite_info;

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -159,6 +159,7 @@ Object.assign(Points, {
                 style.texcoords = sprite_info.texcoords;
             }
             else {
+                log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}' uses a texture '${style.texture}' with defined sprites, but no sprite is specified. Skipping features in layer`);
                 return;
             }
         }

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -161,8 +161,7 @@ Object.assign(Points, {
                 style.texcoords = sprite_info.texcoords;
             }
             else {
-                // sprites are defined, but none are used
-                log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}' uses a texture '${style.texture}' with defined sprites, but no sprite is specified. Skipping features in layer`);
+                // sprites are defined in the style's texture, but none are used in the current layer
                 return;
             }
         } else if (draw.sprite) {

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -171,10 +171,12 @@ Object.assign(Points, {
         else {
             style.size = StyleParser.evalCachedPointSizeProperty(draw.size, sprite_info, context);
             if (style.size == null) {
-                log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}': ` +
-                    `'size' includes % and/or ratio-based scaling (${JSON.stringify(draw.size.value)}); ` +
-                    `these can only applied to sprites, but no sprite was specified, skipping features in layer`);
-                return;
+                // the StyleParser couldn't evaluate a sprite size - this means no sprite was defined,
+                // use the texture size
+                let tex = Texture.textures[style.texture];
+                let factor = (draw.size.value.indexOf('%') > -1 ? parseFloat(draw.size.value) : 1.0) / 100.0;
+                style.size = [(tex.width * factor), (tex.height * factor)];
+
             }
             else if (typeof style.size === 'number') {
                 style.size = [style.size, style.size]; // convert 1d size to 2d

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -192,6 +192,7 @@ StyleParser.createPointSizePropertyCache = function (obj) {
     }
 
     if (!has_pct) { // no percentage-based calculation, one cache for all sprites
+        if (obj === "auto") { throw `this value only allowed as half of an array, eg [16px, auto]:`; }
         obj = StyleParser.createPropertyCache(obj, parsePositiveNumber);
     }
     else { // per-sprite based evaluation


### PR DESCRIPTION
Currently, `points` styles which do not have sprites defined can only specify `size` in fixed values of `px`. Additionally, setting a `density` in the texture definition has no effect.

This PR will allow points styles to use percentages (`size: 50%`) and ratios (`size: [16px, auto]` or `size: [50%, auto]`), and will use `density` in css_size calculations.

Fixes #638, fixes #642, and fixes #644.