### PR TITLE
Ensure static GL attributes are enabled outside VAOs

### DIFF
--- a/src/gl/vao.js
+++ b/src/gl/vao.js
@@ -36,7 +36,7 @@ export default {
             ext.bindVertexArrayOES(vao._vao);
         }
 
-        vao.setup(true);
+        vao.setup();
 
         return vao;
     },
@@ -65,7 +65,7 @@ export default {
                 this.setCurrentBinding(gl, vao);
             }
             else {
-                vao.setup(false);
+                vao.setup();
             }
         }
         else {

--- a/src/gl/vbo_mesh.js
+++ b/src/gl/vbo_mesh.js
@@ -97,14 +97,16 @@ export default class VBOMesh  {
             VertexArrayObject.bind(this.gl, vao);
         }
         else {
-            this.vaos[program.id] = VertexArrayObject.create(this.gl, (force) => {
+            this.vaos[program.id] = VertexArrayObject.create(this.gl, () => {
                 this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertex_buffer);
                 if (this.toggle_element_array) {
                     this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, this.element_buffer);
                 }
-                this.vertex_layout.enable(this.gl, program, force);
+                this.vertex_layout.enableDynamicAttributes(this.gl, program);
             });
         }
+
+        this.vertex_layout.enableStaticAttributes(this.gl, program);
     }
 
     // Upload buffer data to GPU

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -24,17 +24,11 @@ attribute vec4 a_color;
 
 // Optional dynamic line extrusion
 #ifdef TANGRAM_EXTRUDE_LINES
-    // xy: extrusion direction in xy plane
-    // z:  half-width of line (amount to extrude)
-    // w:  scaling factor for interpolating width between zooms
-    attribute vec2 a_extrude;
-    // xy: direction of line, for getting perpendicular offset
-    attribute vec2 a_offset;
-    // x: zoom scaling factor for line width
-    // y: zoom scaling factor for line offset
-    attribute vec2 a_scaling;
+    attribute vec2 a_extrude; // extrusion direction in xy plane
+    attribute vec2 a_offset;  // offset direction in xy plane
+    attribute vec2 a_scaling; // x: zoom scaling factor for line width, y: zoom scaling factor for line offset
 
-    uniform float u_v_scale_adjust;
+    uniform float u_v_scale_adjust; // scales texture UVs for line dash patterns w/fractional pixel width
 #endif
 
 varying vec4 v_position;


### PR DESCRIPTION
Several features make use of static GL vertex attributes, e.g. set with `vertexAttrib4fv()` etc. methods, unlike dynamic per-vertex "array" attributes set with `enableVertexAttribArray()` and `vertexAttribPointer()` methods).

These fixed vertex attribute calls were being made along with the rest of the Vertex Array Object initialization. However, it turns out that this state is NOT part of the VAO state. From the [OpenGL VAO docs](https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values):

> A vertex shader can read an attribute that is not currently enabled (via glEnableVertexAttribArray). 
  The value that it gets is defined by special context state, which is *not* part of the VAO.

This discrepancy likely hasn't been frequently observed because we have only used static attribute values of zero -- perhaps while the spec indicates the values are undefined, most implementations set them to zero.

However, with the upcoming addition of a static attribute with a non-zero value (separate branch), this bug (with the attribute flipping between different values, unexpectedly) was observed in Chrome (though not in Firefox or Safari; perhaps they store the fixed attribute value as part of the VAO even if it's not to spec?).

And, to confirm the validity of the fix, it does appear to resolve an intermittent issue we had seen with line offsets (which make use of static attributes) in Edge on Win10. 
