### PR TITLE
Label zoom out improvements

### DIFF
--- a/src/labels/main_pass.js
+++ b/src/labels/main_pass.js
@@ -30,6 +30,14 @@ export default function mainThreadLabelCollisionPass (tiles, view_zoom, hide_bre
             meshes.forEach(mesh => {
                 if (mesh.labels) {
                     for (let label_id in mesh.labels) {
+                        // For proxy tiles, only allow visible labels to be *hidden* by further collisions,
+                        // don't allow new ones to appear. Promotes label stability and prevents thrash
+                        // from different labels (often not thematically relevant given the different zoom level of
+                        // the proxy tile content, e.g. random POIs popping in/out when zooming out to city-wide view).
+                        if (tile.isProxy() && !prev_visible[label_id]) {
+                            continue;
+                        }
+
                         const params = mesh.labels[label_id].container.label;
                         const linked = mesh.labels[label_id].container.linked;
                         const ranges = mesh.labels[label_id].ranges;

--- a/src/styles/points/points.js
+++ b/src/styles/points/points.js
@@ -80,11 +80,7 @@ Object.assign(Points, {
             this.defines.TANGRAM_LAYER_ORDER = true;
         }
 
-        // Fade out when tile is zooming out, e.g. acting as proxy tiles
-        this.defines.TANGRAM_FADE_ON_ZOOM_OUT = true;
-        this.defines.TANGRAM_FADE_ON_ZOOM_OUT_RATE = 2; // fade at 2x, e.g. fully transparent at 0.5 zoom level away
-
-        // Fade in (depending on tile proxy status)
+        // Fade in labels
         if (debugSettings.suppress_label_fade_in === true) {
             this.fade_in_time = 0;
             this.defines.TANGRAM_FADE_IN_RATE = null;

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -64,6 +64,7 @@ vec2 rotate2D(vec2 _st, float _angle) {
 #ifdef TANGRAM_CURVED_LABEL
     // Assumes stops are [0, 0.33, 0.66, 0.99];
     float mix4linear(float a, float b, float c, float d, float x) {
+        x = clamp(x, 0., 1.);
         return mix(mix(a, b, 3. * x),
                    mix(b,
                        mix(c, d, 3. * (max(x, .66) - .66)),
@@ -150,14 +151,6 @@ void main() {
         if (u_tile_fade_in) {
             v_alpha_factor *= clamp(u_visible_time * TANGRAM_FADE_IN_RATE, 0., 1.);
         }
-    #endif
-
-    // Fade out when tile is zooming out, e.g. acting as proxy tiles
-    // NB: this is mostly done to compensate for text label collision happening at the label's 1x zoom. As labels
-    // in proxy tiles are scaled down, they begin to overlap, and the fade is a simple way to ease the transition.
-    // Value passed to fragment shader in the v_alpha_factor varying
-    #ifdef TANGRAM_FADE_ON_ZOOM_OUT
-        v_alpha_factor *= clamp(1. + TANGRAM_FADE_ON_ZOOM_OUT_RATE * (u_map_position.z - u_tile_origin.z), 0., 1.);
     #endif
 
     // World coordinates for 3d procedural textures

--- a/src/tile/tile_manager.js
+++ b/src/tile/tile_manager.js
@@ -171,8 +171,7 @@ export default class TileManager {
                         Task.finish(task, results);
                         this.updateTileStates().then(() => this.scene.immediateRedraw());
                     });
-                },
-                user_moving_view: false // don't run task when user is moving view
+                }
             };
             Task.add(this.collision.task);
         }


### PR DESCRIPTION
Improvements to label behavior on zoom out:

- Run collision more frequently (don't block on user input).
- Allow proxy labels to keep displaying, but only if they were previously visible (e.g. collision can remove visible proxy labels, but not add new ones that weren't already visible).
- Clamp curved label zoom interpolation factor (so curved labels don't go wild when zoomed beyond 1x up/down).
- Don't fade proxied labels out when zoomed beyond 1x (was only there to hide unsatisfactory proxy collision behavior addressed by above changes).