### PR TITLE
Support variable font weight ranges + JS function weights

### DIFF
--- a/src/styles/text/font_manager.js
+++ b/src/styles/text/font_manager.js
@@ -56,6 +56,12 @@ const FontManager = {
 
         // Wait for font to load
         try {
+            // FontFaceObserver does not directly support variable fonts syntax, which allows for ranges,
+            // e.g. `font-weight: 100 800`. FontFaceObserver will insert the entire string value into a
+            // CSS `font` shorthand property, causing an error. To get around this, we simply take the first
+            // value, because as soon as one variant of the variable font is available, they all should be.
+            // See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide
+            options.weight = typeof options.weight === 'string' ? options.weight.split(' ')[0] : options.weight;
             const observer = new FontFaceObserver(family, options);
             await observer.load();
             // Promise resolves, font is available
@@ -63,7 +69,7 @@ const FontManager = {
         }
         catch (e) {
             // Promise rejects, font is not available
-            log('debug', `Font face '${family}' is NOT available`, options);
+            log('warn', `Font face '${family}' is NOT available`, options, e);
         }
     },
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -276,6 +276,9 @@ export const TextLabels = {
             return;
         }
 
+        // Font weight
+        draw.font.weight = StyleParser.createPropertyCache(draw.font.weight);
+
         // Colors
         draw.font.fill = StyleParser.createPropertyCache(draw.font.fill);
         draw.font.alpha = StyleParser.createPropertyCache(draw.font.alpha);

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -26,7 +26,7 @@ const TextSettings = {
 
     defaults: {
         style: 'normal',
-        weight: null,
+        weight: 'normal',
         size: '12px',
         px_size: 12,
         family: 'Helvetica',
@@ -62,8 +62,11 @@ const TextSettings = {
         // - style: normal, italic, oblique
         // - weight: normal, bold, etc.
         // - transform: capitalize, uppercase, lowercase
-        style.style = draw.font.style || this.defaults.style;
-        style.weight = draw.font.weight || this.defaults.weight;
+
+        // clamp weight to 1-1000 (see https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-number)
+        style.weight = StyleParser.evalCachedProperty(draw.font.weight, context) || this.defaults.weight;
+        style.weight = Math.min(Math.max(style.weight, 1), 1000);
+
         if (draw.font.family) {
             style.family = draw.font.family;
             if (style.family !== this.defaults.family) {
@@ -74,6 +77,7 @@ const TextSettings = {
             style.family = this.defaults.family;
         }
 
+        style.style = draw.font.style || this.defaults.style;
         style.transform = draw.font.transform;
 
         // calculated pixel size


### PR DESCRIPTION
[Variable fonts](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide) allow multiple variants of a font to be stored in a single file. 

Supporting these has several benefits:

- Streamlines the Tangram font definition, e.g. for example instead of 
  ```
    Open Sans:
        - weight: 200
          url: fonts/Open Sans.woff2
        - weight: 400
          url: fonts/Open Sans.woff2
        - weight: 600
          url: fonts/Open Sans.woff2
        - weight: 800
          url: fonts/Open Sans.woff2
  ```
  we can do
  ```
    Open Sans:
        url: fonts/Open Sans.woff2
        weight: 200 800
  ```
- Reduces network requests, requesting one file instead of many.
- Introducing new cartographic flexibility, as some variable fonts can render at intermediate weights along the spectrum, not just at predefined weights.

In CSS, the syntax for variable font weight looks like: `font-weight: 125 950;`.
Tangram font syntax is similarly extended to support this as `weight: 125 950` for a given font within the `fonts` block.

Note that while the variable font spec supports variation for other properties including font stretch and even custom, per-typeface-defined properties, Tangram relies on Canvas text rendering for labels, which unfortunately does not support these properties (font stretch cannot be set even for non-variable fonts).

This PR also enables JS function-based font `weight`, e.g. an example mapping font weight to building heights:

```
weight: |
  function() {
    return (feature.height||0) * 2 + 400;
}
```

![tangram-1591501269395](https://user-images.githubusercontent.com/16733/83959773-38613980-a84f-11ea-9195-f197b736000f.png)
