### PR TITLE
Fix raster sampling at explicit pixel locations with mixed vector/raster tile sizes

### DIFF
--- a/src/styles/raster/raster_globals.glsl
+++ b/src/styles/raster/raster_globals.glsl
@@ -33,7 +33,7 @@ uniform bool u_raster_mask_alpha;
 
 // Samples a raster tile texture for a given pixel
 #define sampleRasterAtPixel(raster_index, pixel) \
-    (texture2D(u_rasters[raster_index], adjustRasterUV(raster_index, (pixel) / rasterPixelSize(raster_index))))
+    (texture2D(u_rasters[raster_index], (pixel) / rasterPixelSize(raster_index)))
 
 // Returns size of raster sampler in pixels
 #define rasterPixelSize(raster_index) \


### PR DESCRIPTION
In doing some raster tests, @meetar found that the built-in `sampleRasterAtPixel()` raster shader method was not working properly when using mixed tile sizes, for example a 256px vector tile source with an attached 512px raster tile source. While the default / more common `sampleRaster()` method (used in the default raster style implementation) was working properly in this scenario, the explicit pixel look-ups were scrambled, with incorrect UV offsets. An example of the correct vs. actual results:

![webp net-gifmaker 4](https://user-images.githubusercontent.com/16733/52083126-99e30b00-256c-11e9-87ec-26fc4d41471a.gif)

Digging in, it looks like the `sampleRasterAtPixel()` method was incorrectly applying a call to `adjustRasterUV()`, which is used to correctly offset tile UVs from smaller (e.g. 256px) tiles inside of a larger (e.g. 512px) raster tile texture. This adjustment is used in `currentRasterUV()`, which uses the tile's vertex positions. But it is incorrect to apply in the case of `sampleRasterAtPixel()`, where the final pixel location is already explicitly provided.

Removing this call fixes the problem. It appears this bug has always existed, but we have not previously caught it because we have never had a case where we are using `sampleRasterAtPixel()` with mixed tile size sources. `sampleRasterAtPixel()` is usually used to sample nearby pixels, such as for a kernel look-up. We have several such examples in https://github.com/tangrams/terrain-demos/, but these all operate on a single data source of terrain normal tiles. Mapzen styles such as Walkabout and Refill vector-masked raster tiles, but always of the same tile size.

To prevent a regression, I've added two Differ tests, for mixed vector/raster styles, with `sampleRaster()`, and `sampleRasterAtPixel()`:

https://github.com/tangrams/differ-tests/commit/e1a2e0e3d4c16ae6703e47ed5cf51366a1eabb57

![screen shot 2019-01-31 at 3 08 40 pm](https://user-images.githubusercontent.com/16733/52083634-fa267c80-256d-11e9-957c-f7a6e1b66028.png)

