### PR TITLE
Feature selection optimizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,6 @@ http://mapzen.com/tangram
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.9.4/leaflet-geocoder-mapzen.js"></script> <!-- leaflet plugin for pelias search UI -->
     <script src="demos/lib/dat.gui.min.js"></script> <!-- lightweight GUI lib -->
-    <script src="demos/lib/rStats.js"></script> <!-- rStats provides WebGL performance profiling-->
-    <script src="demos/lib/rStats.extras.js"></script>
     <script src="demos/lib/FileSaver.js"></script> <!-- used in the demo to save screenshots -->
     <script src="demos/lib/keymaster.js"></script> <!-- Keymaster handles keyboard input -->
 
@@ -37,7 +35,13 @@ http://mapzen.com/tangram
     <script src="demos/app/url.js"></script> <!-- URL parsing -->
     <script src="demos/app/key.js"></script> <!-- demo key setup -->
     <script src="demos/app/gui.js"></script> <!-- UI for configuring map -->
-    <!-- <script src="demos/app/rStats.js"></script> --> <!-- WebGL stats for debugging -->
+
+    <!-- Uncomment to enable WebGL stats for debugging -->
+    <!--
+    <script src="demos/lib/rStats.js"></script>
+    <script src="demos/lib/rStats.extras.js"></script>
+    <script src="demos/app/rStats.js"></script>
+    -->
 
   </body>
 

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -75,7 +75,7 @@ function extendLeaflet(options) {
                         wrapView: (this.options.noWrap === true ? false : true),
                         highDensityDisplay: this.options.highDensityDisplay,
                         logLevel: this.options.logLevel,
-                        introspection: this.options.introspection,
+                        introspection: this.options.introspection, // turn scene introspection on/off
                         webGLContextOptions: this.options.webGLContextOptions, // override/supplement WebGL context options
                         disableRenderLoop: this.options.disableRenderLoop // app must call scene.update() per frame
                     });

--- a/src/scene.js
+++ b/src/scene.js
@@ -136,6 +136,8 @@ export default class Scene {
         this.initializing = this.loadScene(config_source, options)
             .then(() => this.createWorkers())
             .then(() => {
+                this.destroyFeatureSelection();
+
                 // Scene loaded from a JS object, or modified by a `load` event, may contain compiled JS functions
                 // which need to be serialized, while one loaded only from a URL does not.
                 const serialize_funcs = ((typeof this.config_source === 'object') || this.hasSubscribersFor('load'));
@@ -186,17 +188,13 @@ export default class Scene {
         this.render_loop_stop = true; // schedule render loop to stop
 
         this.destroyListeners();
+        this.destroyFeatureSelection();
 
         if (this.canvas && this.canvas.parentNode) {
             this.canvas.parentNode.removeChild(this.canvas);
             this.canvas = null;
         }
         this.container = null;
-
-        if (this.selection) {
-            this.selection.destroy();
-            this.selection = null;
-        }
 
         if (this.gl) {
             Texture.destroy(this.gl);
@@ -1237,6 +1235,13 @@ export default class Scene {
         Texture.unsubscribe(this.listeners.texture);
         SceneLoader.unsubscribe(this.listeners.scene_loader);
         this.listeners = null;
+    }
+
+    destroyFeatureSelection() {
+        if (this.selection) {
+            this.selection.destroy();
+            this.selection = null;
+        }
     }
 
     resetFeatureSelection() {

--- a/src/scene.js
+++ b/src/scene.js
@@ -1352,6 +1352,7 @@ export default class Scene {
                 return counts;
             },
 
+            // Return geometry counts of visible tiles, grouped by base style name
             geometryCountByBaseStyle () {
                 let style_counts = scene.debug.geometryCountByStyle();
                 let counts = {};
@@ -1363,6 +1364,13 @@ export default class Scene {
                 return counts;
             },
 
+            // Return sum of all geometry counts for visible tiles
+            geometryCountTotal () {
+                const styles = scene.debug.geometryCountByStyle();
+                return Object.keys(styles).reduce((p, c) => styles[c] + p, 0);
+            },
+
+            // Return geometry GL buffer sizes for visible tiles, grouped by style name
             geometrySizeByStyle () {
                 let sizes = {};
                 scene.tile_manager.getRenderableTiles().forEach(tile => {
@@ -1376,6 +1384,7 @@ export default class Scene {
                 return sizes;
             },
 
+            // Return geometry GL buffer sizes for visible tiles, grouped by base style name
             geometrySizeByBaseStyle () {
                 let style_sizes = scene.debug.geometrySizeByStyle();
                 let sizes = {};
@@ -1385,6 +1394,12 @@ export default class Scene {
                     sizes[base] += style_sizes[style];
                 }
                 return sizes;
+            },
+
+            // Return sum of all geometry GL buffer sizes for visible tiles
+            geometrySizeTotal () {
+                const styles = scene.debug.geometrySizeByStyle();
+                return Object.keys(styles).reduce((p, c) => styles[c] + p, 0);
             },
 
             layerStats () {

--- a/src/scene_worker.js
+++ b/src/scene_worker.js
@@ -100,6 +100,8 @@ Object.assign(self, {
         self.configuring = self.syncing_textures.then(() => {
             log('debug', `updated config`);
         });
+
+        return self.configuring;
     },
 
     // Create data sources and clear tile cache if necessary

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -32,7 +32,6 @@ Object.assign(Lines, {
         Style.init.apply(this, arguments);
 
         // Tell the shader we want a order in vertex attributes, and to extrude lines
-        this.defines.TANGRAM_LAYER_ORDER = true;
         this.defines.TANGRAM_EXTRUDE_LINES = true;
         this.defines.TANGRAM_TEXTURE_COORDS = true; // texcoords attribute is set to static when not needed
 

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -300,8 +300,8 @@ Object.assign(Lines, {
             draw.outline.interactive = (draw.outline.interactive != null) ? draw.outline.interactive : draw.interactive;
             draw.outline.cap = draw.outline.cap || draw.cap;
             draw.outline.join = draw.outline.join || draw.join;
-            draw.outline.miter_limit = draw.outline.miter_limit || draw.miter_limit;
-            draw.outline.offset = draw.offset;
+            draw.outline.miter_limit = (draw.outline.miter_limit != null) ? draw.outline.miter_limit : draw.miter_limit;
+            draw.outline.offset = draw.offset; // always apply inline offset to outline
 
             // outline inhertits dash pattern, but NOT explicit texture
             let outline_style = this.styles[draw.outline.style];

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -15,8 +15,8 @@ import {shaderSrc_polygonsVertex, shaderSrc_polygonsFragment} from '../polygons/
 
 export const Lines = Object.create(Style);
 
-Lines.vertex_layouts = [[], []]; // first dimension is texcoords on/off, second is offsets on/off
 Lines.variants = {}; // mesh variants by variant key
+Lines.vertex_layouts = {}; // vertex layouts by variant key
 Lines.dash_textures = {}; // needs to be cleared on scene config update
 
 const DASH_SCALE = 20; // adjustment factor for UV scale to for line dash patterns w/fractional pixel width
@@ -453,7 +453,7 @@ Object.assign(Lines, {
     vertexLayoutForMeshVariant (variant) {
         if (Lines.vertex_layouts[variant.key] == null) {
             // Basic attributes, others can be added (see texture UVs below)
-            let attribs = [
+            const attribs = [
                 { name: 'a_position', size: 4, type: gl.SHORT, normalized: false },
                 { name: 'a_extrude', size: 2, type: gl.SHORT, normalized: false },
                 { name: 'a_offset', size: 2, type: gl.SHORT, normalized: false, static: (variant.offset ? null : [0, 0]) },

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -256,9 +256,6 @@ Object.assign(Lines, {
 
                 // Outlines are always at half-layer intervals to avoid conflicting with inner lines
                 style.outline.order -= 0.5;
-
-                // Ensure outlines in a separate mesh variant are drawn first
-                style.outline.variant_order = 0;
             }
         }
         else {
@@ -292,6 +289,7 @@ Object.assign(Lines, {
         this.computeVariant(draw);
 
         if (draw.outline) {
+            draw.outline.is_outline = true; // mark as outline (so mesh variant can be adjusted for render order, etc.)
             draw.outline.style = draw.outline.style || this.name;
             draw.outline.color = StyleParser.createColorPropertyCache(draw.outline.color);
             draw.outline.width = StyleParser.createPropertyCache(draw.outline.width, StyleParser.parseUnits);
@@ -429,13 +427,14 @@ Object.assign(Lines, {
         }
         key += '/' + draw.texcoords;
         key += '/' + (draw.interactive ? 1 : 0); // NB: if interactive is function, enable selection for whole draw group
+        key += '/' + draw.is_outline;
         key = hashString(key);
         draw.variant = key;
 
         if (Lines.variants[key] == null) {
             Lines.variants[key] = {
                 key,
-                order: draw.variant_order,
+                order: (draw.is_outline ? 0 : 1), // outlines should be drawn first, so inline is on top
                 selection: (draw.interactive ? 1 : 0),
                 offset: (draw.offset ? 1 : 0),
                 texcoords: draw.texcoords,

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -234,6 +234,7 @@ Object.assign(Lines, {
 
                 // Inherited properties
                 style.outline.color = draw.outline.color;
+                style.outline.interactive = draw.outline.interactive;
                 style.outline.cap = draw.outline.cap;
                 style.outline.join = draw.outline.join;
                 style.outline.miter_limit = draw.outline.miter_limit;
@@ -297,6 +298,7 @@ Object.assign(Lines, {
             draw.outline.width = StyleParser.createPropertyCache(draw.outline.width, StyleParser.parseUnits);
             draw.outline.next_width = StyleParser.createPropertyCache(draw.outline.width, StyleParser.parseUnits); // width re-computed for next zoom
 
+            draw.outline.interactive = (draw.outline.interactive != null) ? draw.outline.interactive : draw.interactive;
             draw.outline.cap = draw.outline.cap || draw.cap;
             draw.outline.join = draw.outline.join || draw.join;
             draw.outline.miter_limit = draw.outline.miter_limit || draw.miter_limit;

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -429,6 +429,7 @@ Object.assign(Lines, {
             key += draw.texture_merged;
         }
         key += '/' + draw.texcoords;
+        key += '/' + (draw.interactive ? 1 : 0); // NB: if interactive is function, enable selection for whole draw group
         key = hashString(key);
         draw.variant = key;
 
@@ -436,6 +437,7 @@ Object.assign(Lines, {
             Lines.variants[key] = {
                 key,
                 order: draw.variant_order,
+                selection: (draw.interactive ? 1 : 0),
                 offset: (draw.offset ? 1 : 0),
                 texcoords: draw.texcoords,
                 texture: draw.texture_merged,
@@ -458,8 +460,9 @@ Object.assign(Lines, {
                 { name: 'a_scaling', size: 2, type: gl.SHORT, normalized: false },
                 { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true, static: (variant.texcoords ? null : [0, 0]) },
                 { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-                { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
+                { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true, static: (variant.selection ? null : [0, 0, 0, 0]) }
             ];
+
             Lines.vertex_layouts[variant.key] = new VertexLayout(attribs);
         }
         return Lines.vertex_layouts[variant.key];
@@ -513,7 +516,7 @@ Object.assign(Lines, {
         this.vertex_template[i++] = style.color[3] * 255;
 
         // selection color
-        if (this.selection) {
+        if (mesh.variant.selection) {
             // a_selection_color.rgba
             this.vertex_template[i++] = style.selection_color[0] * 255;
             this.vertex_template[i++] = style.selection_color[1] * 255;

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -28,7 +28,6 @@ Object.assign(Polygons, {
 
         // Tell the shader about optional attributes (shader is shared with lines style, which has different config)
         this.defines.TANGRAM_NORMAL_ATTRIBUTE = true;
-        this.defines.TANGRAM_LAYER_ORDER = true;
         this.defines.TANGRAM_TEXTURE_COORDS = this.texcoords;
     },
 

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -282,7 +282,7 @@ export var Style = {
 
             // Feature selection (only if feature is marked as interactive, and style supports it)
             if (this.selection) {
-                style.interactive = StyleParser.evalProperty(this.introspection || draw.interactive, context);
+                style.interactive = StyleParser.evalProperty(draw.interactive, context);
             }
             else {
                 style.interactive = false;
@@ -321,6 +321,13 @@ export var Style = {
                         draw[param] = val;
                     }
                 }
+            }
+
+            if (!this.selection) {
+                draw.interactive = false; // always disable feature selection for when style doesn't support it
+            }
+            else if (this.introspection) {
+                draw.interactive = true;  // always enable feature selection for introspection
             }
 
             draw = this._preprocess(draw); // optional subclass implementation

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -176,7 +176,7 @@ export var Style = {
         return this.vertex_layout;
     },
 
-    default_mesh_variant: { key: 0 },
+    default_mesh_variant: { key: 0, order: 0 },
     meshVariantTypeForDraw (draw) {
         return this.default_mesh_variant;
     },


### PR DESCRIPTION
A few optimizations to improve performance for feature selection:

- Skip feature selection rendering entirely when there are no `interactive` features currently rendered in the scene (either because the style doesn't specify any, or just if they are not in the current visible tile set).
- Lazily instantiate feature selection resources the first time a selection render pass is needed. Specifically, this avoids allocating a GL framebuffer until it's needed, which is a significant savings / delay in memory usage.
  - Also clear these resources when a new scene is loaded (new scene may not have any interactive features).
- Using the "mesh variants" capability developed for line offsets (which allows for doing multiple draw calls per style, with different vertex layout and/or uniform values), only allocate VBO space for `interactive` features on `polygons` and `lines` styles (this could be enabled for `points`/`text` as well, but these usually consume considerably less space and the code change is more complex, since these already have mesh variants for different texture bindings and shader-drawn points). This is a ~15% memory savings for non-`interactive` features (most of them!).

These only improve existing behavior, so can be included in a 0.15.x release (and we also have several PRs stacking up for a 0.16.0 release!).