### PR TITLE
Namespace built-in shader defines

### DIFF
--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -47,7 +47,7 @@ varying float v_alpha_factor;
     varying float v_label_hidden;
 #endif
 
-#define PI 3.14159265359
+#define TANGRAM_PI 3.14159265359
 #define TANGRAM_NORMAL vec3(0., 0., 1.)
 
 #pragma tangram: camera
@@ -124,8 +124,8 @@ void main() {
     #ifdef TANGRAM_CURVED_LABEL
         //TODO: potential bug? null is passed in for non-curved labels, otherwise the first offset will be 0
         if (a_offsets[0] != 0.){
-            vec4 angles_scaled = (PI / 16384.) * a_angles;
-            vec4 pre_angles_scaled = (PI / 128.) * a_pre_angles;
+            vec4 angles_scaled = (TANGRAM_PI / 16384.) * a_angles;
+            vec4 pre_angles_scaled = (TANGRAM_PI / 128.) * a_pre_angles;
             vec4 offsets_scaled = (1. / 64.) * a_offsets;
 
             float pre_angle = mix4linear(pre_angles_scaled[0], pre_angles_scaled[1], pre_angles_scaled[2], pre_angles_scaled[3], zoom);

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -51,7 +51,7 @@ varying vec4 v_world_position;
     varying vec4 v_lighting;
 #endif
 
-#define UNPACK_SCALING(x) (x / 1024.)
+#define TANGRAM_UNPACK_SCALING(x) (x / 1024.)
 
 #pragma tangram: camera
 #pragma tangram: material
@@ -93,11 +93,11 @@ void main() {
 
         // Interpolate line width between zooms
         float mdz = (dz - 0.5) * 2.; // zoom from mid-point
-        extrude -= extrude * UNPACK_SCALING(a_scaling.x) * mdz;
+        extrude -= extrude * TANGRAM_UNPACK_SCALING(a_scaling.x) * mdz;
 
         // Interpolate line offset between zooms
         // Scales from the larger value to the smaller one
-        float dwdz = UNPACK_SCALING(a_scaling.y);
+        float dwdz = TANGRAM_UNPACK_SCALING(a_scaling.y);
         float sdwdz = sign(step(0., dwdz) - 0.5); // sign indicates "direction" of scaling
         offset -= offset * abs(dwdz) * ((1.-step(0., sdwdz)) - (dz * -sdwdz)); // scale "up" or "down"
 


### PR DESCRIPTION
@hanbyul-here found that one of @patriciogonzalezvivo's old maps -- https://github.com/tangrams/WeatherOverTime -- was not working anymore due to a shader compilation error showing conflicting `#define PI` definitions.

It turns out a `#define PI` was added to Tangram's `points` vertex shader back when curved label support was added: https://github.com/tangrams/tangram/pull/484/files#diff-5c9ade004b24e8b556a6b8b8e9d3096fR24

To avoid these conflicts, we should namespace built-in shader defines with `TANGRAM_`. Most already do this, but this PR catches two that didn't.
