### PR TITLE
Fix repeat culling on main thread for non-collision labels

### DIFF
--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -120,6 +120,12 @@ export default Collision = {
                                 object.linked.label.breach = true;
                             }
 
+                            // Similarly for labels that need main thread repeat culling, keep linked labels in sync
+                            if (object.label.may_repeat_across_tiles || object.linked.label.may_repeat_across_tiles) {
+                                object.label.may_repeat_across_tiles = true;
+                                object.linked.label.may_repeat_across_tiles = true;
+                            }
+
                             labels[style].push(object);
                             this.place(object, tile, state);
                             this.place(object.linked, tile, state);

--- a/src/labels/label.js
+++ b/src/labels/label.js
@@ -2,6 +2,7 @@ import PointAnchor from './point_anchor';
 import {boxIntersectsList} from './intersect';
 import Utils from '../utils/utils';
 import OBB from '../utils/obb';
+import Geo from '../geo';
 // import log from '../utils/log';
 
 export default class Label {
@@ -32,6 +33,7 @@ export default class Label {
             size: this.size,
             offset: this.offset,
             breach: this.breach,
+            may_repeat_across_tiles: this.may_repeat_across_tiles,
             layout: textLayoutToJSON(this.layout)
         };
     }
@@ -85,6 +87,22 @@ export default class Label {
         }
 
         return true;
+    }
+
+    // some labels need further repeat culling checks on the main thread
+    // checks whether the label is within its repeat distance of the tile boundaries
+    mayRepeatAcrossTiles () {
+        if (this.layout.collide) {
+            return true; // additional collision pass will already apply, so skip further distance checks
+        }
+
+        const dist = this.layout.repeat_distance;
+        if (dist === 0) {
+            return false;
+        }
+
+        return (Math.abs(this.position[0]) < dist ||  Math.abs(this.position[0] - Geo.tile_scale) < dist) ||
+               (Math.abs(this.position[1]) < dist ||  Math.abs(-(this.position[1] - Geo.tile_scale)) < dist);
     }
 
     // Whether the label should be discarded

--- a/src/labels/label_line.js
+++ b/src/labels/label_line.js
@@ -72,6 +72,7 @@ export class LabelLineBase {
             offset: this.offset,
             angle: this.angle,
             breach: this.breach,
+            may_repeat_across_tiles: this.may_repeat_across_tiles,
             layout: textLayoutToJSON(this.layout)
         };
     }
@@ -334,8 +335,13 @@ export class LabelLineStraight extends LabelLineBase {
 
         this.obbs.push(obb);
         this.aabbs.push(aabb);
+
         if (this.inTileBounds) {
             this.breach = !this.inTileBounds();
+        }
+
+        if (this.mayRepeatAcrossTiles) {
+            this.may_repeat_across_tiles = this.mayRepeatAcrossTiles();
         }
     }
 }
@@ -365,6 +371,7 @@ class LabelLineCurved extends LabelLineBase {
             obbs: this.obbs.map(o => o.toJSON()),
             position: this.position,
             breach: this.breach,
+            may_repeat_across_tiles: this.may_repeat_across_tiles,
             layout: textLayoutToJSON(this.layout)
         };
     }

--- a/src/labels/label_point.js
+++ b/src/labels/label_point.js
@@ -1,6 +1,5 @@
 import Label from './label';
 import PointAnchor from './point_anchor';
-import Geo from '../geo';
 import OBB from '../utils/obb';
 import StyleParser from '../styles/style_parser';
 
@@ -63,41 +62,14 @@ export default class LabelPoint extends Label {
 
         this.obb = new OBB(p[0], p[1], 0, width, height);
         this.aabb = this.obb.getExtent();
+
         if (this.inTileBounds) {
             this.breach = !this.inTileBounds();
         }
-    }
 
-    // Try to move the label into the tile bounds
-    // Returns true if label was moved into tile, false if it couldn't be moved
-    moveIntoTile () {
-        let updated = false;
-
-        if (this.aabb[0] < 0) {
-            this.position[0] += -this.aabb[0];
-            updated = true;
+        if (this.mayRepeatAcrossTiles) {
+            this.may_repeat_across_tiles = this.mayRepeatAcrossTiles();
         }
-
-        if (this.aabb[2] >= Geo.tile_scale) {
-            this.position[0] -= this.aabb[2] - Geo.tile_scale + 1;
-            updated = true;
-        }
-
-        if (this.aabb[3] > 0) {
-            this.position[1] -= this.aabb[3];
-            updated = true;
-        }
-
-        if (this.aabb[1] <= -Geo.tile_scale) {
-            this.position[1] -= this.aabb[1] + Geo.tile_scale - 1;
-            updated = true;
-        }
-
-        if (updated) {
-            this.updateBBoxes();
-        }
-
-        return updated;
     }
 
     discard (bboxes, exclude = null) {

--- a/src/labels/main_pass.js
+++ b/src/labels/main_pass.js
@@ -156,7 +156,7 @@ export default function mainThreadLabelCollisionPass (tiles, view_zoom, hide_bre
 }
 
 // Generic discard function for labels, does simple occlusion with one or more bounding boxes
-// (no additional logic to try alternate anchors or other layour options, etc.)
+// (no additional logic to try alternate anchors or other layout options, etc.)
 function discard (bboxes, exclude = null) {
     if (this.obb) { // single collision box
         return Label.prototype.occluded.call(this, bboxes, exclude);


### PR DESCRIPTION
This fixes repeat behavior across tiles for labels that don't have regular collision applied (e.g. `collide: false`). These labels had repeat culling applied *within* the tile, during the initial tile build on the worker thread, but did not have an additional repeat culling pass applied later on the main thread, to catch repeats from nearby tiles (labels with `collide: true` *did* already have this additional check; `collide: false` labels skip part of the collision pipeline for speed, and were inadvertently missing this piece).

This is solved with an additional flag that tracks whether the label is less than its repeat distance away from the tile edge. If so, it may need to be culled with labels from nearby tiles; if not, it's far enough away to not be affected by them.

Here's an example showing labels with a repeat distance of `50px`. Note the extra labels that are too close one another, which are now removed. For dense point sets, this could also cause an artifact that showed a "ghost" tile edge, where points were noticeable denser.

![webp net-gifmaker](https://user-images.githubusercontent.com/16733/50406111-07cd3300-0774-11e9-95ed-3aec67b47a5f.gif)

This branch also removes the deprecated `moveIntoTile()` function.