### PR TITLE
More robust support for `feature.id`

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -844,13 +844,15 @@ export default class Scene {
         // Optional uniqueify criteria
         // Valid values: true, false/null, single property name, or array of property names
         unique = (typeof unique === 'string') ? [unique] : unique;
+        const uniqueify_on_id = (unique === true || (Array.isArray(unique) && unique.indexOf('$id') > -1));
         const uniqueify = unique && (obj => {
-            const props = Array.isArray(unique) ? sliceObject(obj.properties, unique) : obj.properties;
+            const properties = Array.isArray(unique) ? sliceObject(obj.properties, unique) : obj.properties;
+            const id = uniqueify_on_id ? obj.id : null;
             if (geometry) {
                 // when `geometry` flag is set, we need to uniqueify based on *both* feature properties and geometry
-                return JSON.stringify({ geometry: obj.geometry, properties: props });
+                return JSON.stringify({ geometry: obj.geometry, properties, id });
             }
-            return JSON.stringify(props);
+            return JSON.stringify({ properties, id });
         });
 
         // Optional grouping criteria

--- a/src/scene/scene_worker.js
+++ b/src/scene/scene_worker.js
@@ -294,6 +294,7 @@ const SceneWorker = Object.assign(self, {
                     let context = StyleParser.getFeatureParseContext(feature, tile, this.global);
                     context.source = tile.source;  // add data source name
                     context.layer = layer;         // add data source layer name
+                    context.id = feature.id;       // add feature id
 
                     if (!filter(context)) {
                         return;

--- a/src/scene/scene_worker.js
+++ b/src/scene/scene_worker.js
@@ -277,6 +277,11 @@ const SceneWorker = Object.assign(self, {
         tiles.forEach(tile => {
             for (let layer in tile.source_data.layers) {
                 let data = tile.source_data.layers[layer];
+
+                if (data == null) {
+                    return;
+                }
+
                 data.features.forEach(feature => {
                     // Optionally check if feature is visible (e.g. was rendered for current generation)
                     const feature_visible = (feature.generation === this.generation);

--- a/src/scene/scene_worker.js
+++ b/src/scene/scene_worker.js
@@ -302,6 +302,7 @@ const SceneWorker = Object.assign(self, {
                     // Info to return with each feature
                     let subset = {
                         type: feature.type,
+                        id: feature.id,
                         properties: Object.assign({}, feature.properties, {
                             $source: context.source,
                             $layer: context.layer,

--- a/src/sources/geojson.js
+++ b/src/sources/geojson.js
@@ -73,6 +73,7 @@ export class GeoJSONSource extends NetworkSource {
                 let f = {
                     type: 'Feature',
                     geometry: {},
+                    id: feature.id,
                     properties: feature.tags
                 };
 
@@ -155,7 +156,7 @@ export class GeoJSONSource extends NetworkSource {
                 let coordinates, centroid_feature;
                 if (feature.geometry.type === 'Polygon') {
                     coordinates = feature.geometry.coordinates;
-                    centroid_feature = getCentroidFeatureForPolygon(coordinates, feature.properties, centroid_properties);
+                    centroid_feature = getCentroidFeatureForPolygon(coordinates, feature.id, feature.properties, centroid_properties);
                     features_centroid.push(centroid_feature);
                 }
                 else if (feature.geometry.type === 'MultiPolygon') {
@@ -170,7 +171,7 @@ export class GeoJSONSource extends NetworkSource {
                             max_area_index = index;
                         }
                     }
-                    centroid_feature = getCentroidFeatureForPolygon(coordinates[max_area_index], feature.properties, centroid_properties);
+                    centroid_feature = getCentroidFeatureForPolygon(coordinates[max_area_index], feature.id, feature.properties, centroid_properties);
                     features_centroid.push(centroid_feature);
                 }
             });
@@ -252,7 +253,7 @@ DataSource.register('GeoJSON', source => {
 
 
 // Helper function to create centroid point feature from polygon coordinates and provided feature meta-data
-function getCentroidFeatureForPolygon (coordinates, properties, newProperties) {
+function getCentroidFeatureForPolygon (coordinates, id, properties, newProperties) {
     let centroid = Geo.centroid(coordinates);
     if (!centroid) {
         return;
@@ -264,6 +265,7 @@ function getCentroidFeatureForPolygon (coordinates, properties, newProperties) {
 
     return {
         type: 'Feature',
+        id,
         properties: centroid_properties,
         geometry: {
             type: 'Point',

--- a/src/sources/mvt.js
+++ b/src/sources/mvt.js
@@ -82,6 +82,7 @@ export class MVTSource extends NetworkTileSource {
                 var feature_geojson = {
                     type: 'Feature',
                     geometry: {},
+                    id: feature.id,
                     properties: feature.properties
                 };
 

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -31,6 +31,7 @@ StyleParser.wrapFunction = function (func) {
         var $source = context.source;
         var $geometry = context.geometry;
         var $meters_per_pixel = context.meters_per_pixel;
+        var $id = context.feature.id;
 
         var val = (function(){ ${func} }());
 

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -31,7 +31,7 @@ StyleParser.wrapFunction = function (func) {
         var $source = context.source;
         var $geometry = context.geometry;
         var $meters_per_pixel = context.meters_per_pixel;
-        var $id = context.feature.id;
+        var $id = context.id;
 
         var val = (function(){ ${func} }());
 
@@ -91,6 +91,7 @@ StyleParser.macros = {
 StyleParser.getFeatureParseContext = function (feature, tile, global) {
     return {
         feature,
+        id: feature.id,
         tile,
         global,
         zoom: tile.style_z,


### PR DESCRIPTION
All data formats supported by Tangram have a `feature.id` property (at the top `feature` level, outside `feature.properties`; some data sets may separately include an id or similar property within `feature.properties`), but we haven't had full support for it. This PR fixes that:

- Ensures `feature.id` persists wherever features are internally copied/synthesized/etc. internally
- Provides access to `feature.id` in user-authored JS scene functions with a new `$id` variable
- Includes `feature.id` in feature object results returned from `scene.queryFeatures()`
- Includes `feature.id` in the default uniqueness check for `scene.queryFeatures()`, with `$id` syntax used if specifying a list of properties to uniqueify on, e.g.:
  - For default `scene.queryFeatures({ unique: true })`, `feature.id` will be included in uniqueness check
  - For explicit unique property list `scene.queryFeatures({ unique: ['$id'] })`, `feature.id` can be included in uniqueness check with `$id` (un-prefixed names refer to `feature.properties`)

