### PR TITLE
Data sources can specify optional request headers

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -97,6 +97,8 @@ sources:
         url: https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.topojson
         tile_size: 512
         max_zoom: 15
+        # request_headers: # send custom headers with tile requests
+        #     Authorization: Bearer xxxxxxxxx
         # Data filtering demo with 'scripts' and 'transform' properties:
         # Tile data is passed through a 'transform' pre-processing function before Tangram geometry is built.
         # 'transform' adds an 'intersects_park' property to each road that intersects a park feature.

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -219,6 +219,10 @@ export class NetworkSource extends DataSource {
         super(source, sources);
         this.response_type = ""; // use to set explicit XHR type
 
+        if (typeof source.url !== 'string') {
+            throw Error('Network data source must provide a string `url` property');
+        }
+
         // Add extra URL params, and warn on duplicates
         let [url, dupes] = URLs.addParamsToURL(source.url, source.url_params);
         this.url = url;
@@ -228,8 +232,9 @@ export class NetworkSource extends DataSource {
                 `skipping value '${param}=${value}' specified in 'url_params'`);
         });
 
-        if (typeof this.url !== 'string') {
-            throw Error('Network data source must provide a string `url` property');
+        // Optional HTTP request headers to send
+        if (source.request_headers && typeof source.request_headers === 'object') {
+            this.request_headers = source.request_headers;
         }
     }
 
@@ -251,7 +256,7 @@ export class NetworkSource extends DataSource {
             // promise.then((body) => {
 
             let request_id = (network_request_id++) + '-' + url;
-            let promise = Utils.io(url, 60 * 1000, this.response_type, 'GET', {}, request_id);
+            let promise = Utils.io(url, 60 * 1000, this.response_type, 'GET', this.request_headers, request_id);
             source_data.request_id = request_id;
 
             promise.then((body) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -44,6 +44,14 @@ Utils.io = function (url, timeout = 60000, responseType = 'text', method = 'GET'
             request.open(method, url, true);
             request.timeout = timeout;
             request.responseType = responseType;
+
+            // Attach optional request headers
+            if (headers && typeof headers === 'object') {
+                for (let key in headers) {
+                    request.setRequestHeader(key, headers[key]);
+                }
+            }
+
             request.onload = () => {
                 if (request.status === 200) {
                     if (['text', 'json'].indexOf(request.responseType) > -1) {


### PR DESCRIPTION
Following up on #668: to enable cases where a client would like to send additional, custom HTTP headers with each tile request.

A data source can specify key/value pairs for header names/values, with the `request_headers` parameter. For example, if the tile backend is authorized with and OAuth token:

```
sources:
    tiles:
        type: TopoJSON
        url: ...
        request_headers:
            Authorization: Bearer XXXXXX
```

While `request_headers` *can* be specified statically in the scene file, it's more likely they would be added programmatically at run-time (they could either be added after a scene `load` event, or by directly modifying `scene.config` and calling `scene.updateConfig()`). They would also generally be expected to be used with custom tile sources.

CORS
------
If the tile source is being made via CORS requests (the tile source's origin is different from the origin the the web page was loaded from), then adding custom `request_headers` will cause an additional 
["preflight"](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) `OPTIONS` request for each tile (before the `GET` request for tile data). This extra request is required so that the client can verify that the server will accept the desired headers, which the server must authorize with the `Access-Control-Allow-Headers` header. See more info on [CORS preflight requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests).


