### PR TITLE
make preserve_tiles_within_zoom an option in tile source config

### DIFF
--- a/src/sources/data_source.js
+++ b/src/sources/data_source.js
@@ -26,6 +26,9 @@ export default class DataSource {
             });
         }
 
+        // Optional setting to keep tiles within a zoom range (higher requires more memory)
+        this.preserve_tiles_within_zoom = config.preserve_tiles_within_zoom;
+
         // Optional function to preprocess source data
         this.preprocess = config.preprocess;
         if (typeof this.preprocess === 'function') {


### PR DESCRIPTION
I didn't see anywhere `preserve_tiles_within_zoom` was being set other than to 0 for raster layers. Is the intention that this can be customized through the YAML? This PR adds it as an option in the YAML like so:

    sources:
        tilezen:
            type: MVT
            url: https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt
            tile_size: 512
            preserve_tiles_within_zoom: 4