### PR TITLE
Quick fix for Polygons with interior (holes)

### DIFF
--- a/src/builders/polygons.js
+++ b/src/builders/polygons.js
@@ -60,9 +60,8 @@ export function buildPolygons (
 
                     // Add UVs:
                     if (texcoord_index) {
-                        vertex_template.splice(texcoord_index, 2,
-                                ((vertex[0] - min_x) * scale_u + min_u) * texcoord_normalize,
-                                ((vertex[1] - min_y) * scale_v + min_v) * texcoord_normalize);
+                        vertex_template[texcoord_index + 0] = ((vertex[0] - min_x) * scale_u + min_u) * texcoord_normalize;
+                        vertex_template[texcoord_index + 1] = ((vertex[1] - min_y) * scale_v + min_v) * texcoord_normalize;
                     }
 
                     vertex_data.addVertex(vertex_template);

--- a/src/builders/polygons.js
+++ b/src/builders/polygons.js
@@ -23,12 +23,13 @@ export function buildPolygons (
     let vertex_elements = vertex_data.vertex_elements,
         element_offset = vertex_data.vertex_count,
         num_polygons = polygons.length,
-        geom_count = 0;
+        geom_count = 0,
+        min_u, min_v, max_u, max_v,
+        min_x, min_y, max_x, max_y;
 
     if (texcoord_index) {
         texcoord_normalize = texcoord_normalize || 1;
-        // Usage of "var" for function wide visibility:
-        var [min_u, min_v, max_u, max_v] = texcoord_scale || default_uvs;
+        [min_u, min_v, max_u, max_v] = texcoord_scale || default_uvs;
     }
 
     for (let p = 0; p < num_polygons; p++) {
@@ -37,13 +38,12 @@ export function buildPolygons (
             indices = triangulatePolygon(earcut.flatten(polygon)),
             num_indices = indices.length;
 
-        // The verices and vertex-elements must not be added if earcut returns no indicies:
+        // The vertices and vertex-elements must not be added if earcut returns no indices:
         if (num_indices) {
 
             // Find polygon extents to calculate UVs, fit them to the axis-aligned bounding box:
             if (texcoord_index) {
-                // Usage of "var" for function wide visibility:
-                var [min_x, min_y, max_x, max_y] = Geo.findBoundingBox(polygon),
+                [min_x, min_y, max_x, max_y] = Geo.findBoundingBox(polygon),
                     span_x = max_x - min_x,
                     span_y = max_y - min_y,
                     scale_u = (max_u - min_u) / span_x,
@@ -69,7 +69,7 @@ export function buildPolygons (
             }
 
             // Add element indices:
-            for (let i = 0; i < num_indices; i++){
+            for (let i = 0; i < num_indices; i++) {
                 vertex_elements.push(element_offset + indices[i]);
             }
             geom_count += num_indices / 3;

--- a/src/builders/polygons.js
+++ b/src/builders/polygons.js
@@ -7,63 +7,79 @@ import earcut from 'earcut';
 
 const up_vec3 = [0, 0, 1];
 
-// Tesselate a flat 2D polygon
-// x & y coordinates will be set as first two elements of provided vertex_template
-export function buildPolygons (
-    polygons,
-    vertex_data, vertex_template,
-    { texcoord_index, texcoord_scale, texcoord_normalize }) {
 
-    var vertex_elements = vertex_data.vertex_elements;
+/**
+ * To tesselate flat 2D polygons.
+ * The x & y coordinates will be set as first two elements of provided vertex_template.
+ * @param {Array.<Array.<Array.<Array.<number>>>>} polygons The polygons to tesselate.
+ * @param {VertexData} vertex_data The VertexData were to store the results
+ * @param {Array.<number>} vertex_template The vertex template to use
+ * @param {Object} options The texture coordinate options to apply
+ * @return {number} the number of the resulting geometries (triangles)
+ */
+export function buildPolygons (
+        polygons, vertex_data, vertex_template, { texcoord_index, texcoord_scale, texcoord_normalize }) {
+
+    let vertex_elements = vertex_data.vertex_elements,
+        element_offset = vertex_data.vertex_count,
+        num_polygons = polygons.length,
+        geom_count = 0;
 
     if (texcoord_index) {
         texcoord_normalize = texcoord_normalize || 1;
+        // Usage of "var" for function wide visibility:
         var [min_u, min_v, max_u, max_v] = texcoord_scale || default_uvs;
     }
 
-    var geom_count = 0;
-    var num_polygons = polygons.length;
-    for (var p=0; p < num_polygons; p++) {
-        var element_offset = vertex_data.vertex_count;
+    for (let p = 0; p < num_polygons; p++) {
 
-        var polygon = polygons[p];
+        let polygon = polygons[p],
+            indices = triangulatePolygon(earcut.flatten(polygon)),
+            num_indices = indices.length;
 
-        // Find polygon extents to calculate UVs, fit them to the axis-aligned bounding box
-        if (texcoord_index) {
-            var [min_x, min_y, max_x, max_y] = Geo.findBoundingBox(polygon);
-            var span_x = max_x - min_x;
-            var span_y = max_y - min_y;
-            var scale_u = (max_u - min_u) / span_x;
-            var scale_v = (max_v - min_v) / span_y;
-        }
+        // The verices and vertex-elements must not be added if earcut returns no indicies:
+        if (num_indices) {
 
-        for (var ring_index = 0; ring_index < polygon.length; ring_index++){
-            // Add vertex data
-            var polygon_ring = polygon[ring_index];
-            for (let i = 0; i < polygon_ring.length; i++) {
-                var vertex = polygon_ring[i];
-                vertex_template[0] = vertex[0];
-                vertex_template[1] = vertex[1];
-
-                // Add UVs
-                if (texcoord_index) {
-                    vertex_template[texcoord_index + 0] = ((vertex[0] - min_x) * scale_u + min_u) * texcoord_normalize;
-                    vertex_template[texcoord_index + 1] = ((vertex[1] - min_y) * scale_v + min_v) * texcoord_normalize;
-                }
-
-                vertex_data.addVertex(vertex_template);
+            // Find polygon extents to calculate UVs, fit them to the axis-aligned bounding box:
+            if (texcoord_index) {
+                // Usage of "var" for function wide visibility:
+                var [min_x, min_y, max_x, max_y] = Geo.findBoundingBox(polygon),
+                    span_x = max_x - min_x,
+                    span_y = max_y - min_y,
+                    scale_u = (max_u - min_u) / span_x,
+                    scale_v = (max_v - min_v) / span_y;
             }
-        }
 
-        // Add element indices
-        var indices = triangulatePolygon(earcut.flatten(polygon));
-        for (let i = 0; i < indices.length; i++){
-            vertex_elements.push(element_offset + indices[i]);
+            for (let ring_index = 0; ring_index < polygon.length; ring_index++) {
+                // Add vertex data:
+                let polygon_ring = polygon[ring_index];
+                for (let i = 0; i < polygon_ring.length; i++) {
+                    let vertex = polygon_ring[i];
+                    vertex_template[0] = vertex[0];
+                    vertex_template[1] = vertex[1];
+
+                    // Add UVs:
+                    if (texcoord_index) {
+                        vertex_template.splice(texcoord_index, 2,
+                                ((vertex[0] - min_x) * scale_u + min_u) * texcoord_normalize,
+                                ((vertex[1] - min_y) * scale_v + min_v) * texcoord_normalize);
+                    }
+
+                    vertex_data.addVertex(vertex_template);
+                }
+            }
+
+            // Add element indices:
+            for (let i = 0; i < num_indices; i++){
+                vertex_elements.push(element_offset + indices[i]);
+            }
+            geom_count += num_indices / 3;
+
         }
-        geom_count += indices.length/3;
     }
     return geom_count;
 }
+
 
 // Tesselate and extrude a flat 2D polygon into a simple 3D model with fixed height and add to GL vertex buffer
 export function buildExtrudedPolygons (

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -198,7 +198,7 @@ export var Style = {
 
         let mesh = this.getTileMesh(tile, this.meshVariantTypeForDraw(style));
 
-        // In case of polygons with interiors (holes) it may happen that during buildGeometry() vertices were
+        // In case of polygons with interiors within interiors it may happen that during buildGeometry() vertices were
         // added but the returned geometries count is 0 because the triangulation and checks against interiors
         // interrupted the build process. For such cases we have to memorize the original vertex_count and offset to
         // reset the vertex_data afterwards:

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -198,7 +198,7 @@ export var Style = {
 
         let mesh = this.getTileMesh(tile, this.meshVariantTypeForDraw(style));
 
-        // In case of polygons with interiors within interiors it may happen that during buildGeometry() vertices were
+        // In case of polygons with interiors (holes) it may happen that during buildGeometry() vertices were
         // added but the returned geometries count is 0 because the triangulation and checks against interiors
         // interrupted the build process. For such cases we have to memorize the original vertex_count and offset to
         // reset the vertex_data afterwards:

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -197,24 +197,8 @@ export var Style = {
         }
 
         let mesh = this.getTileMesh(tile, this.meshVariantTypeForDraw(style));
-
-        // In case of polygons with interiors within interiors it may happen that during buildGeometry() vertices were
-        // added but the returned geometries count is 0 because the triangulation and checks against interiors
-        // interrupted the build process. For such cases we have to memorize the original vertex_count and offset to
-        // reset the vertex_data afterwards:
-        const orig_offset = mesh.vertex_data.offset;
-        const orig_vertex_count = mesh.vertex_data.vertex_count;
-
         if (this.buildGeometry(feature.geometry, style, mesh, context) > 0) {
             feature.generation = this.generation; // track scene generation that feature was rendered for
-        } else {
-            // Check if vertices were added but geometries count is 0:
-            if (mesh.vertex_data.vertex_count > orig_vertex_count) {
-                // Reset the vertex_data:
-                mesh.vertex_data.vertex_buffer.fill(0, orig_offset, mesh.vertex_data.offset);
-                mesh.vertex_data.vertex_count = orig_vertex_count;
-                mesh.vertex_data.offset = orig_offset;
-            }
         }
     },
 


### PR DESCRIPTION
**Steps to reproduce the bug:**
Open the [Tangram Play](https://tangram.city/play/?#2/0/0)
and set this YAML definition:
```
sources:
  geojson:
    type: GeoJSON
    url: https://gist.githubusercontent.com/germanz/e0fc172fa458bd50c17bbac9b24e17e0/raw/a1f9bb86265c0ae1c72fc37b99b2967fb302faaa/polygon_with_hole

scene:
  background:
    color: black

layers:
  layer:
    data: {source: geojson}
    draw:
      polygons:
        color: red
        order: 1
```
A red rectangle with a rectangular hole is rendered as expected.
Zoom in until you see render artefacts like this:

![screen shot 2018-06-19 at 13 57 11](https://user-images.githubusercontent.com/1173592/41595949-f175c8f4-73c8-11e8-8309-1c580b0b85ee.png)

