### PR TITLE
Mask non-`opaque` proxy tiles with stencil buffer

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -566,7 +566,7 @@ export default class Scene {
                     this.gl.stencilFunc(this.gl.EQUAL, this.gl.ZERO, 0xFF);
                     this.gl.stencilOp(this.gl.KEEP, this.gl.KEEP, this.gl.INCR);
                 }
-                else if (blend !== 'opaque') {
+                else if (blend !== 'opaque' && style.stencil_proxy_tiles === true) {
                     // Mask proxy tiles to with stencil buffer to avoid overlap/flicker from compounding alpha
                     // Find unique levels of proxy tiles to render for this style
                     const proxy_levels = this.tile_manager.getRenderableTiles()

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -70,6 +70,12 @@ Object.assign(Points, {
         this.collision_group_points = this.name+'-points';
         this.collision_group_text = this.name+'-text';
 
+        // Stenciling proxy tiles (to avoid compounding alpha artifacts) doesn't work well with
+        // points/text labels, which have pure transparent pixels that interfere with the stencil buffer,
+        // causing a "cut-out"/"x-ray" effect (preventing pixels that would usually be covered by proxy tiles
+        // underneath from being rendered).
+        this.stencil_proxy_tiles = false;
+
         this.reset();
     },
 

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -2,7 +2,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
-uniform float u_tile_proxy_depth;
+uniform float u_tile_proxy_order_offset;
 uniform bool u_tile_fade_in;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
@@ -172,7 +172,7 @@ void main() {
 
     #ifdef TANGRAM_LAYER_ORDER
         // +1 is to keep all layers including proxies > 0
-        applyLayerOrder(a_position.w + u_tile_proxy_depth + 1., position);
+        applyLayerOrder(a_position.w + u_tile_proxy_order_offset + 1., position);
     #endif
 
     // Apply pixel offset in screen-space

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -2,7 +2,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform vec3 u_map_position;
 uniform vec4 u_tile_origin;
-uniform float u_tile_proxy_depth;
+uniform float u_tile_proxy_order_offset;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 
@@ -154,7 +154,7 @@ void main() {
     cameraProjection(position);
 
     // +1 is to keep all layers including proxies > 0
-    applyLayerOrder(a_position.w + u_tile_proxy_depth + 1., position);
+    applyLayerOrder(a_position.w + u_tile_proxy_order_offset + 1., position);
 
     gl_Position = position;
 }

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -34,6 +34,7 @@ export var Style = {
         this.feature_style = {};                    // style for feature currently being parsed, shared to lessen GC/memory thrash
         this.vertex_template = [];                  // shared single-vertex template, filled out by each style
         this.tile_data = {};
+        this.stencil_proxy_tiles = true;            // applied to proxy tiles w/non-opaque blend mode to avoid compounding alpha
 
         // Default world coords to wrap every 100,000 meters, can turn off by setting this to 'false'
         this.defines.TANGRAM_WORLD_POSITION_WRAP = 100000;

--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -33,8 +33,8 @@ export default class Tile {
 
         this.visible = false;
         this.proxy_for = null;
-        this.proxy_depth = 0;
         this.proxied_as = null;
+        this.proxy_order_offset = 0;
         this.fade_in = true;
         this.loading = false;
         this.loaded = false;
@@ -516,12 +516,12 @@ export default class Tile {
             this.visible = true;
             this.proxy_for = this.proxy_for || [];
             this.proxy_for.push(tile);
-            this.proxy_depth = 1; // draw proxies a half-layer back (order is scaled 2x to avoid integer truncation)
+            this.proxy_order_offset = 1; // draw proxies a half-layer back (order is scaled 2x to avoid integer truncation)
             tile.proxied_as = (tile.style_z > this.style_z ? 'child' : 'parent');
         }
         else {
             this.proxy_for = null;
-            this.proxy_depth = 0;
+            this.proxy_order_offset = 0;
         }
     }
 
@@ -540,7 +540,7 @@ export default class Tile {
     setupProgram ({ model, model32 }, program) {
         // Tile origin
         program.uniform('4fv', 'u_tile_origin', [this.min.x, this.min.y, this.style_z, this.coords.z]);
-        program.uniform('1f', 'u_tile_proxy_depth', this.proxy_depth);
+        program.uniform('1f', 'u_tile_proxy_order_offset', this.proxy_order_offset);
 
         // Model - transform tile space into world space (meters, absolute mercator position)
         mat4.identity(model);

--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -34,6 +34,7 @@ export default class Tile {
         this.visible = false;
         this.proxy_for = null;
         this.proxied_as = null;
+        this.proxy_level = 0;
         this.proxy_order_offset = 0;
         this.fade_in = true;
         this.loading = false;
@@ -518,10 +519,12 @@ export default class Tile {
             this.proxy_for.push(tile);
             this.proxy_order_offset = 1; // draw proxies a half-layer back (order is scaled 2x to avoid integer truncation)
             tile.proxied_as = (tile.style_z > this.style_z ? 'child' : 'parent');
+            this.proxy_level = Math.abs(tile.style_z - this.style_z); // # of zoom levels proxy is above/below target tile
         }
         else {
             this.proxy_for = null;
             this.proxy_order_offset = 0;
+            this.proxy_level = 0;
         }
     }
 


### PR DESCRIPTION
This PR eliminates a long-standing, nasty artifact that occurs with features rendered with non-`opaque` blend modes when zooming -- as one or more levels of proxy tiles are rendered on top of each other (and/or with the new tile that is loading to replace them), the compounding alpha causes a flickering effect.

This PR avoids these artifacts using the stencil buffer: proxy tiles are drawn from front to back, with the stencil buffer adjusted for each level (e.g. zoom ancestor or descendant level) such that proxies will only draw pixels not previously covered by a previous level. Note, it's important that pixels from proxies are allowed to overwrite other pixels from the *same* proxy level, for overlapping geometries to render properly; we just want to mask out pixels from other, previously draw proxy tile *levels*.

(The `translucent` blend mode already avoided this problem, also by using the stencil buffer, though tailored for the particular "x-ray" effect of that blend mode, where backfaces are eliminated from translucent geometry.)

**Before 😭**
![tangram-video-1550023010504](https://user-images.githubusercontent.com/16733/52681142-dc133180-2f08-11e9-8f17-631cdffa081d.gif)

**After 😌**
![tangram-video-1550022276650](https://user-images.githubusercontent.com/16733/52681034-7de64e80-2f08-11e9-93d9-ede95452c652.gif)

Note: this PR builds on the commits of #703 for convenience (changed similar code). The specific changes for this feature are https://github.com/tangrams/tangram/compare/f7a10c1...8bfc5d0.
