### PR TITLE
Data sources can define specific zoom levels at which tiles are loaded

### DIFF
--- a/demos/scene.yaml
+++ b/demos/scene.yaml
@@ -98,6 +98,7 @@ sources:
         url: https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.topojson
         tile_size: 512
         max_zoom: 16
+        # zooms: [0, 2, 4, 6, 8, 10, 12, 14, 16] # only load tiles every 2 zooms (overrides max_zoom)
         url_params:
             api_key: global.api_key
         # request_headers: # send custom headers with tile requests
@@ -140,6 +141,7 @@ sources:
     # counties:
     #     type: TopoJSON
     #     url: https://gist.githubusercontent.com/mbostock/4090846/raw/c899e3d4f3353924e495667c842f54a07090cfab/us.json
+    #     zooms: [0, 4, 8, 10]
 
 layers:
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import WorkerBroker from './utils/worker_broker';
 import Task from './utils/task';
 import {StyleManager} from './styles/style_manager';
 import StyleParser from './styles/style_parser';
+import {TileID} from './tile/tile_id';
 import Collision from './labels/collision';
 import FeatureSelection from './selection/selection';
 import TextCanvas from './styles/text/text_canvas';
@@ -47,6 +48,7 @@ const debug = {
     Task,
     StyleManager,
     StyleParser,
+    TileID,
     Collision,
     FeatureSelection,
     TextCanvas,

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -17,7 +17,6 @@ export class GeoJSONSource extends NetworkSource {
         super(source, sources);
         this.load_data = null;
         this.tile_indexes = {}; // geojson-vt tile indices, by layer name
-        this.max_zoom = Math.max(this.max_zoom || 0, 15); // TODO: max zoom < 15 causes artifacts/no-draw at 20, investigate
         this.setTileSize(512); // auto-tile to 512px tiles for fewer internal tiles
         this.pad_scale = 0; // we don't want padding on auto-tiled sources
     }

--- a/src/sources/raster.js
+++ b/src/sources/raster.js
@@ -81,7 +81,7 @@ export class RasterTileSource extends NetworkTileSource {
                 // do extra zoom adjustment and apply this raster source's max zoom
                 coords = TileID.normalizedCoord(tile.coords, {
                     zoom_bias: zdiff,
-                    max_zoom: this.max_zoom
+                    zooms: this.zooms
                 });
             }
             else {
@@ -95,7 +95,7 @@ export class RasterTileSource extends NetworkTileSource {
                 }
 
                 // no extra zoom adjustment needed, but still need to apply this raster source's max zoom
-                coords = TileID.coordWithMaxZoom(coords, this.max_zoom);
+                coords = TileID.coordForTileZooms(coords, this.zooms);
             }
         }
         return coords;

--- a/src/tile/tile_pyramid.js
+++ b/src/tile/tile_pyramid.js
@@ -6,6 +6,7 @@ export default class TilePyramid {
         this.tiles = {};
         this.max_proxy_descendant_depth = 6; // # of levels to search up/down for proxy tiles
         this.max_proxy_ancestor_depth = 7;
+        this.children_cache = {}; // cache for children of coordinates
     }
 
     addTile(tile) {
@@ -57,7 +58,6 @@ export default class TilePyramid {
     getAncestor (tile) {
         let level = 0;
         while (level < this.max_proxy_ancestor_depth) {
-            const last_z = tile.coords.z;
             tile = TileID.parent(tile);
             if (!tile) {
                 return;
@@ -69,9 +69,7 @@ export default class TilePyramid {
                 return this.tiles[tile.key].tile;
             }
 
-            if (tile.coords.z !== last_z) {
-                level++;
-            }
+            level++;
         }
     }
 
@@ -79,7 +77,7 @@ export default class TilePyramid {
     getDescendants (tile, level = 0) {
         let descendants = [];
         if (level < this.max_proxy_descendant_depth) {
-            let tiles = TileID.children(tile);
+            let tiles = TileID.children(tile, this.children_cache);
             if (!tiles) {
                 return;
             }
@@ -91,7 +89,7 @@ export default class TilePyramid {
                         descendants.push(this.tiles[t.key].tile);
                     }
                     else if (this.tiles[t.key].descendants > 0) { // didn't find any children, try next level
-                        descendants.push(...this.getDescendants(t, level + (t.coords.z !== tile.coords.z)));
+                        descendants.push(...this.getDescendants(t, level + 1));
                     }
                 }
             });

--- a/test/tile_pyramid.js
+++ b/test/tile_pyramid.js
@@ -17,8 +17,10 @@ describe('TilePyramid', function() {
 
             style_z = coords.z;
             source = {
+                id: 0,
                 name: 'test',
-                max_coord_zoom: 18
+                zooms: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+                zoom_bias: 0
             };
 
             tile = {

--- a/test/tile_spec.js
+++ b/test/tile_spec.js
@@ -9,7 +9,7 @@ describe('Tile', function() {
     describe('overzooming', () => {
 
         it('does NOT overzoom a coordinate at the max zoom', () => {
-            let coords2 = TileID.coordWithMaxZoom(coords, coords.z);
+            let coords2 = TileID.coordForTileZooms(coords, [0, 12, 17]);
 
             assert.deepEqual(coords2.x, coords.x);
             assert.deepEqual(coords2.y, coords.y);
@@ -17,7 +17,7 @@ describe('Tile', function() {
         });
 
         it('does NOT overzoom a coordinate below the max zoom', () => {
-            let coords2 = TileID.coordWithMaxZoom(coords, coords.z + 1);
+            let coords2 = TileID.coordForTileZooms(coords, [0, 12, 16, 17, 18]);
 
             assert.deepEqual(coords2.x, coords.x);
             assert.deepEqual(coords2.y, coords.y);
@@ -28,7 +28,7 @@ describe('Tile', function() {
             let unzoomed = { x: Math.floor(coords.x*2), y: Math.floor(coords.y*2), z: coords.z + 1 };
             let overzoomed = { x: Math.floor(coords.x/4), y: Math.floor(coords.y/4), z: coords.z - 2 };
 
-            let coords2 = TileID.coordWithMaxZoom(unzoomed, coords.z - 2);
+            let coords2 = TileID.coordForTileZooms(unzoomed, [0, 12, 15]);
 
             assert.deepEqual(coords2.x, overzoomed.x);
             assert.deepEqual(coords2.y, overzoomed.y);


### PR DESCRIPTION
Currently, tiled data sources request data at every map zoom level. There are some parameters that affect the mapping between the "view" zoom and the "tile" zoom (`tile_size`, `zoom_offset`), but these still trigger a new load at each zoom level.

There are some cases where it may be unnecessary or undesirable to load new tile data this frequently. This PR extends the syntax for data sources, with a new `zooms` parameter that can specify a list of zoom levels at which new data should be loaded.

For example, to only load new tile data at every other zoom level:

```
sources:
  tilezen:
    type: MVT
    url: ...
    zooms: [0, 2, 4, 6, 8, 10, 12, 14, 16] # only load tiles every 2 zooms
```

Or, an application with two logical levels -- such as a zoomed out and zoomed in view -- could define these explicitly, for example: `zooms: [4, 12]`.

For view zooms in between these defined tile zooms, the tile for the next lowest available zoom will be overzoomed; in this sense, this feature extends and allows for more control of our existing overzooming behavior. For example, if `zooms: [4, 8, 12, 16]`, when viewing the map at zoom 14, the zoom 12 tile will be overzoomed (note, this assumes 256px tiles).

**Default / Max / Min Zooms**

When `zooms` is undefined, the current behavior is used (tiles load at all zooms). If both `zooms` and `max_zoom` is present, the last zoom listed in `zooms` takes precedence, and overrides the `max_zoom` parameter. The `min_display_zoom` also automatically defaults to the first entry in the `zooms` list (e.g. if `zooms: [4, 8, 12, 16]`, then `min_display_zoom` defaults to 4).

**Other Zoom Adjustment Parameters**

The `tile_size` and `zoom_offset` parameters can be mixed with `zooms`, and continue to behave as they do currently, by lowering the potential tile zoom requested for a given view zoom. For example, with this combination:

```
zooms: [4, 8, 12, 16]
tile_size: 512
zoom_offset: 2
```

A given view zoom will look for a tile zoom that is **3 levels** lower (1 level for 512px tiles, plus 2 more for the `zoom_offset`). Thus at a view zoom of 12, the data source will look for the z9 tile, and then request/overzoom the z8 tile instead (the next available level defined in `zooms`). But at zoom 14, the data source will look for a z11 tile -- and will *also* use the z8 tile, since the requested level falls below the z12 thresholds in zooms, even though the map view zoom is above it; in this example, the z12 tile will not be requested until the view zoom is z15 (note, this is a somewhat extreme/contrived example for illustration).