### PR TITLE
Allow draw groups to `freeze` parameter values through sub-layers

### DIFF
--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -28,15 +28,15 @@ function cacheKey (layers) {
 // Merge matching layer trees into a final draw group
 export function mergeTrees(matchingTrees, group) {
     // Find deepest tree
-    let treeDepth = 0;
-    for (let t=0; t < matchingTrees.length; t++) {
-        if (matchingTrees[t].length > treeDepth) {
-            treeDepth = matchingTrees[t].length;
+    let maxTreeDepth = 0;
+    for (let t = 0; t < matchingTrees.length; t++) {
+        if (matchingTrees[t].length > maxTreeDepth) {
+            maxTreeDepth = matchingTrees[t].length;
         }
     }
 
     // No layers to parse
-    if (treeDepth === 0) {
+    if (maxTreeDepth === 0) {
         return null;
     }
 
@@ -48,16 +48,16 @@ export function mergeTrees(matchingTrees, group) {
     // Iterate layer trees in parallel
     const draws = []; // matching draw groups in priority order
     const frozen = []; // any frozen draw groups, in priority order
-    for (let x=0; x < treeDepth; x++) {
+    for (let depth = 0; depth < maxTreeDepth; depth++) {
         // Pull out the requested draw group, for each tree, at this depth (avoiding duplicates at the same level in tree)
-        matchingTrees.forEach((tree, i) => {
-            if (tree[x] && tree[x][group] && draws.indexOf(tree[x][group]) === -1) {
-                draws.push(tree[x][group]);
+        matchingTrees.forEach((tree, column) => {
+            if (tree[depth] && tree[depth][group] && draws.indexOf(tree[depth][group]) === -1) {
+                draws.push(tree[depth][group]);
 
                 // Set or unset frozen draw group for this layer tree
-                if (tree[x][group].freeze === true) {
-                    frozen[i] = frozen[i] || [];
-                    frozen[i].unshift(tree[x][group]); // reverse order so frozen ancestors take priority
+                if (tree[depth][group].freeze === true) {
+                    frozen[column] = frozen[column] || [];
+                    frozen[column].unshift(tree[depth][group]); // reverse order so frozen ancestors take priority
                 }
             }
         });

--- a/src/styles/layer.js
+++ b/src/styles/layer.js
@@ -56,10 +56,8 @@ export function mergeTrees(matchingTrees, group) {
 
                 // Set or unset frozen draw group for this layer tree
                 if (tree[x][group].freeze === true) {
-                    frozen[i] = tree[x][group];
-                }
-                else if (tree[x][group].freeze === false) {
-                    frozen[i] = null;
+                    frozen[i] = frozen[i] || [];
+                    frozen[i].unshift(tree[x][group]); // reverse order so frozen ancestors take priority
                 }
             }
         });
@@ -69,7 +67,12 @@ export function mergeTrees(matchingTrees, group) {
     }
 
     // Add frozen draw groups (in layer priority order)
-    draws.push(...frozen.filter(x => x));
+    // If needed, merge multiple frozen groups within each tree (inverse order, so ancestors win, not descendants)
+    draws.push(
+        ...frozen
+            .filter(x => x)
+            .map(f => f.length > 1 ? mergeObjects({}, ...f) : f[0])
+    );
 
     // Merge draw objects
     mergeObjects(draw, ...draws);


### PR DESCRIPTION
OK a couple years later I'm returning to this override issue #576. Here's my latest attempt...

This introduces a `freeze` keyword to `draw` groups. When a draw group contains the value `freeze: true`, any values in that group (only those values defined "locally" in the same immediate block as the `freeze` keyword) will be "frozen", meaning they will be unaffected by other draw group values, either from child/descendants in the same layer tree, or from parallel/sibling layer trees.

The simplest way to think of this is that it will create a draw group with infinite layer depth, and that is how it is implemented: after all draw groups are merged across both "across" (parallel layer trees) and "down" (layer -> sub-layers) with existing logic, any frozen groups are then additionally applied, as if they were in the next sub-layer down.

On balance, I think this is a helpful solution, but still has potential issues and is just a tricky problem to solve... suggestions welcome! The implementation footprint is small, it's more a matter of getting the logic right (in a way that keeps the implementation simple/performant :) 

## Basemap override

Returning to one of the common cases where you want to "globally" override one or more values, here is an example that re-colors all roads in an imported Refill:

```
import:
    - https://www.nextzen.org/carto/refill-style/12/refill-style.zip
    - https://www.nextzen.org/carto/refill-style/12/themes/label-10.zip

layers:
    roads:
        override-colors:
            draw:
                lines:
                    freeze: true
                    color: red
                    outline:
                        color: darkred
```

No matter what other draw groups are defined, at the end of the draw group merge process, an additional draw group that looks like this will be applied:

```
draw:
  lines:
    color: red
    outline:
      color: darkred
```

This yields the following:
![tangram-1556902003464](https://user-images.githubusercontent.com/16733/57152489-a95b3580-6da1-11e9-807f-36699ba2b8c4.png)


## Priority
These draw groups are applied with the same priority/specificity as any other layer, so if you have two or more conflicting "frozen" groups...

`override-colors2` will win over `override-colors`, because it has a higher priority due to last-alphabetical-layer-name-wins logic:
```
layers:
    roads:
        override-colors:
            draw:
                lines:
                    freeze: true
                    color: red
                    outline:
                        color: darkred

        override-colors2:
            draw:
                lines:
                    freeze: true
                    color: blue
                    outline:
                        color: darkblue

```

`override-colors` will win over `override-colors2`, because it has a higher explicit `priority` defined:
```
layers:
    roads:
        override-colors:
            priority: 1
            draw:
                lines:
                    freeze: true
                    color: red
                    outline:
                        color: darkred

        override-colors2:
            priority: 2
            draw:
                lines:
                    freeze: true
                    color: blue
                    outline:
                        color: darkblue
```

Similarly, if a layer marked `exclusive` matches, it will take precedence.

## Freeze at multiple levels

A child layer won't modify values of its frozen ancestor, e.g. in this case, the `child` layer won't change the color, which will remain frozen as `red`:

```
layers:
    roads:
        override-colors:
            draw:
                lines:
                    freeze: true
                    color: red
                    outline:
                        color: darkred

            child:
                draw:
                    lines:
                        color: yellow # has no effect because ancestor layer is frozen
```

If multiple levels of the tree contain `freeze: true`, they are merged, but with **inverse** priority from the normal deepest-level-wins logic: instead, the higher-up/ancestor groups will win (**does this make sense, or is it backwards...? I'm trying to think through the use cases**). Also as a result, marking a descendant draw group as `freeze: false` has no effect (**though I suppose this could be useful, as a way to say "you definitely cannot override this value"?**).

## Imports

There's a potential gotcha with imports (which would be likely to be mixed with this feature due to its nature), in that if you are importing an existing draw group and then applying `freeze` to it, you're also going to freeze the **whole** draw group, including any properties that were imported -- because import merges happen at the beginning of scene parsing, long before layers are parsed and merged (and it's likely not really practical to change that).

That's why in the example above, a top-level draw group with no filter and adjacent to others was created, called ` override-colors`, rather than just applying `freeze` to the existing top-level `draw` group under the `roads` layer.

