### PR TITLE
make tile available in source transform function

### DIFF
--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -235,6 +235,7 @@ export class GeoJSONTileSource extends NetworkTileSource {
     prepareGeoJSON (data, tile, source) {
         // Apply optional data transform
         if (typeof this.transform === 'function') {
+            this.tile = tile;
             data = this.transform(data, this.extra_data);
         }
 

--- a/src/sources/mvt.js
+++ b/src/sources/mvt.js
@@ -24,7 +24,12 @@ export class MVTSource extends NetworkTileSource {
 
         // Apply optional data transform
         if (typeof this.transform === 'function') {
-            source.layers = this.transform(source.layers, this.extra_data);
+            const tile_data = {
+                min: Object.assign({}, tile.min),
+                max: Object.assign({}, tile.max),
+                coords: Object.assign({}, tile.coords)
+            };
+            source.layers = this.transform(source.layers, this.extra_data, tile_data);
         }
 
         delete source.data; // comment out to save raw data for debugging

--- a/src/sources/topojson.js
+++ b/src/sources/topojson.js
@@ -15,7 +15,7 @@ export class TopoJSONSource extends GeoJSONSource {
         data = this.toGeoJSON(data);
 
         let layers = this.getLayers(data);
-        super.preprocessLayers(layers);
+        super.preprocessLayers(layers, tile);
         source.layers = layers;
     }
 


### PR DESCRIPTION
This makes per-tile data transformations possible, including debugging data. For example, this creates a polygon at the tile boundaries, named for its source tile:

```javascript
transform: |
    function(data) {
        t = this.tile;
        c = Tangram.debug.Geo.metersToLatLng;
        min = c([t.min.x, t.min.y]);
        max = c([t.max.x, t.max.y]);
        return {
            type: 'FeatureCollection',
            features: [{
                type: 'Feature',
                geometry: {
                    type: 'Polygon',
                    coordinates: [[
                        [min[0], min[1]], [max[0], min[1]],
                        [max[0], max[1]], [min[0], max[1]],
                        [min[0], min[1]]
                    ]]
                },
                properties: {
                    name: this.tile.coords.key
                }
            }]
        };
    }
```

Addresses https://github.com/tangrams/tangram/issues/354.