### PR TITLE
Meetar/overzoom

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -48,6 +48,11 @@ export default class DataSource {
         // set a custom extra overzoom adjustment factor to load consistently lower zoom levels
         // than the current map zoom level – eg a zoom_offset of 1 would load z3 data at z4
         this.zoom_offset = (config.zoom_offset != null) ? config.zoom_offset : 0;
+        if (this.zoom_offset < 0) {
+            let msg = `Data source '${this.name}' zoom_offset must not be negative – setting to 0. `;
+            log({ level: 'warn', once: true }, msg);
+            this.zoom_offset = 0;
+        }
 
         this.setTileSize(config.tile_size);
         // factor in zoom_bias to account for tile sizes > than 256px

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -45,6 +45,9 @@ export default class DataSource {
         // overzoom will apply for zooms higher than this
         this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
 
+        // set a custom extra overzoom factor to load consistently lower zoom levels
+        this.overzoom = (config.overzoom != null) ? config.overzoom : 0;
+
         this.setTileSize(config.tile_size);
         this.max_coord_zoom = this.max_zoom + this.zoom_bias;
 
@@ -159,7 +162,10 @@ export default class DataSource {
         }
 
         // # of zoom levels bigger than 256px tiles - 8 in place of log2(256)
-        this.zoom_bias = Math.log2(this.tile_size) - 8;
+        // Many Tangram functions assume 256px tiles, this factor adjusts for the
+        // case of bigger tile sizes - eg 512px tiles are 1 zoom level bigger,
+        // 1024px tiles are 2 levels bigger
+        this.zoom_bias = Math.log2(this.tile_size) - 8 + this.overzoom;
     }
 
     // Infer winding for data source from first ring of provided geometry

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -45,8 +45,9 @@ export default class DataSource {
         // overzoom will apply for zooms higher than this
         this.max_zoom = (config.max_zoom != null) ? config.max_zoom : Geo.default_source_max_zoom;
 
-        // set a custom extra overzoom factor to load consistently lower zoom levels
-        this.overzoom = (config.overzoom != null) ? config.overzoom : 0;
+        // set a custom extra overzoom adjustment factor to load consistently lower zoom levels
+        // than the current map zoom level – eg a zoom_offset of 1 would load z3 data at z4
+        this.zoom_offset = (config.zoom_offset != null) ? config.zoom_offset : 0;
 
         this.setTileSize(config.tile_size);
         // factor in zoom_bias to account for tile sizes > than 256px
@@ -166,7 +167,7 @@ export default class DataSource {
         // Many Tangram functions assume 256px tiles, this factor adjusts for the
         // case of bigger tile sizes - eg 512px tiles are 1 zoom level bigger,
         // 1024px tiles are 2 levels bigger
-        this.zoom_bias = Math.log2(this.tile_size) - 8 + this.overzoom;
+        this.zoom_bias = Math.log2(this.tile_size) - 8 + this.tile_adjust;
     }
 
     // Infer winding for data source from first ring of provided geometry

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -167,7 +167,7 @@ export default class DataSource {
         // Many Tangram functions assume 256px tiles, this factor adjusts for the
         // case of bigger tile sizes - eg 512px tiles are 1 zoom level bigger,
         // 1024px tiles are 2 levels bigger
-        this.zoom_bias = Math.log2(this.tile_size) - 8 + this.tile_adjust;
+        this.zoom_bias = Math.log2(this.tile_size) - 8 + this.zoom_offset;
     }
 
     // Infer winding for data source from first ring of provided geometry

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -49,14 +49,12 @@ export default class DataSource {
         // than the current map zoom level – eg a zoom_offset of 1 would load z3 data at z4
         this.zoom_offset = (config.zoom_offset != null) ? config.zoom_offset : 0;
         if (this.zoom_offset < 0) {
-            let msg = `Data source '${this.name}' zoom_offset must not be negative – setting to 0. `;
+            let msg = `Data source '${this.name}' zoom_offset must not be negative – setting to 0.`;
             log({ level: 'warn', once: true }, msg);
             this.zoom_offset = 0;
         }
 
         this.setTileSize(config.tile_size);
-        // factor in zoom_bias to account for tile sizes > than 256px
-        this.max_coord_zoom = this.max_zoom + this.zoom_bias;
 
         // no tiles will be requested or displayed outside of these min/max values
         this.min_display_zoom = (config.min_display_zoom != null) ? config.min_display_zoom : 0;
@@ -173,6 +171,12 @@ export default class DataSource {
         // case of bigger tile sizes - eg 512px tiles are 1 zoom level bigger,
         // 1024px tiles are 2 levels bigger
         this.zoom_bias = Math.log2(this.tile_size) - 8 + this.zoom_offset;
+
+        // the max/min coordinate zoom level at which tiles will be loaded from server
+        // (but tiles can be styled at other zooms)
+        // zoom_bias adjusts for tile sizes > than 256px, and manual zoom_offset
+        this.max_coord_zoom = this.max_zoom + this.zoom_bias;
+        this.min_coord_zoom = this.zoom_bias;
     }
 
     // Infer winding for data source from first ring of provided geometry

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -49,6 +49,7 @@ export default class DataSource {
         this.overzoom = (config.overzoom != null) ? config.overzoom : 0;
 
         this.setTileSize(config.tile_size);
+        // factor in zoom_bias to account for tile sizes > than 256px
         this.max_coord_zoom = this.max_zoom + this.zoom_bias;
 
         // no tiles will be requested or displayed outside of these min/max values

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -1,5 +1,5 @@
 import DataSource, {NetworkTileSource} from './data_source';
-import Tile from '../tile';
+import {TileID} from '../tile_id';
 import Geo from '../geo';
 import log from '../utils/log';
 
@@ -70,7 +70,7 @@ export class RasterTileSource extends NetworkTileSource {
             let zdiff = this.zoom_bias - tile_source.zoom_bias; // difference in zoom detail between the sources
             if (zdiff > 0) { // raster source is less detailed
                 // do extra zoom adjustment and apply this raster source's max zoom
-                coords = Tile.normalizedCoordinate(tile.coords, {
+                coords = TileID.normalizedCoord(tile.coords, {
                     zoom_bias: zdiff,
                     max_zoom: this.max_zoom
                 });
@@ -86,7 +86,7 @@ export class RasterTileSource extends NetworkTileSource {
                 }
 
                 // no extra zoom adjustment needed, but still need to apply this raster source's max zoom
-                coords = Tile.coordinateWithMaxZoom(coords, this.max_zoom);
+                coords = TileID.coordWithMaxZoom(coords, this.max_zoom);
             }
         }
         return coords;

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -48,9 +48,9 @@ export class RasterTileSource extends NetworkTileSource {
     // Return texture info for a raster tile
     tileTexture (tile) {
         let new_coords = tile.coords;
-        if (this.overzoom !== 0) {
-            // account for any overzoom parameter on the raster datasource
-            new_coords = Tile.coordinateAtZoom({x: tile.coords.x, y: tile.coords.y, z: tile.coords.z}, Math.max(tile.coords.z - this.overzoom, 0));
+        if (this.zoom_offset !== 0) {
+            // account for any zoom_offset parameter on the raster datasource
+            new_coords = Tile.coordinateAtZoom({x: tile.coords.x, y: tile.coords.y, z: tile.coords.z}, Math.max(tile.coords.z - this.zoom_offset, 0));
         }
         let key = new_coords.key;
         if (!this.textures[key]) {

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -47,9 +47,14 @@ export class RasterTileSource extends NetworkTileSource {
 
     // Return texture info for a raster tile
     tileTexture (tile) {
-        let key = tile.coords.key;
+        let new_coords = tile.coords;
+        if (this.overzoom !== 0) {
+            // account for any overzoom parameter on the raster datasource
+            new_coords = Tile.coordinateAtZoom({x: tile.coords.x, y: tile.coords.y, z: tile.coords.z}, Math.max(tile.coords.z - this.overzoom, 0));
+        }
+        let key = new_coords.key;
         if (!this.textures[key]) {
-            let coords = Tile.coordinateWithMaxZoom(tile.coords, this.max_zoom);
+            let coords = Tile.coordinateWithMaxZoom(new_coords, this.max_zoom);
             let url = this.formatUrl(this.url, { coords });
             this.textures[key] = { url, filtering: this.filtering, coords };
         }

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -47,14 +47,9 @@ export class RasterTileSource extends NetworkTileSource {
 
     // Return texture info for a raster tile
     tileTexture (tile) {
-        let new_coords = tile.coords;
-        if (this.zoom_offset !== 0) {
-            // account for any zoom_offset parameter on the raster datasource
-            new_coords = Tile.coordinateAtZoom({x: tile.coords.x, y: tile.coords.y, z: tile.coords.z}, Math.max(tile.coords.z - this.zoom_offset, 0));
-        }
-        let key = new_coords.key;
+        let coords = Tile.normalizedCoordinate(tile.coords, { max_zoom: this.max_zoom, zoom_bias: this.zoom_offset });
+        let key = coords.key;
         if (!this.textures[key]) {
-            let coords = Tile.coordinateWithMaxZoom(new_coords, this.max_zoom);
             let url = this.formatUrl(this.url, { coords });
             this.textures[key] = { url, filtering: this.filtering, coords };
         }

--- a/src/tile.js
+++ b/src/tile.js
@@ -85,12 +85,13 @@ export default class Tile {
 
     static normalizedCoordinate (coords, source) {
         if (source.zoom_bias) {
-            coords = Tile.coordinateAtZoom(coords, Math.max(0, coords.z - source.zoom_bias)); // zoom can't go below zero
+            coords = Tile.coordinateAtZoom(coords, coords.z - source.zoom_bias);
         }
         return Tile.coordinateWithMaxZoom(coords, source.max_zoom);
     }
 
     static coordinateAtZoom({x, y, z}, zoom) {
+        zoom = Math.max(0, zoom); // zoom can't go below zero
         if (z !== zoom) {
             let zscale = Math.pow(2, z - zoom);
             x = Math.floor(x / zscale);
@@ -101,7 +102,7 @@ export default class Tile {
     }
 
     static coordinateWithMaxZoom({x, y, z}, max_zoom) {
-        if (max_zoom !== undefined && z > max_zoom) {
+        if (max_zoom != null && z > max_zoom) {
             return Tile.coordinateAtZoom({x, y, z}, max_zoom);
         }
         return Tile.coord({x, y, z});

--- a/src/tile.js
+++ b/src/tile.js
@@ -44,7 +44,7 @@ export default class Tile {
         this.debug = {};
 
         this.style_zoom = style_zoom; // zoom level to be used for styling
-        this.coords = Tile.normalizedCoordinate(coords, this.source, this.style_zoom);
+        this.coords = Tile.normalizedCoordinate(coords, this.source);
         this.key = Tile.key(this.coords, this.source, this.style_zoom);
         this.overzoom = Math.max(this.style_zoom - this.coords.z, 0); // number of levels of overzooming
         this.overzoom2 = Math.pow(2, this.overzoom);
@@ -80,10 +80,10 @@ export default class Tile {
     }
 
     static normalizedKey (coords, source, style_zoom) {
-        return Tile.key(Tile.normalizedCoordinate(coords, source, style_zoom), source, style_zoom);
+        return Tile.key(Tile.normalizedCoordinate(coords, source, style_zoom), source);
     }
 
-    static normalizedCoordinate (coords, source, style_zoom) {
+    static normalizedCoordinate (coords, source) {
         if (source.zoom_bias) {
             coords = Tile.coordinateAtZoom(coords, Math.max(0, coords.z - source.zoom_bias)); // zoom can't go below zero
         }

--- a/src/tile.js
+++ b/src/tile.js
@@ -128,6 +128,52 @@ export default class Tile {
         return false;
     }
 
+    // Return identifying info for tile's parent tile
+    static parentInfo ({ coords, source, style_zoom }) {
+        if (style_zoom > source.max_coord_zoom || style_zoom <= source.min_coord_zoom) {
+            if (style_zoom > 0) { // no more tiles above style zoom 0
+                return {
+                    key: Tile.key(coords, source, style_zoom - 1),
+                    coords,
+                    style_zoom: style_zoom - 1,
+                    source
+                };
+            }
+            return;
+        }
+        else if (style_zoom > 0) { // no more tiles above style zoom 0
+            const c = Tile.coordinateAtZoom(coords, coords.z - 1);
+            return {
+                key: Tile.key(c, source, style_zoom - 1),
+                coords: c,
+                style_zoom: style_zoom - 1,
+                source
+            };
+        }
+    }
+
+    // Return identifying info for tile's child tiles
+    static childrenInfo ({ coords, source, style_zoom }) {
+        if (style_zoom >= source.max_coord_zoom || style_zoom < source.min_coord_zoom) {
+            return [{
+                key: Tile.key(coords, source, style_zoom + 1),
+                coords,
+                style_zoom: style_zoom + 1,
+                source
+            }];
+        }
+
+        const children = Tile.childrenForCoordinate(coords);
+        return children.map(c => {
+            return {
+                key: Tile.key(c, source, style_zoom + 1),
+                coords: c,
+                style_zoom: style_zoom + 1,
+                source
+            };
+        });
+    }
+
     // Free resources owned by tile
     freeResources () {
         for (let m in this.meshes) {

--- a/src/tile_id.js
+++ b/src/tile_id.js
@@ -1,0 +1,117 @@
+
+const COORD_CHILDREN = {}; // only allocate children coords once per coord
+
+export const TileID = {
+
+    coord(c) {
+        return {x: c.x, y: c.y, z: c.z, key: this.coordKey(c)};
+    },
+
+    coordKey({x, y, z}) {
+        return x + '/' + y + '/' + z;
+    },
+
+    key (coords, source, style_zoom) {
+        if (coords.y < 0 || coords.y >= (1 << coords.z) || coords.z < 0) {
+            return; // cull tiles out of range (x will wrap)
+        }
+        return [source.name, style_zoom, coords.x, coords.y, coords.z].join('/');
+    },
+
+    normalizedKey (coords, source, style_zoom) {
+        return this.key(this.normalizedCoord(coords, source), source, style_zoom);
+    },
+
+    normalizedCoord (coords, source) {
+        if (source.zoom_bias) {
+            coords = this.coordAtZoom(coords, coords.z - source.zoom_bias);
+        }
+        return this.coordWithMaxZoom(coords, source.max_zoom);
+    },
+
+    coordAtZoom({x, y, z}, zoom) {
+        zoom = Math.max(0, zoom); // zoom can't go below zero
+        if (z !== zoom) {
+            let zscale = Math.pow(2, z - zoom);
+            x = Math.floor(x / zscale);
+            y = Math.floor(y / zscale);
+            z = zoom;
+        }
+        return this.coord({x, y, z});
+    },
+
+    coordWithMaxZoom({x, y, z}, max_zoom) {
+        if (max_zoom != null && z > max_zoom) {
+            return this.coordAtZoom({x, y, z}, max_zoom);
+        }
+        return this.coord({x, y, z});
+    },
+
+    childrenForCoord({x, y, z, key}) {
+        if (!COORD_CHILDREN[key]) {
+            z++;
+            x *= 2;
+            y *= 2;
+            COORD_CHILDREN[key] = [
+                this.coord({x, y,      z}), this.coord({x: x+1, y,      z}),
+                this.coord({x, y: y+1, z}), this.coord({x: x+1, y: y+1, z})
+            ];
+        }
+        return COORD_CHILDREN[key];
+    },
+
+    isDescendant(parent, descendant) {
+        if (descendant.z > parent.z) {
+            let {x, y} = this.coordAtZoom(descendant, parent.z);
+            return (parent.x === x && parent.y === y);
+        }
+        return false;
+    },
+
+    // Return identifying info for tile's parent tile
+    parent ({ coords, source, style_zoom }) {
+        if (style_zoom > source.max_coord_zoom || style_zoom <= source.min_coord_zoom) {
+            if (style_zoom > 0) { // no more tiles above style zoom 0
+                return {
+                    key: this.key(coords, source, style_zoom - 1),
+                    coords,
+                    style_zoom: style_zoom - 1,
+                    source
+                };
+            }
+            return;
+        }
+        else if (style_zoom > 0) { // no more tiles above style zoom 0
+            const c = this.coordAtZoom(coords, coords.z - 1);
+            return {
+                key: this.key(c, source, style_zoom - 1),
+                coords: c,
+                style_zoom: style_zoom - 1,
+                source
+            };
+        }
+    },
+
+    // Return identifying info for tile's child tiles
+    children ({ coords, source, style_zoom }) {
+        if (style_zoom >= source.max_coord_zoom || style_zoom < source.min_coord_zoom) {
+            return [{
+                key: this.key(coords, source, style_zoom + 1),
+                coords,
+                style_zoom: style_zoom + 1,
+                source
+            }];
+        }
+
+        const children = this.childrenForCoord(coords);
+        return children.map(c => {
+            return {
+                key: this.key(c, source, style_zoom + 1),
+                coords: c,
+                style_zoom: style_zoom + 1,
+                source
+            };
+        });
+    }
+
+};

--- a/src/tile_manager.js
+++ b/src/tile_manager.js
@@ -1,4 +1,5 @@
 import Tile from './tile';
+import {TileID} from './tile_id';
 import TilePyramid from './tile_pyramid';
 import Geo from './geo';
 import mainThreadLabelCollisionPass from './labels/main_pass';
@@ -224,7 +225,7 @@ export default class TileManager {
             else {
                 // brute force
                 for (let key in this.visible_coords) {
-                    if (Tile.isDescendant(tile.coords, this.visible_coords[key])) {
+                    if (TileID.isDescendant(tile.coords, this.visible_coords[key])) {
                         tile.visible = true;
                         break;
                     }
@@ -344,7 +345,7 @@ export default class TileManager {
                 continue;
             }
 
-            let key = Tile.normalizedKey(coords, source, this.view.tile_zoom);
+            let key = TileID.normalizedKey(coords, source, this.view.tile_zoom);
             if (key && !this.hasTile(key)) {
                 log('trace', `load tile ${key}, distance from view center: ${coords.center_dist}`);
                 let tile = new Tile({

--- a/src/tile_pyramid.js
+++ b/src/tile_pyramid.js
@@ -76,6 +76,7 @@ export default class TilePyramid {
         }
     }
 
+    // Find the parent tile for a given point and zoom level
     getAncestor ({ coords, style_zoom, source }, level = 1) {
         if (level > this.max_proxy_ancestor_depth) {
             return;
@@ -107,6 +108,7 @@ export default class TilePyramid {
         }
     }
 
+    // Find the descendant tiles for a given point and zoom level
     getDescendants ({ coords, style_zoom, source }, level = 1) {
         let descendants = [];
 

--- a/src/tile_pyramid.js
+++ b/src/tile_pyramid.js
@@ -1,4 +1,4 @@
-import Tile from './tile';
+import {TileID} from './tile_id';
 
 export default class TilePyramid {
 
@@ -15,7 +15,7 @@ export default class TilePyramid {
 
         // Add to parents
         while (tile.style_zoom >= 0) {
-            tile = Tile.parentInfo(tile);
+            tile = TileID.parent(tile);
             if (!tile) {
                 return;
             }
@@ -39,7 +39,7 @@ export default class TilePyramid {
 
         // Decrement reference count up the tile pyramid
         while (tile.style_zoom >= 0) {
-            tile = Tile.parentInfo(tile);
+            tile = TileID.parent(tile);
             if (!tile) {
                 return;
             }
@@ -58,7 +58,7 @@ export default class TilePyramid {
         let level = 0;
         while (level < this.max_proxy_ancestor_depth) {
             const last_z = tile.coords.z;
-            tile = Tile.parentInfo(tile);
+            tile = TileID.parent(tile);
             if (!tile) {
                 return;
             }
@@ -79,7 +79,7 @@ export default class TilePyramid {
     getDescendants (tile, level = 0) {
         let descendants = [];
         if (level < this.max_proxy_descendant_depth) {
-            let tiles = Tile.childrenInfo(tile);
+            let tiles = TileID.children(tile);
             if (!tiles) {
                 return;
             }

--- a/src/tile_pyramid.js
+++ b/src/tile_pyramid.js
@@ -4,8 +4,8 @@ export default class TilePyramid {
 
     constructor() {
         this.tiles = {};
-        this.max_proxy_descendant_depth = 3; // # of levels to search up/down for proxy tiles
-        this.max_proxy_ancestor_depth = 5;
+        this.max_proxy_descendant_depth = 6; // # of levels to search up/down for proxy tiles
+        this.max_proxy_ancestor_depth = 7;
     }
 
     addTile(tile) {

--- a/src/view.js
+++ b/src/view.js
@@ -1,5 +1,5 @@
 import Geo from './geo';
-import Tile from './tile';
+import {TileID} from './tile_id';
 import Camera from './camera';
 import Utils from './utils/utils';
 import subscribeMixin from './utils/subscribe';
@@ -243,7 +243,7 @@ export default class View {
         let coords = [];
         for (let x = range[0]; x <= range[1]; x++) {
             for (let y = range[2]; y <= range[3]; y++) {
-                coords.push(Tile.coord({ x, y, z }));
+                coords.push(TileID.coord({ x, y, z }));
             }
         }
         return coords;
@@ -280,7 +280,7 @@ export default class View {
             }
 
             // Handle tiles at different zooms
-            let coords = Tile.coordinateAtZoom(tile.coords, this.tile_zoom);
+            let coords = TileID.coordAtZoom(tile.coords, this.tile_zoom);
 
             // Discard tiles outside an area surrounding the viewport
             if (Math.abs(coords.x - this.center.tile.x) - border_tiles[0] > this.buffer) {

--- a/test/tile_pyramid.js
+++ b/test/tile_pyramid.js
@@ -27,65 +27,49 @@ describe('TilePyramid', function() {
                 source,
                 loaded: true
             };
+            tile.key = Tile.key(tile.coords, source, style_zoom);
         });
 
         it('creates one entry per zoom', () => {
             pyramid.addTile(tile);
-            assert.equal(Object.keys(pyramid.coords).length, coords.z + 1);
+
+            assert.equal(Object.keys(pyramid.tiles).length, coords.z + 1);
         });
 
         it('creates one entry for non-overzoomed tile', () => {
             pyramid.addTile(tile);
 
-            let entries = pyramid.coords[tile.coords.key].sources[tile.source.name];
-            assert.equal(Object.keys(entries).length, 1);
+            assert.isNotNull(pyramid.tiles[tile.key]);
         });
 
-        it('creates one entry for an overzoomed tile', () => {
+        it('creates entries for overzoomed tiles', () => {
             tile = Object.assign({}, tile);
             tile.coords = Tile.coordinateAtZoom(coords, 18);
             tile.style_zoom = 20;
             pyramid.addTile(tile);
 
-            let entries = pyramid.coords[tile.coords.key].sources[tile.source.name];
-            assert.equal(Object.keys(entries).length, 1);
-        });
-
-        it('creates additional entries for overzoomed tiles', () => {
-            tile = Object.assign({}, tile);
-            tile.coords = Tile.coordinateAtZoom(coords, 18);
-            tile.style_zoom = 19;
-            pyramid.addTile(tile);
-
-            tile = Object.assign({}, tile);
-            tile.style_zoom = 20;
-            pyramid.addTile(tile);
-
-            let entries = pyramid.coords[tile.coords.key].sources[tile.source.name];
-            assert.equal(Object.keys(entries).length, 2);
+            assert.isNotNull(pyramid.tiles[Tile.key(tile.coords, source, tile.style_zoom)]);
         });
 
         it('removes all entries for single tile', () => {
             pyramid.addTile(tile);
             pyramid.removeTile(tile);
-            assert.equal(Object.keys(pyramid.coords).length, 0);
+
+            assert.equal(Object.keys(pyramid.tiles).length, 0);
         });
 
         it('gets tile ancestor', () => {
             pyramid.addTile(tile);
-            tile = Object.assign({}, tile);
-            tile.coords = Tile.coordinateAtZoom(tile.coords, tile.coords.z + 2);
-            tile.style_zoom = tile.coords.z;
             let ancestor = pyramid.getAncestor(tile);
+
             assert.isNotNull(ancestor);
         });
 
         it('gets tile descendant', () => {
             pyramid.addTile(tile);
-            tile = Object.assign({}, tile);
-            tile.coords = Tile.coordinateAtZoom(tile.coords, tile.coords.z - 2);
-            tile.style_zoom = tile.coords.z;
-            let descendants = pyramid.getDescendants(tile);
+            let ancestor = Tile.parentInfo(Tile.parentInfo(tile));
+            let descendants = pyramid.getDescendants(ancestor);
+
             assert.equal(descendants.length, 1);
         });
 

--- a/test/tile_pyramid.js
+++ b/test/tile_pyramid.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 let assert = chai.assert;
 import TilePyramid from '../src/tile_pyramid';
-import Tile from '../src/tile';
+import {TileID} from '../src/tile_id';
 
 describe('TilePyramid', function() {
 
@@ -22,12 +22,12 @@ describe('TilePyramid', function() {
             };
 
             tile = {
-                coords: Tile.coord(coords),
+                coords: TileID.coord(coords),
                 style_zoom,
                 source,
                 loaded: true
             };
-            tile.key = Tile.key(tile.coords, source, style_zoom);
+            tile.key = TileID.key(tile.coords, source, style_zoom);
         });
 
         it('creates one entry per zoom', () => {
@@ -44,11 +44,11 @@ describe('TilePyramid', function() {
 
         it('creates entries for overzoomed tiles', () => {
             tile = Object.assign({}, tile);
-            tile.coords = Tile.coordinateAtZoom(coords, 18);
+            tile.coords = TileID.coordAtZoom(coords, 18);
             tile.style_zoom = 20;
             pyramid.addTile(tile);
 
-            assert.isNotNull(pyramid.tiles[Tile.key(tile.coords, source, tile.style_zoom)]);
+            assert.isNotNull(pyramid.tiles[TileID.key(tile.coords, source, tile.style_zoom)]);
         });
 
         it('removes all entries for single tile', () => {
@@ -67,7 +67,7 @@ describe('TilePyramid', function() {
 
         it('gets tile descendant', () => {
             pyramid.addTile(tile);
-            let ancestor = Tile.parentInfo(Tile.parentInfo(tile));
+            let ancestor = TileID.parent(TileID.parent(tile));
             let descendants = pyramid.getDescendants(ancestor);
 
             assert.equal(descendants.length, 1);

--- a/test/tile_spec.js
+++ b/test/tile_spec.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 let assert = chai.assert;
-import Tile from '../src/tile';
+import {TileID} from '../src/tile_id';
 
 describe('Tile', function() {
 
@@ -9,7 +9,7 @@ describe('Tile', function() {
     describe('overzooming', () => {
 
         it('does NOT overzoom a coordinate at the max zoom', () => {
-            let coords2 = Tile.coordinateWithMaxZoom(coords, coords.z);
+            let coords2 = TileID.coordWithMaxZoom(coords, coords.z);
 
             assert.deepEqual(coords2.x, coords.x);
             assert.deepEqual(coords2.y, coords.y);
@@ -17,7 +17,7 @@ describe('Tile', function() {
         });
 
         it('does NOT overzoom a coordinate below the max zoom', () => {
-            let coords2 = Tile.coordinateWithMaxZoom(coords, coords.z + 1);
+            let coords2 = TileID.coordWithMaxZoom(coords, coords.z + 1);
 
             assert.deepEqual(coords2.x, coords.x);
             assert.deepEqual(coords2.y, coords.y);
@@ -28,7 +28,7 @@ describe('Tile', function() {
             let unzoomed = { x: Math.floor(coords.x*2), y: Math.floor(coords.y*2), z: coords.z + 1 };
             let overzoomed = { x: Math.floor(coords.x/4), y: Math.floor(coords.y/4), z: coords.z - 2 };
 
-            let coords2 = Tile.coordinateWithMaxZoom(unzoomed, coords.z - 2);
+            let coords2 = TileID.coordWithMaxZoom(unzoomed, coords.z - 2);
 
             assert.deepEqual(coords2.x, overzoomed.x);
             assert.deepEqual(coords2.y, overzoomed.y);


### PR DESCRIPTION
This PR adds an `overzoom` parameter to data source specifications, to allow manual adjustment of the internal `zoom_bias` property.

In circumstances when the default tiles are either too large or detailed for the current application, this parameter allows the user to request lower zooms for each zoom level, reducing tile size and visual detail.

Examples:

```yaml
sources:
  tilezen:
    type: TopoJSON
    url: https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.topojson
    tile_size: 512
    overzoom: 3
    url_params:
        api_key: global.api_key
```

```yaml
sources:
  stamen:
    type: Raster
    url: http://a.tile.stamen.com/terrain-background/{z}/{x}/{y}.jpg
    overzoom: 2
```