### PR TITLE
Default to data source's only layer

### DIFF
--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -324,36 +324,31 @@ export default class Tile {
             geom: GeoJSON FeatureCollection
     */
     static getDataForSource (source_data, source_config, scene_layer) {
-        var layers = [];
+        const layers = [];
+        const single_layer = (Object.keys(source_data.layers).length === 1 && Object.keys(source_data.layers)[0]);
 
         if (source_config != null && source_data != null && source_data.layers != null) {
-            // If no layer specified, and a default source layer exists
-            if (!source_config.layer && source_data.layers._default) {
-                layers.push({
-                    geom: source_data.layers._default
-                });
-            }
-            // If no layer specified, and a layer for the scene layer name exists
-            else if (!source_config.layer && scene_layer) {
+            // If no source layer specified:
+            // 1. Look for a source layer that matches the scene layer name
+            // 2. If not, but the source only has one layer, use that as the default
+            if (!source_config.layer && (scene_layer || single_layer)) {
                 layers.push({
                     layer: scene_layer,
-                    geom: source_data.layers[scene_layer]
+                    geom: source_data.layers[scene_layer] || source_data.layers[single_layer]
                 });
             }
-            // If a layer is specified by name, use it
+            // If a source layer is specified by name, use it
             else if (typeof source_config.layer === 'string') {
                 layers.push({
                     layer: source_config.layer,
                     geom: source_data.layers[source_config.layer]
                 });
             }
-            // If multiple layers are specified by name, combine them
+            // If multiple source layers are specified by name, combine them
             else if (Array.isArray(source_config.layer)) {
                 source_config.layer.forEach(layer => {
                     if (source_data.layers[layer] && source_data.layers[layer].features) {
-                        layers.push({
-                            layer,
-                            geom: source_data.layers[layer]
+                        layers.push({ layer, geom: source_data.layers[layer]
                         });
                     }
                 });


### PR DESCRIPTION
Many data sources only have a single layer. With GeoJSON sources, the layer is implicit and un-named, because the contents of the file are a single `FeatureCollection` object. This layer gets automatically matched when a `data` block in `layers` leaves the source `layer` name unspecified, e.g.

```
layers:
  geojson:
    data: { source: geojson } # uses the default layer in the geojson source
    ...
```

Many MVT sources typically have a single layer as well, but there's no obvious or standard "default" layer name. Popular tools like Tippecanoe may [reuse the source file name as the layer name](https://github.com/mapbox/tippecanoe#input-files-and-layer-names) (you can explicitly name those layers if you want instead), or similar behavior. Other tools may just use a generic layer name like `features`.

This has come up repeatedly as a gotcha when using single-layer MVT sources in Tangram, because it's not always natural to realize you have to specify the layer in these cases.

This PR changes the data source layer matching behavior such that, for any data source that has a single layer, that layer will be matched in cases where no source `layer` name is specified in the `data` block. (If a `layer` name *is* specified, Tangram will still try to match on that, and return no data if the layer names don't match.)