### PR TITLE
Add support to parse some or all MVT feature properties as JSON

### DIFF
--- a/src/sources/mvt.js
+++ b/src/sources/mvt.js
@@ -1,8 +1,17 @@
 import DataSource, {NetworkTileSource} from './data_source';
 import Geo from '../utils/geo';
+import log from '../utils/log';
 
 import Pbf from 'pbf';
 import {VectorTile, VectorTileFeature} from '@mapbox/vector-tile';
+
+const PARSE_JSON_TYPE = {
+    NONE: 0,
+    ALL: 1,
+    SOME: 2
+};
+
+const PARSE_JSON_TEST = ['{', '[']; // one-time allocated array/strings
 
 /**
  Mapbox Vector Tile format
@@ -13,6 +22,27 @@ export class MVTSource extends NetworkTileSource {
     constructor (source, sources) {
         super(source, sources);
         this.response_type = 'arraybuffer'; // binary data
+
+        // Optionally parse some or all properties from JSON strings
+        if (source.parse_json === true) {
+            // try to parse all properties (least efficient)
+            this.parse_json_type = PARSE_JSON_TYPE.ALL;
+        }
+        else if (Array.isArray(source.parse_json)) {
+            // try to parse a specific list of property names (more efficient)
+            this.parse_json_type = PARSE_JSON_TYPE.SOME;
+            this.parse_json_prop_list = source.parse_json;
+        }
+        else {
+            if (source.parse_json != null) {
+                let msg = `Data source '${this.name}': 'parse_json' parameter should be 'true', or an array of ` +
+                    `property names (was '${JSON.stringify(source.parse_json)}')`;
+                log({ level: 'warn', once: true }, msg);
+            }
+
+            // skip parsing entirely (default behavior)
+            this.parse_json_type = PARSE_JSON_TYPE.NONE;
+        }
     }
 
     parseSourceData (tile, source, response) {
@@ -55,6 +85,8 @@ export class MVTSource extends NetworkTileSource {
                     properties: feature.properties
                 };
 
+                this.parseJSONProperties(feature_geojson);
+
                 var geometry = feature_geojson.geometry;
                 var coordinates = feature.loadGeometry();
                 for (var r=0; r < coordinates.length; r++) {
@@ -92,6 +124,29 @@ export class MVTSource extends NetworkTileSource {
         return layers;
     }
 
+    // Optionally parse some or all feature properties from JSON strings
+    parseJSONProperties (feature) {
+        if (this.parse_json_type !== PARSE_JSON_TYPE.NONE) {
+            const props = feature.properties;
+            for (const p in props) {
+                // if specified, check list of explicit properties to parse
+                // (otherwise try to parse all properties)
+                if (this.parse_json_type === PARSE_JSON_TYPE.SOME &&
+                    this.parse_json_prop_list.indexOf(p) === -1) {
+                    continue; // skip this property
+                }
+
+                // check if this property looks like JSON, and parse if so
+                if (PARSE_JSON_TEST.indexOf(props[p][0]) > -1) {
+                    try {
+                        props[p] = JSON.parse(props[p]);
+                    } catch (e) {
+                        // continue with original value if couldn't parse as JSON
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Decode multipolygons, which are encoded as a single set of rings

--- a/src/sources/mvt.js
+++ b/src/sources/mvt.js
@@ -128,20 +128,27 @@ export class MVTSource extends NetworkTileSource {
     parseJSONProperties (feature) {
         if (this.parse_json_type !== PARSE_JSON_TYPE.NONE) {
             const props = feature.properties;
-            for (const p in props) {
-                // if specified, check list of explicit properties to parse
-                // (otherwise try to parse all properties)
-                if (this.parse_json_type === PARSE_JSON_TYPE.SOME &&
-                    this.parse_json_prop_list.indexOf(p) === -1) {
-                    continue; // skip this property
-                }
 
-                // check if this property looks like JSON, and parse if so
-                if (PARSE_JSON_TEST.indexOf(props[p][0]) > -1) {
+            // if specified, check list of explicit properties to parse
+            if (this.parse_json_type === PARSE_JSON_TYPE.SOME) {
+                this.parse_json_prop_list.forEach(p => {
                     try {
                         props[p] = JSON.parse(props[p]);
                     } catch (e) {
                         // continue with original value if couldn't parse as JSON
+                    }
+                });
+            }
+            // otherwise try to parse all properties
+            else {
+                for (const p in props) {
+                    // check if this property looks like JSON, and parse if so
+                    if (PARSE_JSON_TEST.indexOf(props[p][0]) > -1) {
+                        try {
+                            props[p] = JSON.parse(props[p]);
+                        } catch (e) {
+                            // continue with original value if couldn't parse as JSON
+                        }
                     }
                 }
             }

--- a/src/styles/filter.js
+++ b/src/styles/filter.js
@@ -90,26 +90,18 @@ function rangeMatch(key, value, options) {
 function includesMatch(key, value) {
     let expressions = [];
 
-    // the array includes ONE OE MORE of the provided values
-    if (value.includes) {
-        if (Array.isArray(value.includes)) {
-            let arr = '['+ value.includes.map(maybeQuote).join(',') + ']';
-            expressions.push(`${arr}.some(function(v) { return ${lookUp(key)}.indexOf(v) > -1 })`);
-        }
-        else {
-            expressions.push(`${lookUp(key)}.indexOf(${maybeQuote(value.includes)}) > -1`);
-        }
+    // the array includes ONE OE MORE of the provided values (a single value is converted to an array)
+    if (value.includes_any) {
+        const vals = Array.isArray(value.includes_any) ? value.includes_any : [value.includes_any];
+        const arr = '['+ vals.map(maybeQuote).join(',') + ']';
+        expressions.push(`${arr}.some(function(v) { return ${lookUp(key)}.indexOf(v) > -1 })`);
     }
 
-    // the array includes ALL of the provided values
+    // the array includes ALL of the provided values (a single value is converted to an array)
     if (value.includes_all) {
-        if (Array.isArray(value.includes_all)) {
-            let arr = '[' + value.includes_all.map(maybeQuote).join(',') + ']';
-            expressions.push(`${arr}.every(function(v) { return ${lookUp(key)}.indexOf(v) > -1 })`);
-        }
-        else {
-            expressions.push(`${lookUp(key)}.indexOf(${maybeQuote(value.includes_all)}) > -1`);
-        }
+        const vals = Array.isArray(value.includes_all) ? value.includes_all : [value.includes_all];
+        const arr = '[' + vals.map(maybeQuote).join(',') + ']';
+        expressions.push(`${arr}.every(function(v) { return ${lookUp(key)}.indexOf(v) > -1 })`);
     }
 
     return wrap(expressions.join(' && '));
@@ -156,7 +148,7 @@ function parseFilter(filter, options) {
             if (value.max || value.min) {
                 filterAST.push(rangeMatch(key, value, options));
             }
-            else if (value.includes || value.includes_all) {
+            else if (value.includes_any || value.includes_all) {
                 filterAST.push(includesMatch(key, value, options));
             }
         } else if (value == null) {

--- a/src/styles/filter.js
+++ b/src/styles/filter.js
@@ -14,8 +14,19 @@ function lookUp(key) {
         return 'context[\'' + key.substring(1) + '\']';
     }
     else if (key.indexOf('.') > -1) {
-        // dot notation indicates a nested feature property
-        return `context.feature.properties${key.split('.').map(k => '[\'' + k + '\']').join('')}`;
+        if (key.indexOf('\\.') === -1) { // no escaped dot notation
+            // un-escaped dot notation indicates a nested feature property
+            return `context.feature.properties${key.split('.').map(k => '[\'' + k + '\']').join('')}`;
+        }
+        else { // mixed escaped/unescaped dot notation
+            // escaped dot notation will be interpreted as a single-level feature property with dots in the name
+            // this splits on unescaped dots, which requires a temporary swap of escaped and unescaped dots
+            let keys = key
+                .replace(/\\\./g, '__TANGRAM_SEPARATOR__')
+                .split('.')
+                .map(s => s.replace(/__TANGRAM_SEPARATOR__/g, '.'));
+            return `context.feature.properties${keys.map(k => '[\'' + k + '\']').join('')}`;
+        }
     }
     // single-level feature property
     return 'context.feature.properties[\'' + key + '\']';

--- a/src/styles/filter.js
+++ b/src/styles/filter.js
@@ -22,9 +22,9 @@ function lookUp(key) {
             // escaped dot notation will be interpreted as a single-level feature property with dots in the name
             // this splits on unescaped dots, which requires a temporary swap of escaped and unescaped dots
             let keys = key
-                .replace(/\\\./g, '__TANGRAM_SEPARATOR__')
+                .replace(/\\\./g, '__TANGRAM_DELIMITER__')
                 .split('.')
-                .map(s => s.replace(/__TANGRAM_SEPARATOR__/g, '.'));
+                .map(s => s.replace(/__TANGRAM_DELIMITER__/g, '.'));
             return `context.feature.properties${keys.map(k => '[\'' + k + '\']').join('')}`;
         }
     }
@@ -70,18 +70,46 @@ function propertyMatchesBoolean(key, value) {
     return wrap(lookUp(key) + (value ? ' != ' : ' == ')  + 'null');
 }
 
-function rangeMatch(key, values, options) {
+function rangeMatch(key, value, options) {
     var expressions = [];
     var transform = options && (typeof options.rangeTransform === 'function') && options.rangeTransform;
 
-    if (values.max) {
-        var max = transform ? transform(values.max) : values.max;
+    if (value.max) {
+        var max = transform ? transform(value.max) : value.max;
         expressions.push('' + lookUp(key) + ' < ' + max);
     }
 
-    if (values.min) {
-        var min = transform ? min = transform(values.min) : values.min;
+    if (value.min) {
+        var min = transform ? min = transform(value.min) : value.min;
         expressions.push('' + lookUp(key) + ' >= ' + min);
+    }
+
+    return wrap(expressions.join(' && '));
+}
+
+function includesMatch(key, value) {
+    let expressions = [];
+
+    // the array includes ONE OE MORE of the provided values
+    if (value.includes) {
+        if (Array.isArray(value.includes)) {
+            let arr = '['+ value.includes.map(maybeQuote).join(',') + ']';
+            expressions.push(`${arr}.some(function(v) { return ${lookUp(key)}.indexOf(v) > -1 })`);
+        }
+        else {
+            expressions.push(`${lookUp(key)}.indexOf(${maybeQuote(value.includes)}) > -1`);
+        }
+    }
+
+    // the array includes ALL of the provided values
+    if (value.includes_all) {
+        if (Array.isArray(value.includes_all)) {
+            let arr = '[' + value.includes_all.map(maybeQuote).join(',') + ']';
+            expressions.push(`${arr}.every(function(v) { return ${lookUp(key)}.indexOf(v) > -1 })`);
+        }
+        else {
+            expressions.push(`${lookUp(key)}.indexOf(${maybeQuote(value.includes_all)}) > -1`);
+        }
     }
 
     return wrap(expressions.join(' && '));
@@ -127,6 +155,9 @@ function parseFilter(filter, options) {
         } else if (type === 'object' && value != null) {
             if (value.max || value.min) {
                 filterAST.push(rangeMatch(key, value, options));
+            }
+            else if (value.includes || value.includes_all) {
+                filterAST.push(includesMatch(key, value, options));
             }
         } else if (value == null) {
             filterAST.push(nullValue(key, value));

--- a/src/styles/filter.js
+++ b/src/styles/filter.js
@@ -10,8 +10,14 @@ function maybeQuote(value) {
 
 function lookUp(key) {
     if (key[0] === '$') {
+        // keys prefixed with $ are special properties in the context object (not feature properties)
         return 'context[\'' + key.substring(1) + '\']';
     }
+    else if (key.indexOf('.') > -1) {
+        // dot notation indicates a nested feature property
+        return `context.feature.properties${key.split('.').map(k => '[\'' + k + '\']').join('')}`;
+    }
+    // single-level feature property
     return 'context.feature.properties[\'' + key + '\']';
 }
 

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -196,14 +196,14 @@ class Layer {
                     // Context property
                     this.context_prop_matches = this.context_prop_matches || [];
                     this.context_prop_matches.push([key.substring(1), array ? val : [val]]);
+                    delete this.filter[key];
                 }
-                else {
-                    // Feature property
+                else if (key.indexOf('.') === -1) { // exclude nested feature properties
+                    // Single-level feature property
                     this.feature_prop_matches = this.feature_prop_matches || [];
                     this.feature_prop_matches.push([key, array ? val : [val]]);
+                    delete this.filter[key];
                 }
-
-                delete this.filter[key];
             }
         });
     }


### PR DESCRIPTION
Sometimes source data includes properties with a richer object format than just strings or numbers -- e.g. arrays, nested objects, etc. The MVT spec [doesn't prescribe explicit behavior](https://docs.mapbox.com/vector-tiles/specification/#how-to-encode-attributes-that-arent-strings-or-numbers) for these cases, but notes that common tools such as [Tippecanoe](https://github.com/mapbox/tippecanoe) and Mapnik will encode these properties as stringified JSON.

This requires client-side support for parsing these fields. This PR adds support for this on MVT data sources through a new `parse_json` property:

- If `parse_json` is `true`, then *each* property will be checked to see if it "looks like" stringified JSON (defined as a string with first character being `{` or `[`); if so, it is parsed as JSON (with `JSON.parse`).
- If `parse_json` is an array of property names, only those specific properties are checked for JSON parsing. This is preferred to the above, because it limits the parsing impact to only the fields that need it.
- If `parse_json` is undefined/null/false, no special parsing of properties is done (e.g. the current behavior).

Example usage:

```
sources:
  tiles:
    type: MVT
    url: https://...
    parse_json: [prop_a, prop_b] # treat feature properties 'prop_a' and 'prop_b' as stringified JSON
```

These parsed properties will now be properly returned as full JS objects through functions such as `scene.getFeatureAt()` or `scene.queryFeatures()`.

To make use of these properties in filtering and styling, you will need to write a JS function to access the complex properties, e.g. if `prop_a` is an array of values, you could filter on it containing the value `x` like so:

`filter: function() { return feature.prop_a.indexOf('x') > -1; }`
