### PR TITLE
Use getters/setters to fix "sticky" global property edge case

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -925,7 +925,6 @@ export default class Scene {
     */
     loadScene(config_source = null, { base_path, file_type } = {}) {
         this.config_source = config_source || this.config_source;
-        this.config_globals_applied = [];
 
         if (typeof this.config_source === 'string') {
             this.base_path = URLs.pathForURL(base_path || this.config_source);
@@ -1142,7 +1141,7 @@ export default class Scene {
         this.generation = ++Scene.generation;
         this.updating++;
 
-        this.config = SceneLoader.applyGlobalProperties(this.config, this.config_globals_applied);
+        this.config = SceneLoader.applyGlobalProperties(this.config);
         if (normalize) {
             // normalize whole scene
             SceneLoader.normalize(this.config, this.config_bundle);


### PR DESCRIPTION
Changes how `global` property substitution is applied, to fix an edge case where globals were too "sticky": once a property had a global value substituted, it could never be "un-linked" from that global, even if directly modified in the `scene.config` object.

Example, for a global:
```
global:
  color: red
```

Referenced in a draw block:
```
layer:
  draw:
    color: global.color
```

When the scene is loaded, the `global.color` value will be applied, and the draw `color` will be `red`.

If the value is then modified in JS:

```
scene.config.layers.layer.draw.color = 'blue'; // set to an explicit, non-global value
scene.updateConfig();
```

The original global linkage would "stick", and the final `color` would still be `red` (instead of the new `blue` value)! This is a rare but frustrating issue, especially in cases where you want to modify the behavior of an existing basemap (and where changing the actual `global` value may be impractical, e.g. if it is used in other places in the scene).

This PR uses JS `get` and `set` methods to detect cases where a previously `global` value is being set to an explicit one. These getters/setters are only applied to properties that have global substitution (for performance), and the setter removes the getter/setter pair (reverting back to a plain JS value). A `Proxy`-based solution was also considered, but has issues both with browser compatibility (can't be sufficiently polyfilled for our needs in IE11), and performance (applies to the whole `config` object, which is heavily accessed).

