### PR TITLE
Fix line dash color handling

### DIFF
--- a/src/styles/lines/lines.js
+++ b/src/styles/lines/lines.js
@@ -391,6 +391,7 @@ Object.assign(Lines, {
 
                     if (variant.dash) {
                         uniforms.u_v_scale_adjust = Geo.tile_scale * DASH_SCALE;
+                        uniforms.u_has_dash = (variant.dash_background_color != null ? 1 : 0);
                         uniforms.u_dash_background_color = variant.dash_background_color || [0, 0, 0, 0];
                     }
 

--- a/src/styles/polygons/polygons_fragment.glsl
+++ b/src/styles/polygons/polygons_fragment.glsl
@@ -58,7 +58,7 @@ void main (void) {
             // which either don't support alpha, or would cause transparent pixels to write to the depth buffer,
             // obscuring geometry underneath.
             #ifdef TANGRAM_HAS_MASKED_RASTERS   // skip masking logic if no masked raster sources
-            #ifndef TANGRAM_ALL_MASKED_RASTERS  // skip conditional if *only* masked raster sources (always true)
+            #ifndef TANGRAM_ALL_MASKED_RASTERS  // skip source check for masking if *all* raster sources are masked
             if (u_raster_mask_alpha) {
             #else
             {


### PR DESCRIPTION
This PR revamps the logic for applying line dash patterns and textures. The prior logic had some holes and inconsistencies, including #741. It implements the following logic in the fragment shader for lines (and also replaces some conditional `if/else` shader branching with nested `mix` functions):

- A line can have an active texture sampler in two cases:
  - Implicitly, through a `dash` pattern (the texture is automatically generated from the dash pattern).
    - The dash pattern defines a foreground color (via the regular `color` parameter, available in the shader as the vertex `color`) and background color (via the `dash_background_color` parameter, available in the fragment shader as `u_dash_background_color`).
    - The dash texture is a monochrome representation of the pattern, with opaque white for the foreground and transparent black for the background. By using a monochrome texture, the same texture can be reused for the same dash pattern with different foreground/background color combinations.
  - Explicitly, assigned via the `texture` parameter (in `style` or `draw` group).
    - The color values in the texture are meant to be used directly (similar to other style texture sampling behaviors).
- If a line has a dash texture, then in the fragment shader:
  - A uniform `u_has_dash` indicates this, with a float value of `0` or `1`.
  - We determine whether the fragment is in the foreground or background of the dash pattern, and assign the corresponding color, using a `mix` function controlled by the line texture alpha channel (following the monochrome texture described above).
    - `mix(u_dash_background_color, color, _line_color.a), // choose dash foreground or background color`
- If the line has an explicit texture, then in the fragment shader:
  - Apply the vertex `color` to the texture color ("tinting" it), consistent with other similar behaviors, e.g. raster textures on polygons.
    - `color * _line_color, // no dash: tint the line texture with the vertex color`
- The determination of which texture type (dash pattern or explicit texture) to use is accomplished through another `mix` function, controlled by the `u_has_dash` uniform described above.
- Finally, for alpha/blending behavior:
  - When `opaque` blending is active, a simple "alpha cutout" behavior is applied, in which any alpha pixel with an alpha of less than 0.5 (`TANGRAM_ALPHA_TEST`) is discarded. This enables basic transparency-like behavior for dashes and textures when using opaque blending.
  - When other blend modes are active, no special logic is applied, and the alpha value resulting from the above color logic will be used as-is.
