### PR TITLE
Default to WebGL "high performance" mode

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -20,6 +20,12 @@ Context.getContext = function getContext (canvas, options)
         fullscreen = true;
     }
 
+    // powerPreference context option spec requires listeners for context loss/restore,
+    // though it's not clear these are required in practice.
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2.1
+    canvas.addEventListener('webglcontextlost', () => {});
+    canvas.addEventListener('webglcontextrestored', () => {});
+
     var gl = canvas.getContext('webgl', options) || canvas.getContext('experimental-webgl', options);
     if (!gl) {
         throw new Error('Couldn\'t create WebGL context.');

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -248,7 +248,8 @@ export default class Scene {
             this.gl = Context.getContext(this.canvas, Object.assign({
                 alpha: true, premultipliedAlpha: true,
                 stencil: true,
-                device_pixel_ratio: Utils.device_pixel_ratio
+                device_pixel_ratio: Utils.device_pixel_ratio,
+                powerPreference: 'high-performance'
             }, this.contextOptions));
         }
         catch(e) {


### PR DESCRIPTION
Defaults to using `high-performance` for WebGL's `powerPreference` setting. This will ask for use of the discrete GPU where possible. The user can override as with other GL context options:

```
const layer = Tangram.leafletLayer({ scene, { webGLContextOptions: { powerPreference: 'low-power' } } });
```