### PR TITLE
`angle` JS functions should treat return value as degrees

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -452,7 +452,12 @@ Object.assign(Points, {
         draw.placement_min_length_ratio = StyleParser.createPropertyCache(draw.placement_min_length_ratio, StyleParser.parsePositiveNumber);
 
         if (typeof draw.angle === 'number') {
-            draw.angle = draw.angle * Math.PI / 180;
+            draw.angle = draw.angle * Math.PI / 180; // convert static value to radians
+        }
+        else if (typeof draw.angle === 'function') {
+            // convert function return value to radians
+            const angle_func = draw.angle;
+            draw.angle = context => angle_func(context) * Math.PI / 180;
         }
         else {
             draw.angle = draw.angle || 0; // angle can be a string like "auto" (use angle of geometry)


### PR DESCRIPTION
@burritojustice noticed that the return value for a JS function on a `points` style `angle` property is treated as radians, instead of degrees, e.g.:

- static values like `angle: 90` are treated as degrees (correct!)
- function values like `angle: function() { return 90 }` are treated as **radians** (wrong!)

This PR corrects behavior to expect a return value in degrees, and converts it to radians.

Also see https://github.com/tangrams/tangram-docs/issues/250.