### PR TITLE
Optimize attribute packing to lower GPU memory usage

### DIFF
--- a/src/gl/vertex_layout.js
+++ b/src/gl/vertex_layout.js
@@ -8,8 +8,8 @@ export default class VertexLayout {
     // ex: { name: 'position', size: 3, type: gl.FLOAT, normalized: false }
     constructor (attribs) {
         this.attribs = attribs; // array of attributes, specified as standard GL attrib options
-        this.dynamic_attribs = this.attribs.filter(x => !x.static); // attributes with per-vertex values, used to build VBOs
-        this.static_attribs = this.attribs.filter(x => x.static); // attributes with fixed values
+        this.dynamic_attribs = this.attribs.filter(x => x.static == null); // attributes with per-vertex values, used to build VBOs
+        this.static_attribs = this.attribs.filter(x => x.static != null); // attributes with fixed values
         this.components = [];   // list of type and offset info about each attribute component
         this.index = {};        // JS buffer index of each attribute component, e.g. this.index.position
         this.offset = {};       // VBO buffer byte offset of each attribute component, e.g. this.offset.color

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -173,12 +173,11 @@ export var Style = {
     },
 
     vertexLayoutForMeshVariant (/*variant*/) {
-        return this.vertex_layout;
+        // styles must implement
     },
 
-    default_mesh_variant: { key: 0, order: 0 },
     meshVariantTypeForDraw (/*draw*/) {
-        return this.default_mesh_variant;
+        // styles must implement
     },
 
     addFeature (feature, draw, context) {
@@ -196,7 +195,7 @@ export var Style = {
             return; // skip feature
         }
 
-        if (this.buildGeometry(feature.geometry, style, /*mesh,*/ context) > 0) {
+        if (this.buildGeometry(feature.geometry, style, context) > 0) {
             feature.generation = this.generation; // track scene generation that feature was rendered for
         }
     },

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -19,20 +19,6 @@ Object.assign(TextStyle, {
     init(options = {}) {
         Style.init.call(this, options);
 
-        var attribs = [
-            { name: 'a_position', size: 4, type: gl.SHORT, normalized: false },
-            { name: 'a_shape', size: 4, type: gl.SHORT, normalized: false },
-            { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true },
-            { name: 'a_offset', size: 2, type: gl.SHORT, normalized: false },
-            { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
-            { name: 'a_angles', size: 4, type: gl.SHORT, normalized: false },
-            { name: 'a_offsets', size: 4, type: gl.UNSIGNED_SHORT, normalized: false },
-            { name: 'a_pre_angles', size: 4, type: gl.BYTE, normalized: false },
-            { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true }
-        ];
-
-        this.vertex_layout = new VertexLayout(attribs);
-
         // Shader defines
         this.setupDefines();
 
@@ -261,8 +247,30 @@ Object.assign(TextStyle, {
             }
         }
         return labels;
-    }
+    },
 
+    // Override
+    // Create or return vertex layout
+    vertexLayoutForMeshVariant (variant) {
+        if (this.vertex_layout == null) {
+            // TODO: could make selection, offset, and curved label attribs optional, but may not be worth it
+            // since text points generally don't consume much memory anyway
+            const attribs = [
+                { name: 'a_position', size: 4, type: gl.SHORT, normalized: false },
+                { name: 'a_shape', size: 4, type: gl.SHORT, normalized: false },
+                { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true },
+                { name: 'a_offset', size: 2, type: gl.SHORT, normalized: false },
+                { name: 'a_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
+                { name: 'a_angles', size: 4, type: gl.SHORT, normalized: false },
+                { name: 'a_offsets', size: 4, type: gl.UNSIGNED_SHORT, normalized: false },
+                { name: 'a_pre_angles', size: 4, type: gl.BYTE, normalized: false },
+                { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true },
+            ];
+
+            this.vertex_layout = new VertexLayout(attribs);
+        }
+        return this.vertex_layout;
+    },
 });
 
 TextStyle.texture_id = 0; // namespaces per-tile label textures


### PR DESCRIPTION
Improve GPU memory usage for `polygons` and `lines` styles with some vertex attribute VBO re-arrangement.

- For `polygons`:
  - Features that aren't extruded don't need per-vertex surface normals, because they're always flat and facing up. We can make the `a_normal` attribute have a static value of `[0, 0, 1]` in these cases. Extruded features like buildings keep the full per-vertex `a_normal` in the VBO.
- For `lines`:
  - This one is a bit trickier. Both the z position of the feature (e.g. the `z` parameter in a `draw` block, which moves the entire line up and down in space) and line `offset` are optional. 
  - While the `a_offset` attribute (different from the line's `a_extrude`, which diverges from the line normal at caps and joins) was already an optional attribute with a static value of `[0, 0]`, the offset scaling factor (used to interpolate the offset between zooms) always had space allocated as the second element of the `a_scaling` attribute (the first element being the line's width scaling factor). Width scaling is required for all lines, but offset scaling only for few.
  - Therefore, to better organize attributes according to their required/optional status:
    - Move the required width scaling factor into `a_position.z` (a required `vec4`).
    - Move the optional style z and offset scaling factor into a new `a_z_and_offset_scale` attribute (an optional `vec2`). The parameters are grouped into one attribute because they are both 2-byte `SHORT` values, and attributes must be aligned on 4-byte boundaries.
    - The previous `a_scaling` `vec2` attribute is removed.

Reviewing Bubble Wrap and the Tangram demo style at a variety of zooms and locations, these changes typically **reduce geometry/GPU memory usage by 15-17%**.