### PR TITLE
Optional `alpha` parameter for `draw` groups

### DIFF
--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -175,6 +175,8 @@ Object.assign(Lines, {
             return;
         }
 
+        style.alpha = StyleParser.evalCachedProperty(draw.alpha, context); // optional alpha override
+
         style.variant = draw.variant; // pre-calculated mesh variant
 
         // height defaults to feature height, but extrude style can dynamically adjust height by returning a number or array (instead of a boolean)
@@ -234,8 +236,8 @@ Object.assign(Lines, {
                 style.outline.offset_precalc = style.offset;
                 style.outline.offset_scale_precalc = style.offset_scale;
 
-                // Inherited properties
                 style.outline.color = draw.outline.color;
+                style.outline.alpha = draw.outline.alpha;
                 style.outline.interactive = draw.outline.interactive;
                 style.outline.cap = draw.outline.cap;
                 style.outline.join = draw.outline.join;
@@ -273,6 +275,7 @@ Object.assign(Lines, {
 
     _preprocess (draw) {
         draw.color = StyleParser.createColorPropertyCache(draw.color);
+        draw.alpha = StyleParser.createPropertyCache(draw.alpha);
         draw.width = StyleParser.createPropertyCache(draw.width, StyleParser.parseUnits);
         if (draw.width && draw.width.type !== StyleParser.CACHE_TYPE.STATIC) {
             draw.next_width = StyleParser.createPropertyCache(draw.width, StyleParser.parseUnits);
@@ -295,6 +298,7 @@ Object.assign(Lines, {
             draw.outline.is_outline = true; // mark as outline (so mesh variant can be adjusted for render order, etc.)
             draw.outline.style = draw.outline.style || this.name;
             draw.outline.color = StyleParser.createColorPropertyCache(draw.outline.color);
+            draw.outline.alpha = StyleParser.createPropertyCache(draw.outline.alpha);
             draw.outline.width = StyleParser.createPropertyCache(draw.outline.width, StyleParser.parseUnits);
             draw.outline.next_width = StyleParser.createPropertyCache(draw.outline.width, StyleParser.parseUnits); // width re-computed for next zoom
 
@@ -536,7 +540,7 @@ Object.assign(Lines, {
         this.vertex_template[i++] = style.color[0] * 255;
         this.vertex_template[i++] = style.color[1] * 255;
         this.vertex_template[i++] = style.color[2] * 255;
-        this.vertex_template[i++] = style.color[3] * 255;
+        this.vertex_template[i++] = (style.alpha != null ? style.alpha : style.color[3]) * 255;
 
         // a_selection_color.rgba - selection color
         if (mesh.variant.selection) {

--- a/src/styles/polygons/polygons.js
+++ b/src/styles/polygons/polygons.js
@@ -38,6 +38,8 @@ Object.assign(Polygons, {
             return null;
         }
 
+        style.alpha = StyleParser.evalCachedProperty(draw.alpha, context); // optional alpha override
+
         style.variant = draw.variant; // pre-calculated mesh variant
 
         style.z = StyleParser.evalCachedDistanceProperty(draw.z, context) || StyleParser.defaults.z;
@@ -73,6 +75,7 @@ Object.assign(Polygons, {
 
     _preprocess (draw) {
         draw.color = StyleParser.createColorPropertyCache(draw.color);
+        draw.alpha = StyleParser.createPropertyCache(draw.alpha);
         draw.z = StyleParser.createPropertyCache(draw.z, StyleParser.parseUnits);
         this.computeVariant(draw);
         return draw;
@@ -150,7 +153,7 @@ Object.assign(Polygons, {
         this.vertex_template[i++] = style.color[0] * 255;
         this.vertex_template[i++] = style.color[1] * 255;
         this.vertex_template[i++] = style.color[2] * 255;
-        this.vertex_template[i++] = style.color[3] * 255;
+        this.vertex_template[i++] = (style.alpha != null ? style.alpha : style.color[3]) * 255;
 
         // a_selection_color.rgba - selection color
         if (mesh.variant.selection) {

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -278,8 +278,10 @@ export const TextLabels = {
 
         // Colors
         draw.font.fill = StyleParser.createPropertyCache(draw.font.fill);
+        draw.font.alpha = StyleParser.createPropertyCache(draw.font.alpha);
         if (draw.font.stroke) {
             draw.font.stroke.color = StyleParser.createPropertyCache(draw.font.stroke.color);
+            draw.font.stroke.alpha = StyleParser.createPropertyCache(draw.font.stroke.alpha);
         }
 
         // Convert font and text stroke sizes


### PR DESCRIPTION
This PR adds a new `alpha` parameter inside several `draw` group contexts. It allows the scene author to set *only* the alpha channel of a color, independently of the RGB channels.

Use cases where this is helpful include:
- Modifying the alpha for named CSS colors
- Modifying the alpha channel in a sub-layer, which can simplify complex layer trees or help with cases where you may be importing/overriding another style, or applying "themes" that change the underlying base colors
- Using a feature property to set the color, but then modifying only the alpha (note, this was not easily achievable before in cases where a feature property might contain a hex or CSS named color), e.g. use transit line colors encoded in tiles, but draw lines at 75% opacity

### Syntax
- Applies to the following styles in `draw` groups, where the `alpha` parameter, if present, will override the alpha channel set by the corresponding color parameter:
  - `polygons`:
    - polygon fill color: `color`
    - example:
    ```
    translucent_polygons:
      color: red
      alpha: 0.5 # red polygon with 50% opacity
    ```
  - `lines`:
    - line fill color: `color`
    - outline color (inside `outline` block): `color`
    - example:
   ```
    overlay_lines:
      color: function() { return feature.colour_name; }
      alpha: 0.75 # color by a feature property but set 75% opacity
    ```
  - `points`:
    - point fill color: `color`
    - outline color (inside `outline` block): `color`
    - font fill/stroke for attached labels as described below, inside a `text` block
    - example:
    ```
    # points with a 25% opacity yellow fill, and a 50% opacity blue outline
    points:
      color: yellow
      alpha: 0.25
      outline:
        color: blue
        alpha: 0.5
        width: 4px
    ```
  - `text`
    - font fill color (inside `font` block): `fill`
    - font stroke color (inside `font.stroke` block): `color`
    - example:
    ```
    text:
      font:
        fill: black
        alpha: 0.5 # black fill with 50 opacity%
        stroke: { color: red, alpha: 0.25 } # red stroke with 25% opacity
    ```
- `alpha` values can be set by:
  - Single value: `alpha: 0.5`
  - Zoom interpolated values: `alpha: [[14, 0.5], [16, 1]]` (fade in opacity from z14-16)
  - JS function: `alpha: function(){ return feature.height/200; }` (set building opacity by height)
- In cases where a color value is required, the `alpha` parameter has no effect if no color is specified. In cases where a default color applies, the `alpha` parameter will modify the default color if no color is specified.
- The `alpha` parameter inherits through sub-layers like any other `draw` parameter, and does not need to be defined at the same depth as a `color` it modifies; it will modify the nearest ancestor layer where color is defined.
  ```
  depth1:
    draw:
      points: { color: red, alpha: 0.5} # these features render w/color [1, 0, 0, 0.5]

    depth2:
      draw:
        points: { alpha: 0.25 } # these features render w/color [1, 0, 0, 0.25]
  ```
- As with other parameters, it is not additive or compounding across layers: in the example, any features rendered at depth2 will have 25% alpha (no interaction with the 50% value from the parent layer).
- If a sub-layer sets `alpha: null`, it un-sets any value set by an ancestor layer. The color's alpha channel returns to its original, unmodified value.
  ```
  depth1:
    draw:
      points: { color: red, alpha: 0.5} # these features render w/color [1, 0, 0, 0.5]

    depth2:
      draw:
        points: { alpha: null } # these features render w/full opacity, color [1, 0, 0, 1]
  ```
- NOTE: for `polygons` and `lines`, alpha channel is only applicable for appropriate `blend` modes (`translucent`, `overlay`, etc.), and is not intended to be used with the default `opaque` blending.