### PR TITLE
Add $source, $layer, $geometry, and $visible properties for queryFeatures()

### DIFF
--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -271,8 +271,9 @@ Object.assign(self, {
                 let data = tile.source_data.layers[layer];
                 data.features.forEach(feature => {
                     // Optionally check if feature is visible (e.g. was rendered for current generation)
-                    if ((visible === true && feature.generation !== self.generation) ||
-                        (visible === false && feature.generation === self.generation)) {
+                    const feature_visible = (feature.generation === self.generation);
+                    if ((visible === true && !feature_visible) ||
+                        (visible === false && feature_visible)) {
                         return;
                     }
 
@@ -288,7 +289,12 @@ Object.assign(self, {
                     // Info to return with each feature
                     let subset = {
                         type: feature.type,
-                        properties: feature.properties
+                        properties: Object.assign({}, feature.properties, {
+                            $source: context.source,
+                            $layer: context.layer,
+                            $geometry: context.geometry,
+                            $visible: feature_visible
+                        })
                     };
 
                     // Optionally include geometry in response


### PR DESCRIPTION
See #671 for background. This branch takes a different approach to enable the same support (and more!) for `queryFeatures()`, but with a smaller code change footprint and API change.

It adds properties for `$source`, `$layer`, and `$geometry` to the features returned by `queryFeatures()`. You could already `filter` these in `queryFeatures()` calls (using the same filter syntax we use in the scene file), but this allows you to also use the `group_by` feature with them. In addition, a `$visible` property was added. While this property (by definition!) doesn't exist for a scene file `filter`, it's a logical extension here.

You can do some neat things with these options, such as:

Features grouped by layer (with feature count for each):
`scene.queryFeatures({ group_by: '$layer' })`
![screen shot 2018-09-19 at 3 59 52 pm](https://user-images.githubusercontent.com/16733/45777948-34c5f300-bc25-11e8-9e77-b5bd1ab7536f.png)

Features grouped by layer and `kind`:
`scene.queryFeatures({ group_by: ['$layer', 'kind'] })`
![screen shot 2018-09-19 at 4 05 31 pm](https://user-images.githubusercontent.com/16733/45778195-f1b84f80-bc25-11e8-9bf4-d45fa643d53b.png)

Features grouped by layer and geometry type:
`scene.queryFeatures({ group_by: ['$layer', '$geometry'] })`
![screen shot 2018-09-19 at 4 01 36 pm](https://user-images.githubusercontent.com/16733/45778007-5f17b080-bc25-11e8-9cd0-c677e85d04cb.png)

Features grouped by layer and visibility:
`scene.queryFeatures({ group_by: ['$layer', '$visible'] })`
![screen shot 2018-09-19 at 4 02 53 pm](https://user-images.githubusercontent.com/16733/45778067-95edc680-bc25-11e8-9aac-b70d47f49b6a.png)

Or even a more granular breakdown:
`scene.queryFeatures({ group_by: ['$layer', '$geometry', '$visible'] })`
![screen shot 2018-09-19 at 4 04 23 pm](https://user-images.githubusercontent.com/16733/45778131-c897bf00-bc25-11e8-8ad0-1dc7c51d246b.png)

## Where Should the Properties Go

The only potential oddity with the above is that these "special" properties are added directly to the `properties` in the returned GeoJSON objects. When filtering source data in the scene file, these properties are implied, but not actually in the same namespace as the feature properties themselves. If you had source data that contained any of these property names, currently those properties would be overridden when accessed via `queryFeatures()`.

Another option would be to put them *outside* the `properties` on the GeoJSON, but then they wouldn't be accessible to any standard GeoJSON-reading software (it was also faster/smaller to code it this way). This is how the related `getFeatureAt()` function works, but it uses a different naming scheme (`source_name` and `source_layer`):

![screen shot 2018-09-19 at 4 13 27 pm](https://user-images.githubusercontent.com/16733/45778655-2d074e00-bc27-11e8-8f95-8496def8f034.png)

The difference is that `getFeatureAt()` doesn't return a real GeoJSON object, just a plain JSON. Settling on an approach that is consistent between the two -- in terms of both property location and naming -- would be ideal, though could result in a breaking change `getFeatureAt()`.
