### PR TITLE
handle multi-source labels

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -236,11 +236,9 @@ Object.assign(Points, {
             draw.text.visible !== false && // explicitly handle `visible` property for nested text
             this.parseTextFeature(feature, draw.text, context, tile);
 
+        // if the text feature is an array, there were multiple options: use the first entry
         if (Array.isArray(tf)) {
-            tf = null; // NB: boundary labels not supported for point label attachments, should log warning
-            log({ level: 'warn', once: true }, `Layer '${draw.layers[draw.layers.length-1]}': ` +
-                `cannot use boundary labels (e.g. 'text_source: { left: ..., right: ... }') for 'text' labels attached to 'points'; ` +
-                `provided 'text_source' value was ${JSON.stringify(draw.text.text_source)}`);
+            tf = tf[0];
         }
 
         if (tf) {

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -43,13 +43,18 @@ export const TextLabels = {
         this.texts[tile.id] = this.texts[tile.id] || {};
         let sizes = this.texts[tile.id][text_settings_key] = this.texts[tile.id][text_settings_key] || {};
 
+        // handle multi-source labels – these could be boundary labels (with left: and right:) or a prioritized
+        // array of possible label sources: [name, kind]
         if (text instanceof Object){
             let results = [];
-
-            // add both left/right text elements to repeat group to improve repeat culling
-            // avoids one component of a boundary label (e.g. Colorado) being culled too aggressively when it also
-            // appears in nearby boundary labels (e.g. Colorado/Utah & Colorado/New Mexico repeat as separate groups)
-            let repeat_group_prefix = text.left + '-' + text.right; // NB: should be all text keys, not just left/right
+            let repeat_group_prefix = "";
+            // boundary labels
+            if (text.left && text.right) {
+                // add both left/right text elements to repeat group to improve repeat culling
+                // avoids one component of a boundary label (e.g. Colorado) being culled too aggressively when it also
+                // appears in nearby boundary labels (e.g. Colorado/Utah & Colorado/New Mexico repeat as separate groups)
+                repeat_group_prefix = text.left + '-' + text.right; // NB: should be all text keys, not just left/right
+            }
 
             for (let key in text){
                 let current_text = text[key];
@@ -65,13 +70,12 @@ export const TextLabels = {
                         ref: 0 // # of times this text/style combo appears in tile
                     };
                 }
-
                 results.push({
                     draw, text : current_text, text_settings_key, layout
                 });
             }
 
-            return (results.length > 0 && results); // return null if no boundary labels found
+            return (results.length > 0 && results); // return null if no labels found
         }
         else {
             // unique text strings, grouped by text drawing style


### PR DESCRIPTION
Handles cases where the `text_source` for a point label should be the first available property in an array of prioritized feature properties, as in `[name, kind]`.

Fixes https://github.com/tangrams/tangram/issues/672.