### PR TITLE
Fix `scene.updateConfig()` memory leak

### DIFF
--- a/src/gl/texture.js
+++ b/src/gl/texture.js
@@ -511,9 +511,11 @@ Texture.getInfo = function (name) {
 Texture.syncTexturesToWorker = function (names) {
     return WorkerBroker.postMessage('Texture.getInfo', names).
         then(textures => {
-            textures.forEach(tex => {
-                Texture.textures[tex.name] = tex;
-            });
+            if (textures) {
+                textures
+                    .filter(x => x) // remove nulls
+                    .forEach(t => Texture.textures[t.name] = t);
+            }
             return Texture.textures;
         });
 };

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -1052,13 +1052,9 @@ export default class Scene {
         }
 
         this.prev_textures.forEach(t => {
-            if (!this.config.textures[t]) {
-                if (!Texture.textures[t]) {
-                    // debugger;
-                }
-                else {
-                    Texture.textures[t].destroy();
-                }
+            // free textures that aren't in the new scene, but are still in the global texture set
+            if (!this.config.textures[t] && Texture.textures[t]) {
+                Texture.textures[t].destroy();
             }
         });
         this.prev_textures = null;

--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -389,7 +389,12 @@ Object.assign(Lines, {
 
                     if (variant.dash_key && Lines.dash_textures[variant.dash_key] == null) {
                         Lines.dash_textures[variant.dash_key] = true;
-                        WorkerBroker.postMessage(this.main_thread_target+'.getDashTexture', variant.dash);
+                        try {
+                            await WorkerBroker.postMessage(this.main_thread_target+'.getDashTexture', variant.dash);
+                        }
+                        catch (e) {
+                            log('trace', `${this.name}: line dash texture create failed because style no longer on main thread`);
+                        }
                     }
 
                     if (Texture.textures[variant.texture] == null) {

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -93,7 +93,7 @@ export var Style = {
         this.generation = generation;
 
         // Provide a hook for this object to be called from worker threads
-        this.main_thread_target = ['Style', this.name, this.generation].join('/');
+        this.main_thread_target = ['Style', this.name, this.generation].join('_');
         if (Thread.is_main) {
             WorkerBroker.addTarget(this.main_thread_target, this);
         }

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -498,6 +498,10 @@ export var Style = {
         if (this.shaders.blocks) {
             this.shaders.blocks[key] = null;
         }
+
+        if (this.shaders.block_scopes) {
+            this.shaders.block_scopes[key] = null;
+        }
     },
 
     replaceShaderBlock (key, block, scope = null) {

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -60,6 +60,9 @@ export class StyleManager {
 
         // Alpha discard threshold (substitute for alpha blending)
         ShaderProgram.defines.TANGRAM_ALPHA_TEST = 0.5;
+
+        // Reset dash texture cache
+        Lines.dash_textures = {};
     }
 
     // Destroy all styles for a given GL context

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -2,6 +2,7 @@
 import ShaderProgram from '../gl/shader_program';
 import mergeObjects from '../utils/merge';
 import Geo from '../utils/geo';
+import WorkerBroker from '../utils/worker_broker';
 import log from '../utils/log';
 
 import {Polygons} from './polygons/polygons';
@@ -294,6 +295,12 @@ export class StyleManager {
 
     // Called to create and initialize styles
     build (styles) {
+        // Un-register existing styles from cross-thread communication
+        if (this.styles) {
+            Object.values(this.styles)
+                .forEach(s => WorkerBroker.removeTarget(s.main_thread_target));
+        }
+
         // Sort styles by dependency, then build them
         let style_deps = Object.keys(styles).sort(
             (a, b) => this.inheritanceDepth(a, styles) - this.inheritanceDepth(b, styles)

--- a/src/tile/tile_manager.js
+++ b/src/tile/tile_manager.js
@@ -39,6 +39,7 @@ export default class TileManager {
         this.queued_coords = [];
         this.scene = null;
         this.view = null;
+        WorkerBroker.removeTarget(this.main_thread_target);
     }
 
     keepTile(tile) {

--- a/src/utils/worker_broker.js
+++ b/src/utils/worker_broker.js
@@ -97,13 +97,15 @@ var message_id = 0;
 var messages = {};
 
 // Register an object to receive calls from other thread
-var targets = {};
+WorkerBroker.targets = {};
 WorkerBroker.addTarget = function (name, target) {
-    targets[name] = target;
+    WorkerBroker.targets[name] = target;
 };
 
 WorkerBroker.removeTarget = function (name) {
-    delete targets[name];
+    if (name) {
+        delete WorkerBroker.targets[name];
+    }
 };
 
 // Given a dot-notation-style method name, e.g. 'Object.object.method',
@@ -115,7 +117,7 @@ function findTarget (method) {
         method = chain.pop();
     }
 
-    var target = targets;
+    var target = WorkerBroker.targets;
 
     for (let m=0; m < chain.length; m++) {
         if (target[chain[m]]) {

--- a/src/utils/worker_broker.js
+++ b/src/utils/worker_broker.js
@@ -221,25 +221,25 @@ function setupMainThread () {
             // Unique id for this message & return call to main thread
             else if (data.type === 'worker_send' && id != null) {
                 // Call the requested method and save the return value
-                var [method_name, target] = findTarget(data.method);
-                if (!target) {
-                    throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because no object with that name is registered on main thread`);
-                }
-
-                var method = (typeof target[method_name] === 'function') && target[method_name];
-                if (!method) {
-                    throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because object has no method with that name`);
-                }
-
-                var result, error;
+                let result, error, target, method_name, method;
                 try {
+                    [method_name, target] = findTarget(data.method);
+                    if (!target) {
+                        throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because no object with that name is registered on main thread`);
+                    }
+
+                    method = (typeof target[method_name] === 'function') && target[method_name];
+                    if (!method) {
+                        throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because object has no method with that name`);
+                    }
+
                     result = method.apply(target, data.message);
                 }
                 catch(e) {
                     // Thrown errors will be passed back (in string form) to worker
                     error = e;
-                }
 
+                }
                 // Send return value to worker
                 let payload, transferables = [];
 
@@ -379,19 +379,19 @@ function setupWorkerThread () {
         // Unique id for this message & return call to main thread
         else if (data.type === 'main_send' && id != null) {
             // Call the requested worker method and save the return value
-            var [method_name, target] = findTarget(data.method);
-            if (!target) {
-                throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because no object with that name is registered on main thread`);
-            }
-
-            var method = (typeof target[method_name] === 'function') && target[method_name];
-
-            if (!method) {
-                throw Error(`Worker broker could not dispatch message type ${data.method} because worker has no method with that name`);
-            }
-
-            var result, error;
+            let result, error, target, method_name, method;
             try {
+                [method_name, target] = findTarget(data.method);
+                if (!target) {
+                    throw Error(`Worker broker could not dispatch message type ${data.method} on target ${data.target} because no object with that name is registered on main thread`);
+                }
+
+                method = (typeof target[method_name] === 'function') && target[method_name];
+
+                if (!method) {
+                    throw Error(`Worker broker could not dispatch message type ${data.method} because worker has no method with that name`);
+                }
+
                 result = method.apply(target, data.message);
             }
             catch(e) {


### PR DESCRIPTION
Fix memory leak when `scene.updateConfig()` is called, due to dangling style references in `WorkerBroker` (outdated style worker broker targets were not removed when new styles were built).

See discussion in https://github.com/tangrams/tangram/issues/696. Thanks to @rihteri!
