### PR TITLE
Add a collision grid for better performance of high density point/label scenes

### DIFF
--- a/src/labels/collision.js
+++ b/src/labels/collision.js
@@ -1,5 +1,6 @@
 import Label from './label';
 import RepeatGroup from './repeat_group';
+import CollisionGrid from './collision_grid';
 import log from '../utils/log';
 
 export default Collision;
@@ -7,6 +8,16 @@ export default Collision;
 const Collision = {
 
     tiles: {},
+    grid: null, // no collision grid by default
+
+    initGrid (options) {
+        if (options == null) {
+            this.grid = null;
+        }
+        else {
+            this.grid = new CollisionGrid(options.anchor, options.span);
+        }
+    },
 
     startTile (tile, { apply_repeat_groups = true, return_hidden = false } = {}) {
         let state = this.tiles[tile] = {
@@ -83,6 +94,10 @@ const Collision = {
         let state = this.tiles[tile];
         let labels = state.labels;
 
+        if (this.grid) {
+            this.addLabelsToGrid(tile);
+        }
+
         if (state.repeat) {
             RepeatGroup.clear(tile);
         }
@@ -114,7 +129,7 @@ const Collision = {
                             object.show = true;
 
                             // If a label is breach, its linked label should be considered breach as well
-                            // (this keeps linked labels from staying (in)visible in tandem)
+                            // (this keeps linked labels (in)visible in tandem)
                             if (object.label.breach || object.linked.label.breach) {
                                 object.label.breach = true;
                                 object.linked.label.breach = true;
@@ -147,6 +162,23 @@ const Collision = {
         state.resolve();
     },
 
+    addLabelsToGrid (tile_id) {
+        // Process labels by priority, then by style
+        const tile = this.tiles[tile_id];
+        for (const priority in tile.objects) {
+            const style_objects = tile.objects[priority];
+            if (!style_objects) { // no labels at this priority, skip to next
+                continue;
+            }
+
+            // For each style
+            for (const style in style_objects) {
+                const objects = style_objects[style];
+                objects.forEach(object => this.grid.addLabel(object.label));
+            }
+        }
+    },
+
     // Run collision and repeat check to see if label can currently be placed
     canBePlaced (object, tile, exclude = null, { repeat = true } = {}) {
         let label = object.label;
@@ -157,9 +189,24 @@ const Collision = {
             return label.placed;
         }
 
-        // Test the label for intersections with other labels in the tile
-        let bboxes = this.tiles[tile].bboxes;
-        if (!layout.collide || !label.discard(bboxes, exclude && exclude.label)) {
+        let placeable = !layout.collide;
+        if (!placeable) {
+            // Test the label for intersections with other labels
+            if (this.grid && label.cells) {
+                // test label candidate against labels placed in each grid cell
+                placeable = label.cells.reduce((keep, cell) => {
+                    if (keep && label.discard(cell, exclude && exclude.label)) {
+                        keep = false;
+                    }
+                    return keep;
+                }, true);
+            }
+            else {
+                placeable = !label.discard(this.tiles[tile].bboxes, exclude && exclude.label);
+            }
+        }
+
+        if (placeable) {
             // repeat culling with nearby labels
             if (repeat && RepeatGroup.check(label, layout, tile)) {
                 label.placed = false;
@@ -186,7 +233,13 @@ const Collision = {
         if (repeat) {
             RepeatGroup.add(label, label.layout, tile);
         }
-        Label.add(label, this.tiles[tile].bboxes);
+
+        if (this.grid && label.cells) {
+            label.cells.forEach(cell => Label.add(label, cell));
+        }
+        else {
+            Label.add(label, this.tiles[tile].bboxes);
+        }
     }
 
 };

--- a/src/labels/collision_grid.js
+++ b/src/labels/collision_grid.js
@@ -1,0 +1,40 @@
+export default class CollisionGrid {
+    constructor (anchor, span) {
+        this.anchor = anchor;
+        this.span = span;
+        this.cells = {};
+    }
+
+    addLabel (label) {
+        if (label.aabb) {
+            this.addLabelBboxes(label, label.aabb);
+        }
+
+        if (label.aabbs) {
+            label.aabbs.forEach(aabb => this.addLabelBboxes(label, aabb));
+        }
+    }
+
+    addLabelBboxes (label, aabb) {
+        // min/max cells that the label falls into
+        // keep grid coordinates at zero or above so any labels that go "below" the anchor are in the lowest grid cell
+        const cell_bounds = [
+            Math.max(Math.floor((aabb[0] - this.anchor.x) / this.span), 0),
+            Math.max(Math.floor(-(aabb[1] - this.anchor.y) / this.span), 0),
+            Math.max(Math.floor((aabb[2] - this.anchor.x) / this.span), 0),
+            Math.max(Math.floor(-(aabb[3] - this.anchor.y) / this.span), 0)
+        ];
+
+        label.cells = []; // label knows which cells it falls in
+
+        // initialize each grid cell as necessary, and add to label's list of cells
+        for (let gy = cell_bounds[1]; gy <= cell_bounds[3]; gy++) {
+            this.cells[gy] = this.cells[gy] || {};
+            for (let gx = cell_bounds[0]; gx <= cell_bounds[2]; gx++) {
+                this.cells[gy][gx] = this.cells[gy][gx] || { aabb: [], obb: [] };
+                label.cells.push(this.cells[gy][gx]);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Previously, the collision system has been brute force for all labels (points and text labels with collision enabled) in the current set of visible tiles. As labels are placed, every new label candidate is tested against every previously placed label.

This brute force approach has been fine (and often faster than adding indexing schemes which bring their own overhead) with typical / small sets of labels, e.g. ~1000. As label density grows, it get quadratically slower, and with large (e.g. 100,000 points) sets it is essentially unusable (multi-second collision passes). These cases have not arisen in typical Tangram basemap scenes, but easily can with dataviz (in many cases you have collision *off* for these large sets anyway... but you still want a practical way to turn them on for some use cases).

This PR adds a simple collision grid system to drastically reduce the number of collisions performed for dense data sets. In a collision grid, the labels are divided (in this case in screen-space) into a grid of a given size; each label is added to the one or more grid cells that it intersects. When we need to know which labels a given label intersects, we only need to test the "local" labels that are in the same grid cells.

The grid size is adaptive based on the label density of the scene. We find the visible tile with the most labels, and determine a grid size based on that. When the label density is low (currently less than 256 labels in the densest tile), the collision grid is skipped entirely.

Currently, the collision grid is only implemented on the main thread collision pass for all labels. The first collision pass of each tile (on the worker thread) is generally assumed to already be "local" enough to not benefit substantially from a grid, though we could benchmark to see if it is helpful for even denser data sets.