### PR TITLE
Cache user-defined JS functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ import Texture from './gl/texture';
 import Material from './material';
 import Light from './light';
 import WorkerBroker from './utils/worker_broker';
-import {layerCache} from './styles/layer';
 import {StyleManager} from './styles/style_manager';
 import StyleParser from './styles/style_parser';
 import Collision from './labels/collision';
@@ -29,7 +28,7 @@ import debugSettings from './utils/debug_settings';
 import yaml from 'js-yaml';
 
 // Make some modules accessible for debugging
-var debug = {
+const debug = {
     log,
     yaml,
     Utils,
@@ -44,7 +43,6 @@ var debug = {
     Light,
     Scene,
     WorkerBroker,
-    layerCache,
     StyleManager,
     StyleParser,
     Collision,

--- a/src/scene.js
+++ b/src/scene.js
@@ -139,7 +139,9 @@ export default class Scene {
         this.initializing = this.loadScene(config_source, options)
             .then(() => this.createWorkers())
             .then(() => {
+                // Clean up resources from prior scene
                 this.destroyFeatureSelection();
+                WorkerBroker.postMessage(this.workers, 'self.clearFunctionStringCache');
 
                 // Scene loaded from a JS object, or modified by a `load` event, may contain compiled JS functions
                 // which need to be serialized, while one loaded only from a URL does not.

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -1,5 +1,5 @@
 import StyleParser from './style_parser';
-import Utils from '../utils/utils';
+import {compileFunctionStrings} from '../utils/functions';
 import log from '../utils/log';
 import mergeObjects from '../utils/merge';
 import {buildFilter} from './filter';
@@ -128,13 +128,13 @@ class Layer {
     }
 
     buildDraw() {
-        this.draw = Utils.stringsToFunctions(this.draw, StyleParser.wrapFunction);
+        this.draw = compileFunctionStrings(this.draw, StyleParser.wrapFunction);
         this.calculatedDraw = calculateDraw(this);
     }
 
     buildFilter() {
         this.filter_original = this.filter;
-        this.filter = Utils.stringsToFunctions(this.filter, StyleParser.wrapFunction);
+        this.filter = compileFunctionStrings(this.filter, StyleParser.wrapFunction);
 
         let type = typeof this.filter;
         if (this.filter != null && type !== 'object' && type !== 'function') {

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -1,4 +1,5 @@
 import Utils from '../utils/utils';
+import {compileFunctionString} from '../utils/functions';
 import Geo from '../geo';
 import log from '../utils/log';
 
@@ -147,7 +148,7 @@ StyleParser.createPropertyCache = function (obj, transform = null) {
 StyleParser.createColorPropertyCache = function (obj) {
     return StyleParser.createPropertyCache(obj, v => {
         if (v === 'Style.color.pseudoRandomColor') {
-            return Utils.stringToFunction(StyleParser.wrapFunction(StyleParser.macros['Style.color.pseudoRandomColor']));
+            return compileFunctionString(StyleParser.wrapFunction(StyleParser.macros['Style.color.pseudoRandomColor']));
         }
         else if (v === 'Style.color.randomColor') {
             return StyleParser.macros['Style.color.randomColor'];

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,0 +1,69 @@
+import hashString from './hash';
+
+// cache of functions, keyed by unique source
+const cache = {
+    functions: {},
+    num_functions: 0,
+    num_cached: 0
+};
+
+export { cache as functionStringCache };
+
+export function clearFunctionStringCache () {
+    cache.functions = {};
+    cache.num_functions = 0;
+    cache.num_cached = 0;
+}
+
+// Recursively parse an object, compiling string properties that look like functions
+export function compileFunctionStrings (obj, wrap) {
+    // Convert string
+    if (typeof obj === 'string') {
+        obj = compileFunctionString(obj, wrap);
+    }
+    // Loop through object properties
+    else if (obj != null && typeof obj === 'object') {
+        for (let p in obj) {
+            obj[p] = compileFunctionStrings(obj[p], wrap);
+        }
+    }
+    return obj;
+}
+
+// Compile a string that looks like a function
+export function compileFunctionString (val, wrap) {
+    // Parse function signature and body
+    let fmatch =
+        (typeof val === 'string') &&
+        val.match(/^\s*function[^(]*\(([^)]*)\)\s*?\{([\s\S]*)\}$/m);
+
+    if (fmatch && fmatch.length > 2) {
+        try {
+            // function body
+            const body = fmatch[2];
+            const source = (typeof wrap === 'function') ? wrap(body) : body; // optionally wrap source
+
+            // compile and cache by unique function source
+            const key = hashString(source);
+            if (cache.functions[key] === undefined) {
+                // function arguments extracted from signature
+                let args = fmatch[1].length > 0 && fmatch[1].split(',').map(x => x.trim()).filter(x => x);
+                args = args.length > 0 ? args : ['context']; // default to single 'context' argument
+
+                cache.functions[key] = new Function(args.toString(), source); // jshint ignore:line
+                cache.functions[key].source = body; // save original, un-wrapped function body source
+                cache.num_functions++;
+            }
+            else {
+                cache.num_cached++;
+            }
+
+            return cache.functions[key];
+        }
+        catch (e) {
+            // fall-back to original value if parsing failed
+            return val;
+        }
+    }
+    return val;
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -127,52 +127,6 @@ Utils.serializeWithFunctions = function (obj) {
     return serialized;
 };
 
-// Recursively parse an object, attempting to convert string properties that look like functions back into functions
-Utils.stringsToFunctions = function(obj, wrap) {
-    // Convert string
-    if (typeof obj === 'string') {
-        obj = Utils.stringToFunction(obj, wrap);
-    }
-    // Loop through object properties
-    else if (obj != null && typeof obj === 'object') {
-        for (let p in obj) {
-            obj[p] = Utils.stringsToFunctions(obj[p], wrap);
-        }
-    }
-    return obj;
-};
-
-// Convert string back into a function
-Utils.stringToFunction = function(val, wrap) {
-    // Parse function signature and body
-    let fmatch =
-        (typeof val === 'string') &&
-        val.match(/^\s*function[^(]*\(([^)]*)\)\s*?\{([\s\S]*)\}$/m);
-
-    if (fmatch && fmatch.length > 2) {
-        try {
-            let src = fmatch[2];
-            let args = fmatch[1].length > 0 && fmatch[1].split(',').map(x => x.trim()).filter(x => x);
-            args = args.length > 0 ? args : ['context']; // default to single 'context' argument
-
-            let func;
-            if (typeof wrap === 'function') {
-                func = new Function(args.toString(), wrap(src)); // jshint ignore:line
-            }
-            else {
-                func = new Function(args.toString(), src); // jshint ignore:line
-            }
-            func.source = src; // save original, un-wrapped function source
-            return func;
-        }
-        catch (e) {
-            // fall-back to original value if parsing failed
-            return val;
-        }
-    }
-    return val;
-};
-
 // Default to allowing high pixel density
 // Returns true if display density changed
 Utils.use_high_density_display = true;


### PR DESCRIPTION
This caches user-defined JS functions for the scene (e.g. for filters, colors, etc.) by their unique source code. This can lead to substantial decrease in the number of functions that have to be compiled when using globals. On Mapzen/Nextzen styles, the reduction is anywhere from 40% (on Bubble Wrap) to almost 300% (on Walkabout). Additionally, the cache is cleared when a new scene is loaded, so these functions can be freed.