### PR TITLE
Fix label default repeat groups

### DIFF
--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -419,9 +419,6 @@ Object.assign(Points, {
 
         // Repeat rules - no repeat limitation for points by default
         draw.repeat_distance = StyleParser.createPropertyCache(draw.repeat_distance, StyleParser.parseNumber);
-        if (draw.repeat_group == null) {
-            draw.repeat_group = draw.layers.join('-');
-        }
 
         // Placement strategies
         draw.placement = PLACEMENT[draw.placement && draw.placement.toUpperCase()];
@@ -494,7 +491,9 @@ Object.assign(Points, {
                 layout.repeat_group = draw.repeat_group(context); // dynamic repeat group
             }
             else {
-                layout.repeat_group = draw.repeat_group; // pre-computed repeat group
+                // default to top-level layer name
+                // (e.g. all labels under `roads` layer, including sub-layers, are in one repeat group)
+                layout.repeat_group = draw.repeat_group || context.layer;
             }
         }
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -304,6 +304,12 @@ export const TextLabels = {
             StyleParser.parsePositiveNumber
         );
 
+        // Repeat group - if not defined, use layer names
+        // (but only if available - will be null for text attached to a point, and will inherit point's repeat group)
+        if (draw.repeat_group == null && draw.layers != null) {
+            draw.repeat_group = draw.layers.join('-');
+        }
+
         return draw;
     },
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -304,12 +304,6 @@ export const TextLabels = {
             StyleParser.parsePositiveNumber
         );
 
-        // Repeat group - if not defined, use layer names
-        // (but only if available - will be null for text attached to a point, and will inherit point's repeat group)
-        if (draw.repeat_group == null && draw.layers != null) {
-            draw.repeat_group = draw.layers.join('-');
-        }
-
         return draw;
     },
 


### PR DESCRIPTION
This fixes an issue with label repeat group logic. The intended behavior is for labels to apply repeat rules **within their unique scene layer group**. For example, labels for a major and minor road with the same name *will* be allowed to repeat near each other. This was intended to catch uncommon but still existent cases where labels of different feature classes are desirable to show.

However, now that the bug is fixed, I notice that there are some suboptimal cases in Mapzen styles where extra labels are being shown nearby to each other and a bit crowded -- often 2 but sometimes even 3 -- because they are different road types, including ramps, etc. See the extra Market St and Park Row labels below:

![sf16](https://user-images.githubusercontent.com/16733/50407884-37406780-0795-11e9-993a-d2efb6473b14.gif)
![sf15](https://user-images.githubusercontent.com/16733/50407885-39a2c180-0795-11e9-9752-90fc746b7863.gif)
![nyc15](https://user-images.githubusercontent.com/16733/50407886-3b6c8500-0795-11e9-98bd-a0a5dc8b3ede.gif)

This can be addressed in the style by putting all of the road labels into one `repeat_group`, or at least into fewer, to consolidate them. That's what I've done in the default demo [here as an example](https://github.com/tangrams/tangram/compare/line-label-repeats?expand=1#diff-7f549883b996e161107e531e5a5db1cb).

This leads me to wonder if we should consider changing the default instead. A couple proposals:

- Use a global namespace for `repeat_group` by default (this is what the bug was doing!)
- Use only the top-level scene layer name instead (e.g. `roads`, instead of getting as granular as each sub-layer). This would still allow cases like roads and parks with the same name to repeat.

In either case, the default could still be overridden with a custom `repeat_group`.

@nvkelso please review the above and give your thoughts on restoring the original behavior vs. using a new default.