### PR TITLE
Add URL template support for @2x tiles

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -431,7 +431,12 @@ export class NetworkTileSource extends NetworkSource {
             coords.y = Math.pow(2, coords.z) - 1 - coords.y; // optionally flip tile coords for TMS
         }
 
-        let url = url_template.replace('{x}', coords.x).replace('{y}', coords.y).replace('{z}', coords.z);
+        // tile URL template replacement
+        let url = url_template
+            .replace('{x}', coords.x)
+            .replace('{y}', coords.y)
+            .replace('{z}', coords.z)
+            .replace('{r}', Utils.device_pixel_ratio > 1 ? '@2x' : ''); // retina / high-dpi screens
 
         if (this.url_subdomains != null) {
             url = url.replace('{s}', this.url_subdomains[this.next_url_subdomain]);

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -460,17 +460,21 @@ export class NetworkTileSource extends NetworkSource {
     // each entry serves as a threshold based on the current display density.
     getDensityModifier () {
         if (this.url_density_scales) {
+            // find the highest matching density
             const dpr = Utils.device_pixel_ratio;
-            const scale = this.url_density_scales
+            let scale = this.url_density_scales
                 .filter(s => dpr >= s)
-                .reverse()[0]; // find the highest matching density
+                .reverse()[0];
 
-            if (scale != null && scale > 1) {
+            // default to first scale if none matched
+            scale = (scale != null ? scale : this.url_density_scales[0]);
+
+            // scales higher than 1x use the `@` modifier (e.g. `@2x`)
+            if (scale > 1) {
                 return `@${scale}x`;
             }
         }
-        // For 1x (or less) displays, no URL modifier is used (following @2x URL convention)
-        return '';
+        return ''; // for 1x (or less) displays, no URL modifier is used (following @2x URL convention)
     }
 
     // Checks for the x/y/z tile pattern in URL template

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -6,8 +6,6 @@ import Utils from '../utils/utils';
 import hashString from '../utils/hash';
 import log from '../utils/log';
 
-// TODO: support high-density `@2x`-style filenames for raster tiles and geo-referenced images
-
 export class RasterTileSource extends NetworkTileSource {
 
     constructor (source, sources) {


### PR DESCRIPTION
This adds support for `@2x`-style tile filenames, often used for high-density raster tiles. For this implementation I opted to follow the same, simple logic as Leaflet, which is:

A `{r}` URL template substitution option, which adds the string `@2x` for any device with a device pixel ratio > 1.

CartoDB basemap example:

```
sources:
    raster:
        type: Raster
        url: https://a.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png
```

- On a device with device pixel ratio <= 1: `https://a.basemaps.cartocdn.com/light_nolabels/14/4823/6163.png`
- On a device with device pixel ratio is > 1: `https://a.basemaps.cartocdn.com/light_nolabels/14/4823/6163@2x.png`

Note, while this syntax is traditionally used with raster tiles, this implementation also applies to vector tiles (which could conceivably be useful for loading higher resolution vectors on high-density displays, though there are no plans for this currently).

Since the `@2x` syntax is pretty specific, the next step here, which I intentionally left out of scope for this PR, would probably be to support a JS function that could be passed the relevant tile XYZ and device pixel ratio, and return a tile URL. 
