### PR TITLE
Enable setting of `blend_order` at the `draw` level

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -529,7 +529,7 @@ export default class Scene {
         this.clearFrame();
 
         // Sort styles by blend order
-        let styles = this.tile_manager.getActiveStyles().
+        let styles = this.style_manager.getActiveStyles().
             map(s => this.styles[s]).
             filter(s => s). // guard against missing styles, such as while loading a new scene
             sort(Style.blendOrderSort);
@@ -1087,7 +1087,7 @@ export default class Scene {
         // Disable animation is scene flag requests it, otherwise enable animation if any animated styles are in view
         return (this.config.scene.animated === false ?
             false :
-            this.tile_manager.getActiveStyles().some(s => this.styles[s].animated));
+            this.style_manager.getActiveStyles().some(s => this.styles[s].animated));
     }
 
     // Get active camera - for public API

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -566,7 +566,7 @@ export default class Scene {
                     this.gl.stencilFunc(this.gl.EQUAL, this.gl.ZERO, 0xFF);
                     this.gl.stencilOp(this.gl.KEEP, this.gl.KEEP, this.gl.INCR);
                 }
-                else if (blend !== 'opaque') {
+                else if (blend !== 'opaque' && style.stencil_proxy_tiles === true) {
                     // Mask proxy tiles to with stencil buffer to avoid overlap/flicker from compounding alpha
                     // Find unique levels of proxy tiles to render for this style
                     const proxy_levels = this.tile_manager.getRenderableTiles()

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -70,6 +70,12 @@ Object.assign(Points, {
         this.collision_group_points = this.name+'-points';
         this.collision_group_text = this.name+'-text';
 
+        // Stenciling proxy tiles (to avoid compounding alpha artifacts) doesn't work well with
+        // points/text labels, which have pure transparent pixels that interfere with the stencil buffer,
+        // causing a "cut-out"/"x-ray" effect (preventing pixels that would usually be covered by proxy tiles
+        // underneath from being rendered).
+        this.stencil_proxy_tiles = false;
+
         this.reset();
     },
 

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -2,7 +2,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
-uniform float u_tile_proxy_depth;
+uniform float u_tile_proxy_order_offset;
 uniform bool u_tile_fade_in;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
@@ -172,7 +172,7 @@ void main() {
 
     #ifdef TANGRAM_LAYER_ORDER
         // +1 is to keep all layers including proxies > 0
-        applyLayerOrder(a_position.w + u_tile_proxy_depth + 1., position);
+        applyLayerOrder(a_position.w + u_tile_proxy_order_offset + 1., position);
     #endif
 
     // Apply pixel offset in screen-space

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -81,16 +81,18 @@ Object.assign(Polygons, {
     // Calculate and store mesh variant (unique by draw group but not feature)
     computeVariant (draw) {
         // Factors that determine a unique mesh rendering variant
-        let selection = (draw.interactive ? 1 : 0); // whether feature has interactivity
-        let normal = (draw.extrude != null ? 1 : 0); // whether feature has extrusion (need per-vertex normals)
-        let texcoords = (this.texcoords ? 1 : 0); // whether feature has texture UVs
-        let key = [selection, normal, texcoords].join('/');
+        const selection = (draw.interactive ? 1 : 0); // whether feature has interactivity
+        const normal = (draw.extrude != null ? 1 : 0); // whether feature has extrusion (need per-vertex normals)
+        const texcoords = (this.texcoords ? 1 : 0); // whether feature has texture UVs
+        const blend_order = this.getBlendOrderForDraw(draw);
+        const key = [selection, normal, texcoords, blend_order].join('/');
         draw.variant = key;
 
         if (Polygons.variants[key] == null) {
             Polygons.variants[key] = {
                 key,
-                order: 0,
+                blend_order,
+                mesh_order: 0,
                 selection,
                 normal,
                 texcoords

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -2,7 +2,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
-uniform float u_tile_proxy_depth;
+uniform float u_tile_proxy_order_offset;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -154,7 +154,7 @@ void main() {
     cameraProjection(position);
 
     // +1 is to keep all layers including proxies > 0
-    applyLayerOrder(a_position.w + u_tile_proxy_depth + 1., position);
+    applyLayerOrder(a_position.w + u_tile_proxy_order_offset + 1., position);
 
     gl_Position = position;
 }

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -34,6 +34,7 @@ export var Style = {
         this.feature_style = {};                    // style for feature currently being parsed, shared to lessen GC/memory thrash
         this.vertex_template = [];                  // shared single-vertex template, filled out by each style
         this.tile_data = {};
+        this.stencil_proxy_tiles = true;            // applied to proxy tiles w/non-opaque blend mode to avoid compounding alpha
 
         // Default world coords to wrap every 100,000 meters, can turn off by setting this to 'false'
         this.defines.TANGRAM_WORLD_POSITION_WRAP = 100000;

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -21,6 +21,7 @@ export class StyleManager {
         this.styles = {};
         this.base_styles = {};
         this.active_styles = [];
+        this.active_blend_orders = [];
 
         // Add built-in rendering styles
         this.register(Object.create(Polygons));
@@ -102,6 +103,33 @@ export class StyleManager {
             }, {})
         );
         return this.active_styles;
+    }
+
+    getActiveBlendOrders () {
+        return this.active_blend_orders;
+    }
+
+    updateActiveBlendOrders (tiles) {
+        const orders = [];
+        tiles.forEach(tile => {
+            Object.entries(tile.meshes)
+                .forEach(([style, style_meshes]) => { // for each tile's set of meshes, keyed by style name
+                    style_meshes.forEach(mesh => { // for each style's list of meshes
+                        // find entry for this mesh's blend order, insert if first entry
+                        const blend_order = mesh.variant.blend_order;
+                        let oi = orders.findIndex(x => x.blend_order === blend_order);
+                        oi = oi > -1 ? oi : orders.push({ blend_order, styles: [] }) - 1;
+
+                        // add style to list for this blend order
+                        if (orders[oi].styles.indexOf(style) === -1) {
+                            orders[oi].styles.push(style);
+                        }
+                    });
+                });
+        });
+
+        // sort ascending by blend order
+        this.active_blend_orders = orders.sort((a, b) => a.blend_order - b.blend_order);
     }
 
     mix (style, styles) {

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -20,6 +20,7 @@ export class StyleManager {
     constructor () {
         this.styles = {};
         this.base_styles = {};
+        this.active_styles = [];
 
         // Add built-in rendering styles
         this.register(Object.create(Polygons));
@@ -86,6 +87,21 @@ export class StyleManager {
     // Remove a style
     remove (name) {
         delete this.styles[name];
+    }
+
+    getActiveStyles () {
+        return this.active_styles;
+    }
+
+    // Get list of active styles based on a set of tiles
+    updateActiveStyles (tiles) {
+        this.active_styles = Object.keys(
+            tiles.reduce((active, tile) => {
+                Object.keys(tile.meshes).forEach(s => active[s] = true);
+                return active;
+            }, {})
+        );
+        return this.active_styles;
     }
 
     mix (style, styles) {

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -134,6 +134,7 @@ Object.assign(TextStyle, {
                     style.label_texture = textures[text_info.align[q.label.align].texture_id];
                 }
 
+                style.blend_order = q.draw.blend_order; // copy pre-computed blend order
                 Style.addFeature.call(this, q.feature, q.draw, q.context);
             });
         }
@@ -158,6 +159,7 @@ Object.assign(TextStyle, {
 
     // Sets up caching for draw properties
     _preprocess (draw) {
+        draw.blend_order = this.getBlendOrderForDraw(draw); // from draw block, or fall back on default style blend order
         return this.preprocessText(draw);
     },
 

--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -33,8 +33,8 @@ export default class Tile {
 
         this.visible = false;
         this.proxy_for = null;
-        this.proxy_depth = 0;
         this.proxied_as = null;
+        this.proxy_order_offset = 0;
         this.fade_in = true;
         this.loading = false;
         this.loaded = false;
@@ -516,12 +516,12 @@ export default class Tile {
             this.visible = true;
             this.proxy_for = this.proxy_for || [];
             this.proxy_for.push(tile);
-            this.proxy_depth = 1; // draw proxies a half-layer back (order is scaled 2x to avoid integer truncation)
+            this.proxy_order_offset = 1; // draw proxies a half-layer back (order is scaled 2x to avoid integer truncation)
             tile.proxied_as = (tile.style_z > this.style_z ? 'child' : 'parent');
         }
         else {
             this.proxy_for = null;
-            this.proxy_depth = 0;
+            this.proxy_order_offset = 0;
         }
     }
 
@@ -540,7 +540,7 @@ export default class Tile {
     setupProgram ({ model, model32 }, program) {
         // Tile origin
         program.uniform('4fv', 'u_tile_origin', [this.min.x, this.min.y, this.style_z, this.coords.z]);
-        program.uniform('1f', 'u_tile_proxy_depth', this.proxy_depth);
+        program.uniform('1f', 'u_tile_proxy_order_offset', this.proxy_order_offset);
 
         // Model - transform tile space into world space (meters, absolute mercator position)
         mat4.identity(model);

--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -34,6 +34,7 @@ export default class Tile {
         this.visible = false;
         this.proxy_for = null;
         this.proxied_as = null;
+        this.proxy_level = 0;
         this.proxy_order_offset = 0;
         this.fade_in = true;
         this.loading = false;
@@ -518,10 +519,12 @@ export default class Tile {
             this.proxy_for.push(tile);
             this.proxy_order_offset = 1; // draw proxies a half-layer back (order is scaled 2x to avoid integer truncation)
             tile.proxied_as = (tile.style_z > this.style_z ? 'child' : 'parent');
+            this.proxy_level = Math.abs(tile.style_z - this.style_z); // # of zoom levels proxy is above/below target tile
         }
         else {
             this.proxy_for = null;
             this.proxy_order_offset = 0;
+            this.proxy_level = 0;
         }
     }
 

--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -409,8 +409,8 @@ export default class Tile {
                         mesh.labels = mesh_variant.labels;
                         meshes[s] = meshes[s] || [];
                         meshes[s].push(mesh);
-                        if (mesh.variant.order == null) {
-                            mesh.variant.order = meshes[s].length - 1; // assign default variant render order
+                        if (mesh.variant.mesh_order == null) {
+                            mesh.variant.mesh_order = meshes[s].length - 1; // assign default variant render order
                         }
 
                         this.debug.buffer_size += mesh.buffer_size;
@@ -422,7 +422,7 @@ export default class Tile {
                 if (meshes[s]) {
                     meshes[s].sort((a, b) => {
                         // Sort variant order ascending if present, then all null values (where order is unspecified)
-                        let ao = a.variant.order, bo = b.variant.order;
+                        let ao = a.variant.mesh_order, bo = b.variant.mesh_order;
                         return (ao == null ? 1 : (bo == null ? -1 : (ao < bo ? -1 : 1)));
                     });
                 }

--- a/src/tile/tile_manager.js
+++ b/src/tile/tile_manager.js
@@ -9,16 +9,14 @@ import Task from '../utils/task';
 
 export default class TileManager {
 
-    constructor({ scene, view }) {
+    constructor({ scene }) {
         this.scene = scene;
-        this.view = view;
         this.tiles = {};
         this.pyramid = new TilePyramid();
         this.visible_coords = {};
         this.queued_coords = [];
         this.building_tiles = null;
         this.renderable_tiles = [];
-        this.active_styles = [];
         this.collision = {
             tile_keys: null,
             mesh_set: null,
@@ -38,8 +36,15 @@ export default class TileManager {
         this.visible_coords = {};
         this.queued_coords = [];
         this.scene = null;
-        this.view = null;
         WorkerBroker.removeTarget(this.main_thread_target);
+    }
+
+    get view () {
+        return this.scene.view;
+    }
+
+    get style_manager () {
+        return this.scene.style_manager;
     }
 
     keepTile(tile) {
@@ -120,6 +125,7 @@ export default class TileManager {
         this.view.pruneTilesForView();
         this.updateRenderableTiles();
         this.style_manager.updateActiveStyles(this.renderable_tiles);
+        this.style_manager.updateActiveBlendOrders(this.renderable_tiles);
         return this.updateLabels();
     }
 

--- a/src/tile/tile_manager.js
+++ b/src/tile/tile_manager.js
@@ -119,7 +119,7 @@ export default class TileManager {
         this.updateProxyTiles();
         this.view.pruneTilesForView();
         this.updateRenderableTiles();
-        this.updateActiveStyles();
+        this.style_manager.updateActiveStyles(this.renderable_tiles);
         return this.updateLabels();
     }
 
@@ -253,21 +253,6 @@ export default class TileManager {
             }
         }
         return this.renderable_tiles;
-    }
-
-    getActiveStyles () {
-        return this.active_styles;
-    }
-
-    updateActiveStyles () {
-        let tiles = this.renderable_tiles;
-        let active = {};
-        for (let t=0; t < tiles.length; t++) {
-            let tile = tiles[t];
-            Object.keys(tile.meshes).forEach(s => active[s] = true);
-        }
-        this.active_styles = Object.keys(active);
-        return this.active_styles;
     }
 
     isLoadingVisibleTiles () {


### PR DESCRIPTION
For styles drawn with non-`opaque` blend modes, the `blend_order` is used to determine the rendering order, and thus which features are drawn on top of each other where there are overlaps. 

Because it has only been possible to set `blend_order` at the `style` level, a common pattern has developed where several very similar / template rendering styles are created, to achieve different visual layering:

```
polygons-overlay-low:
  base: polygons
  blend: overlay
  blend_order: 1
polygons-overlay-mid:
  base: polygons
  blend: overlay
  blend_order: 3
polygons-overlay-high:
  base: polygons
  blend: overlay
  blend_order: 5
```

This is inefficient and unwieldy -- and inflexible, especially when mixing data on top of basemaps (which end up having to predefine certain fixed `blend_order` "slots" for use by data overlays). This PR enables the `blend_order` to be set at the `draw` block level (following prior similar work for `dash`, `texture`, etc.). This allows for much more flexible `blend_order` expressions, and a semantic use that aligns with the `order` parameter used for geometry world order of `opaque`-rendered features. For example:

```
styles:
  polygons-overlay:
    base: polygons
    blend: overlay

layers:
  overlays:
    ...
    draw:
      polygons-overlay:
        blend_order: 3

    sub-layer:
      ...
      draw:
        polygons-overlay:
          blend_order: 7
```

Implementation notes: perviously, the engine enforced that each style was only rendered once per render pass. With this feature, the engine will now bucket geometries for a given style by their `blend_order`, and then render styles one or more times (split up using these buckets), as dictated by the total number of unique, sorted `blend_order` values currently visible in the scene.