### PR TITLE
skip empty layers

### DIFF
--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -338,6 +338,10 @@ export default class Tile {
                 }
 
                 for (const layer in source_data.layers) {
+                    if (typeof source_data.layers[layer] == 'undefined') { // skip missing data
+                        log('warn', `No data found for ${source_config.source} layer '${layer}', skipping.`);
+                        continue;
+                    }
                     if (source_data.layers[layer].features) {
                         layers.push({ layer, geom: source_data.layers[layer] });
                     }

--- a/src/tile/tile.js
+++ b/src/tile/tile.js
@@ -339,7 +339,7 @@ export default class Tile {
 
                 for (const layer in source_data.layers) {
                     if (typeof source_data.layers[layer] == 'undefined') { // skip missing data
-                        log('warn', `No data found for ${source_config.source} layer '${layer}', skipping.`);
+                        log('warn', `No data found forlayer '${scene_layer_name}', skipping.`);
                         continue;
                     }
                     if (source_data.layers[layer].features) {


### PR DESCRIPTION
This PR addresses errors thrown in an edge case, when an untiled data source is drawn with the `all_layers` flag set:

```yaml
sources:
    untiled:
        type: GeoJSON
        url: geometry.json

layers:
    water:
        data: { source: untiled, all_layers: true }
```

In this case, errors will be thrown, once per worker per tile, if the bounds of the geometry do not intersect the tile, even if `bounds` is set on the datasource:

```js
log.js:50 Tangram v0.20.0 [error]: tile load error for tilezen/16/16/5/6: TypeError: Cannot read property 'features' of undefined
    at Function.getDataForSource (blob:http://localhost:8000/7f727039-252b-43cc-8df8-bbb96e936b31:17445:41)
    at Function.buildGeometry (blob:http://localhost:8000/7f727039-252b-43cc-8df8-bbb96e936b31:17261:32)
    at blob:http://localhost:8000/7f727039-252b-43cc-8df8-bbb96e936b31:20765:26
log @ log.js:50
WorkerBrokerMainThreadHandler @ worker_broker.js:236
log.js:47 Tangram v0.20.0 [error]: Error building tile tilezen/16/16/5/6: TypeError: Cannot read property 'features' of undefined
    at Function.getDataForSource (blob:http://localhost:8000/7f727039-252b-43cc-8df8-bbb96e936b31:17445:41)
    at Function.buildGeometry (blob:http://localhost:8000/7f727039-252b-43cc-8df8-bbb96e936b31:17261:32)
    at blob:http://localhost:8000/7f727039-252b-43cc-8df8-bbb96e936b31:20765:26
log @ log.js:47
```

This PR checks for undefined data within a given layer in a given tile when the `all_layers` flag is set, and replaces the errors with a warning. There may well be a better way to handle this :D
