### PR TITLE
bump earcut version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,9 +2256,9 @@
       }
     },
     "earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha1-FXY05fPrtCIk5HUBboalts5Va0U="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
+      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tangram",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@mapbox/vector-tile": "1.3.0",
     "csscolorparser": "1.0.3",
-    "earcut": "2.1.1",
+    "earcut": "2.2.2",
     "fontfaceobserver": "2.0.7",
     "geojson-vt": "3.2.1",
     "gl-mat3": "1.0.0",


### PR DESCRIPTION
I was seeing some sliver polygons being created - was resolved by bumping `earcut` to the latest. also regenerated the package-lock.json