### PR TITLE
Styles can define custom vertex attributes

### DIFF
--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -18,9 +18,6 @@ import polygons_fs from '../polygons/polygons_fragment.glsl';
 
 export const Lines = Object.create(Style);
 
-Lines.variants = {}; // mesh variants by variant key
-Lines.vertex_layouts = {}; // vertex layouts by variant key
-
 const DASH_SCALE = 20; // adjustment factor for UV scale to for line dash patterns w/fractional pixel width
 
 Object.assign(Lines, {
@@ -451,8 +448,8 @@ Object.assign(Lines, {
         key = hashString(key);
         draw.variant = key;
 
-        if (Lines.variants[key] == null) {
-            Lines.variants[key] = {
+        if (this.variants[key] == null) {
+            this.variants[key] = {
                 key,
                 blend_order,
                 mesh_order: (draw.is_outline ? 0 : 1), // outlines should be drawn first, so inline is on top
@@ -471,7 +468,7 @@ Object.assign(Lines, {
     // Override
     // Create or return desired vertex layout permutation based on flags
     vertexLayoutForMeshVariant (variant) {
-        if (Lines.vertex_layouts[variant.key] == null) {
+        if (this.vertex_layouts[variant.key] == null) {
             // Attributes for this mesh variant
             // Optional attributes have placeholder values assigned with `static` parameter
             const attribs = [
@@ -484,14 +481,15 @@ Object.assign(Lines, {
                 { name: 'a_selection_color', size: 4, type: gl.UNSIGNED_BYTE, normalized: true, static: (variant.selection ? null : [0, 0, 0, 0]) }
             ];
 
-            Lines.vertex_layouts[variant.key] = new VertexLayout(attribs);
+            this.addCustomAttributesToAttributeList(attribs);
+            this.vertex_layouts[variant.key] = new VertexLayout(attribs);
         }
-        return Lines.vertex_layouts[variant.key];
+        return this.vertex_layouts[variant.key];
     },
 
     // Override
     meshVariantTypeForDraw (draw) {
-        return Lines.variants[draw.variant]; // return pre-calculated mesh variant
+        return this.variants[draw.variant]; // return pre-calculated mesh variant
     },
 
     /**
@@ -546,6 +544,7 @@ Object.assign(Lines, {
             this.vertex_template[i++] = style.selection_color[3] * 255;
         }
 
+        this.addCustomAttributesToVertexTemplate(style, i);
         return this.vertex_template;
     },
 

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -30,6 +30,7 @@ varying float v_alpha_factor;
 
 #define TANGRAM_NORMAL vec3(0., 0., 1.)
 
+#pragma tangram: varyings
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/points/points_fragment.glsl
+++ b/src/styles/points/points_fragment.glsl
@@ -30,7 +30,7 @@ varying float v_alpha_factor;
 
 #define TANGRAM_NORMAL vec3(0., 0., 1.)
 
-#pragma tangram: varyings
+#pragma tangram: attributes
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -51,7 +51,6 @@ varying float v_alpha_factor;
 #define TANGRAM_NORMAL vec3(0., 0., 1.)
 
 #pragma tangram: attributes
-#pragma tangram: varyings
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/points/points_vertex.glsl
+++ b/src/styles/points/points_vertex.glsl
@@ -50,6 +50,8 @@ varying float v_alpha_factor;
 #define TANGRAM_PI 3.14159265359
 #define TANGRAM_NORMAL vec3(0., 0., 1.)
 
+#pragma tangram: attributes
+#pragma tangram: varyings
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -12,9 +12,6 @@ import polygons_fs from './polygons_fragment.glsl';
 
 export const Polygons = Object.create(Style);
 
-Polygons.variants = {}; // mesh variants by variant key
-Polygons.vertex_layouts = {}; // vertex layouts by variant key
-
 Object.assign(Polygons, {
     name: 'polygons',
     built_in: true,
@@ -88,8 +85,8 @@ Object.assign(Polygons, {
         const key = [selection, normal, texcoords, blend_order].join('/');
         draw.variant = key;
 
-        if (Polygons.variants[key] == null) {
-            Polygons.variants[key] = {
+        if (this.variants[key] == null) {
+            this.variants[key] = {
                 key,
                 blend_order,
                 mesh_order: 0,
@@ -103,7 +100,7 @@ Object.assign(Polygons, {
     // Override
     // Create or return desired vertex layout permutation based on flags
     vertexLayoutForMeshVariant (variant) {
-        if (Polygons.vertex_layouts[variant.key] == null) {
+        if (this.vertex_layouts[variant.key] == null) {
             // Attributes for this mesh variant
             // Optional attributes have placeholder values assigned with `static` parameter
             const attribs = [
@@ -114,9 +111,10 @@ Object.assign(Polygons, {
                 { name: 'a_texcoord', size: 2, type: gl.UNSIGNED_SHORT, normalized: true, static: (variant.texcoords ? null : [0, 0]) }
             ];
 
-            Polygons.vertex_layouts[variant.key] = new VertexLayout(attribs);
+            this.addCustomAttributesToAttributeList(attribs);
+            this.vertex_layouts[variant.key] = new VertexLayout(attribs);
         }
-        return Polygons.vertex_layouts[variant.key];
+        return this.vertex_layouts[variant.key];
     },
 
     // Override
@@ -166,6 +164,7 @@ Object.assign(Polygons, {
             this.vertex_template[i++] = 0;
         }
 
+        this.addCustomAttributesToVertexTemplate(style, i);
         return this.vertex_template;
     },
 

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -34,7 +34,7 @@ varying vec4 v_world_position;
     varying vec4 v_lighting;
 #endif
 
-#pragma tangram: varyings
+#pragma tangram: attributes
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -34,6 +34,7 @@ varying vec4 v_world_position;
     varying vec4 v_lighting;
 #endif
 
+#pragma tangram: varyings
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -63,7 +63,6 @@ varying vec4 v_world_position;
 #define TANGRAM_UNPACK_SCALING(x) (x / 1024.)
 
 #pragma tangram: attributes
-#pragma tangram: varyings
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/polygons/polygons_vertex.glsl
+++ b/src/styles/polygons/polygons_vertex.glsl
@@ -62,6 +62,8 @@ varying vec4 v_world_position;
 
 #define TANGRAM_UNPACK_SCALING(x) (x / 1024.)
 
+#pragma tangram: attributes
+#pragma tangram: varyings
 #pragma tangram: camera
 #pragma tangram: material
 #pragma tangram: lighting

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -287,6 +287,10 @@ export var Style = {
                 for (const aname in this.shaders.attributes) {
                     style.attributes[aname] = StyleParser.evalCachedProperty(
                         draw.attributes && draw.attributes[aname], context);
+                    // set attribute value to zero for null/undefined/non-numeric values
+                    if (typeof style.attributes[aname] !== 'number') {
+                        style.attributes[aname] = 0;
+                    }
                 }
             }
 

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -716,11 +716,29 @@ export var Style = {
     setupCustomAttributes() {
         if (this.shaders.attributes) {
             for (const [aname, attrib] of Object.entries(this.shaders.attributes)) {
+                // alias each custom attribute to the internal attribute name in vertex shader,
+                // and internal varying name in fragment shader (if varying is enabled)
                 if (attrib.type === 'float') {
-                    this.addShaderBlock('attributes', `attribute float a_${aname};`);
                     if (attrib.varying !== false) {
-                        this.addShaderBlock('varyings', `varying float v_${aname};`);
+                        this.addShaderBlock('attributes', `
+                            #ifdef TANGRAM_VERTEX_SHADER
+                                attribute float a_${aname};
+                                varying float v_${aname};
+                                #define ${aname} a_${aname}
+                            #else
+                                varying float v_${aname};
+                                #define ${aname} v_${aname}
+                            #endif
+                        `);
                         this.addShaderBlock('setup', `#ifdef TANGRAM_VERTEX_SHADER\nv_${aname} = a_${aname};\n#endif`);
+                    }
+                    else {
+                        this.addShaderBlock('attributes', `
+                            #ifdef TANGRAM_VERTEX_SHADER
+                                attribute float a_${aname};
+                                #define ${aname} a_${aname}
+                            #endif
+                        `);
                     }
                 }
             }

--- a/src/styles/style_manager.js
+++ b/src/styles/style_manager.js
@@ -195,6 +195,9 @@ export class StyleManager {
         // Defines
         shaders.defines = Object.assign({}, ...shader_merges.map(x => x.defines).filter(x => x));
 
+        // Attributes
+        shaders.attributes = Object.assign({}, ...shader_merges.map(x => x.attributes).filter(x => x));
+
         // Uniforms
         shaders.uniforms = {};  // uniforms for this style, both explicitly defined, and mixed from other styles
         shaders._uniforms = (style.shaders && style.shaders.uniforms) || {}; // uniforms explicitly defined by *this* style

--- a/src/styles/text/text.js
+++ b/src/styles/text/text.js
@@ -11,8 +11,6 @@ import VertexLayout from '../../gl/vertex_layout';
 
 export let TextStyle = Object.create(Points);
 
-TextStyle.vertex_layouts = {}; // vertex layouts by variant key
-
 Object.assign(TextStyle, {
     name: 'text',
     super: Points,
@@ -38,7 +36,7 @@ Object.assign(TextStyle, {
      * A plain JS array matching the order of the vertex layout.
      */
     makeVertexTemplate(style, mesh) {
-        this.super.makeVertexTemplate.apply(this, arguments);
+        this.super.makeVertexTemplate.call(this, style, mesh, /* add_custom_attribs */ false);
         let vertex_layout = mesh.vertex_data.vertex_layout;
         let i = vertex_layout.index.a_pre_angles;
 
@@ -49,6 +47,7 @@ Object.assign(TextStyle, {
             this.vertex_template[i++] = 0;
         }
 
+        this.addCustomAttributesToVertexTemplate(style, i);
         return this.vertex_template;
     },
 
@@ -265,7 +264,7 @@ Object.assign(TextStyle, {
     // Create or return vertex layout
     vertexLayoutForMeshVariant(variant) {
         // Vertex layout only depends on shader point flag, so using it as layout key to avoid duplicate layouts
-        if (TextStyle.vertex_layouts[variant.shader_point] == null) {
+        if (this.vertex_layouts[variant.shader_point] == null) {
             // TODO: could make selection, offset, and curved label attribs optional, but may not be worth it
             // since text points generally don't consume much memory anyway
             const attribs = [
@@ -280,9 +279,10 @@ Object.assign(TextStyle, {
                 { name: 'a_offsets', size: 4, type: gl.UNSIGNED_SHORT, normalized: false },
             ];
 
-            TextStyle.vertex_layouts[variant.shader_point] = new VertexLayout(attribs);
+            this.addCustomAttributesToAttributeList(attribs);
+            this.vertex_layouts[variant.shader_point] = new VertexLayout(attribs);
         }
-        return TextStyle.vertex_layouts[variant.shader_point];
+        return this.vertex_layouts[variant.shader_point];
     },
 });
 


### PR DESCRIPTION
This PR adds support for custom vertex attributes/varyings in user-defined styles. This simplifies existing uses of per-feature property data in shaders, which are usually "smuggled" into the shader by encoding non-color values in the `color` parameter, by moving these values to more semantic-appropriated attributes names/formats, and also preserving the `color` attribute for its intended use. It also enables more advanced forms of custom shader visualizations, by allowing for multiple attributes to be defined, and with the potential for more datatypes (only `float` is covered in the initial PR).

### Syntax
- A new `attributes` object is available under a style's `shaders` block.
  - Each key under `attributes` specifies an attribute name, and the value specifies the attribute type and other options.
  - The attribute must specify its type. Currently, only `type: float` (encoded as a 32-bit GL float) is supported.
  - If the attribute value is only needed in the vertex shader, the user can disable the creation of the varying with `varying: false`, potentially improving performance.
  - For each attribute, a vertex shader attribute and fragment shader varying are created with prefixes `a_`, and `v_`, e.g. for an attribute named `custom`, the vertex attribute `a_custom` and varying `v_custom` will be available in appropriate shader `blocks`.
- Values are assigned to these attributes on a per-feature basis, inside a new corresponding `attributes` object inside a `draw` group. Values can be assigned through common formats:
  - JS function, for example to assign a numeric feature property `custom` to an attribute of the same name (likely most common case for this functionality): `custom: function(){ return feature.custom; }`
  - Single value: `custom: 5`
  - Zoom interpolated values: `custom: [[14, 50], [15, 150], [16, 300]]`

### Example
For example, to create a style that colors buildings by height with a custom attribute named `height`, set here using default `draw` parameters:

```
buildings:
  base: polygons
  shaders:
    attributes:
      height:
        type: float
    blocks:
      color: |
        // Use the custom attribute's varying to shade by height
        color.rgb = vec3(min(v_height / 100., 1.), 0., 0.);
  draw:
    # use default draw parameters to set the height attribute value from the height feature property
    attributes:
      height: function() { return feature.height; }
```

(N.B.: for illustration of concepts only, in practice it would be more efficient to implement this kind of style with existing `color` parameter and JS function, unless some other shader-specific logic needed to be applied.)

This style yields the following:
![tangram-1576540116284](https://user-images.githubusercontent.com/16733/70952599-b6791c00-2034-11ea-96e6-41f0d6b3f30f.png)

### Discussion items
- There is opportunity to support other data types, though the initial PR has been kept to `float` for simplicity. Possible candidates:
  - `vec4`, with byte storage (?) and optional (?) normalization (e.g. mapped to 0..1 or -1..1 ranges); this would also support special cases like wanting to map 64-bit int OSM ids into two vec4s
  - explicit `color` type, with standard color parsing applied such that CSS syntax like `red`, `hsl()`, etc. can be used (maps to an unsigned `vec4` with normalization)
- Is the `varying: false` option to create vertex-shader-only attributes warranted? There are use cases for this (if only vertex-shader blocks like `position` need access to the shader, or even the `normal` block with `lighting: vertex`), but the CPU memory cost is incurred in either case. This only helps if for example you are bumping up against the max number of varyings for current hardware.
- The naming scheme, with `a_` and `v_` namespace prefixes, diverges from how `uniforms` are defined (as-is, with the provided name, the `u_` convention is encouraged but not required). On the other hand, it's consistent with how other internal attributes and varyings are named.
- Custom attributes can be a good supporting mechanism for more shader interactivity / selection patterns (similar to more complete experiments done in this area previously, but in this case stripped down to a simpler primitive). It is fairly straightforward to extend the feature selection system to store any custom attribute values per features, and set a corresponding uniform with the currently selected (hover, click, etc.) value inside a shader. I've prototyped this, but wanted to keep out of the initial PR for scope.





