### PR TITLE
add queryLayers()

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -795,6 +795,20 @@ export default class Scene {
             catch(error => Promise.resolve({ error }));
     }
 
+    // Query layers within visible tiles
+    queryLayers() {
+        let tile_keys = this.tile_manager.getRenderableTiles().map(t => t.key);
+        return WorkerBroker.postMessage(this.workers, 'self.queryLayers', tile_keys).then(results => {
+            // concatenate results from all workers
+            let filteredResults = [].concat.apply([], results);
+            // de-duplicate results
+            filteredResults = filteredResults.filter(function(item, pos) {
+                return filteredResults.indexOf(item) === pos;
+            });
+            return filteredResults;
+        });
+    }
+
     // Query features within visible tiles, with optional filter conditions
     queryFeatures({ filter, unique = true, group_by = null, visible = null, geometry = false } = {}) {
         filter = Utils.serializeWithFunctions(filter);

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -305,6 +305,20 @@ Object.assign(self, {
         return features;
     },
 
+    // Query layers within visible tiles
+    queryLayers (tile_keys) {
+        let layers = [];
+        let tiles = tile_keys.map(t => self.tiles[t]).filter(t => t);
+        tiles.forEach(tile => {
+            for (let layer in tile.source_data.layers) {
+                if (layers.indexOf(layer) === -1) {
+                    layers.push(layer);
+                }
+            }
+        });
+        return layers;
+    },
+
     // Get a feature from the selection map
     getFeatureSelection ({ id, key } = {}) {
         var selection = FeatureSelection.map[key];


### PR DESCRIPTION
Similar to queryFeatures() but just a list of available layer names from the datasource, rather than from the scene file as in `scene.config.layers`.

Allows simple querying in cases when the data isn't human-readable or already known. Also allows run-time style building in these cases, as well as dynamic "layers" UI construction.