### PR TITLE
Support HTTP 204 response

### DIFF
--- a/src/scene/scene_bundle.js
+++ b/src/scene/scene_bundle.js
@@ -94,8 +94,8 @@ export class ZipSceneBundle extends SceneBundle {
         this.zip = new JSZip();
 
         if (typeof this.url === 'string') {
-            const data = await Utils.io(this.url, 60000, 'arraybuffer');
-            await this.zip.loadAsync(data);
+            const { body } = await Utils.io(this.url, 60000, 'arraybuffer');
+            await this.zip.loadAsync(body);
             await this.parseZipFiles();
             return this.loadRoot();
         } else {
@@ -221,10 +221,9 @@ function parseResource (body) {
 function loadResource (source) {
     return new Promise((resolve, reject) => {
         if (typeof source === 'string') {
-            Utils.io(source).then((body) => {
+            Utils.io(source).then(({ body }) => {
                 try {
-                    let data = parseResource(body);
-                    resolve(data);
+                    resolve(parseResource(body));
                 }
                 catch(e) {
                     reject(e);

--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -308,7 +308,7 @@ export class NetworkSource extends DataSource {
             source_data.request_id = request_id;
             source_data.error = null;
 
-            promise.then((body) => {
+            promise.then(({ body }) => {
                 dest.debug.response_size = body.length || body.byteLength;
                 dest.debug.network = +new Date() - dest.debug.network;
                 dest.debug.parsing = +new Date();

--- a/src/styles/text/font_manager.js
+++ b/src/styles/text/font_manager.js
@@ -87,7 +87,7 @@ const FontManager = {
         // Also see https://github.com/bramstein/fontloader/blob/598e9399117bdc946ff786fa2c5007a6bd7d3b9e/src/fontface.js#L145-L153
         let data = url;
         if (url.slice(0, 5) === 'blob:') {
-            data = await Utils.io(url, 60000, 'arraybuffer');
+            data = (await Utils.io(url, 60000, 'arraybuffer')).body;
             let bytes = new Uint8Array(data);
             if (this.supports_native_font_loading) {
                 data = bytes; // use raw binary data

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -55,10 +55,10 @@ Utils.io = function (url, timeout = 60000, responseType = 'text', method = 'GET'
             request.onload = () => {
                 if (request.status === 200) {
                     if (['text', 'json'].indexOf(request.responseType) > -1) {
-                        resolve(request.responseText);
+                        resolve({ body: request.responseText, status: request.status });
                     }
                     else {
-                        resolve(request.response);
+                        resolve({ body: request.response, status: request.status });
                     }
                 } else {
                     reject(Error('Request error with a status of ' + request.statusText));

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -60,7 +60,11 @@ Utils.io = function (url, timeout = 60000, responseType = 'text', method = 'GET'
                     else {
                         resolve({ body: request.response, status: request.status });
                     }
-                } else {
+                }
+                else if (request.status === 204) { // No Content
+                    resolve({ body: null, status: request.status });
+                }
+                else {
                     reject(Error('Request error with a status of ' + request.statusText));
                 }
             };

--- a/test/data_source_spec.js
+++ b/test/data_source_spec.js
@@ -153,7 +153,10 @@ describe('DataSource', () => {
 
                 beforeEach(() => {
                     mockTile = getMockTile();
-                    sinon.stub(Utils, 'io').returns(Promise.resolve(getMockJSONResponse()));
+                    sinon.stub(Utils, 'io').returns(Promise.resolve({
+                        status: 200,
+                        body: getMockJSONResponse()
+                    }));
                     subject = new GeoJSONTileSource(options);
                     return subject.load(mockTile);
                 });


### PR DESCRIPTION
Fixes #729.

Adds support for HTTP 204 (No Content) responses in tile requests. Any tiles returning a 204 will be considered to have loaded successfully, but will simply be empty. Previously these requests would cause warnings as a non-200 response.