### PR TITLE
Quadkey support for tile URL templates

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -456,7 +456,8 @@ export class NetworkTileSource extends NetworkSource {
             .replace('{x}', coords.x)
             .replace('{y}', coords.y)
             .replace('{z}', coords.z)
-            .replace('{r}', this.getDensityModifier()); // modify URL by display density (e.g. @2x)
+            .replace('{r}', this.getDensityModifier()) // modify URL by display density (e.g. @2x)
+            .replace('{q}', this.toQuadKey(coords)); // quadkey for tile coordinates
 
         if (this.url_subdomains != null) {
             url = url.replace('{s}', this.url_subdomains[this.next_url_subdomain]);
@@ -487,12 +488,24 @@ export class NetworkTileSource extends NetworkSource {
         return ''; // for 1x (or less) displays, no URL modifier is used (following @2x URL convention)
     }
 
+    toQuadKey ({ x, y, z }) {
+        let quadkey = '';
+        for (let i = z; i > 0; i--) {
+            let b = 0;
+            let mask = 1 << (i - 1);
+            if ((x & mask) !== 0) b++;
+            if ((y & mask) !== 0) b += 2;
+            quadkey += b.toString();
+        }
+        return quadkey;
+    }
+
     // Checks for the x/y/z tile pattern in URL template
     static urlHasTilePattern (url) {
-        return url &&
-            url.search('{x}') > -1 &&
-            url.search('{y}') > -1 &&
-            url.search('{z}') > -1;
+        return url && (
+            (url.search('{x}') > -1 && url.search('{y}') > -1 && url.search('{z}') > -1) ||
+            url.search('{q}') > -1
+        );
     }
 
 }


### PR DESCRIPTION
Some tile sources, such as Microsoft's aerial imagery and HERE's XYZ vector API, use the quadkey URL scheme (as an alternative to the x/y/z URL pattern), as described here: https://docs.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system

This PR adds support for this alternative, through the `{q}` URL token. For example, here is a mix of Microsoft aerial imagery, with Nextzen place labels atop:

```
sources:
    msft:
        type: Raster
        url: https://ecn.t3.tiles.virtualearth.net/tiles/a{q}.jpeg?g=587
    nextzen:
        type: MVT
        url: https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt
        tile_size: 512
        max_zoom: 16

layers:
    msft:
        data: { source: msft }
        draw:
            raster:
                order: 0

    places:
        data: { source: nextzen }
        draw:
            text:
                font:
                    family: Helvetica
                    size: 12px
                    fill: white
```

![tangram- 13 5000 47 6642 -122 3271_2019-02-12_19 52 59](https://user-images.githubusercontent.com/16733/52678490-d1a06a00-2eff-11e9-80c9-e7e117f2b4e8.png)



Data sources are now considered tiled if they have the `{q}` token in their URL, in addition to the existing `{x}`/`{y}`/`{z}` tokens (the URL template must have one of these schemes present... technically both would be replaced if present, though there is no known practical use for this).
