### PR TITLE
Add support for text highlight boxes + underlines

### DIFF
--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -494,6 +494,18 @@ StyleParser.evalCachedColorProperty = function(val, context = {}) {
     }
 };
 
+// Evaluate color cache object and apply optional alpha override (alpha arg is a single value cache object)
+StyleParser.evalCachedColorPropertyWithAlpha = function (val, alpha_prop, context) {
+    const color = StyleParser.evalCachedColorProperty(val, context);
+    if (color != null && alpha_prop != null) {
+        const alpha = StyleParser.evalCachedProperty(alpha_prop, context);
+        if (alpha != null) {
+            return [color[0], color[1], color[2], alpha];
+        }
+    }
+    return color;
+};
+
 StyleParser.parseColor = function(val, context = {}) {
     if (typeof val === 'function') {
         val = tryEval(val, context);

--- a/src/styles/style_parser.js
+++ b/src/styles/style_parser.js
@@ -223,6 +223,10 @@ StyleParser.createPointSizePropertyCache = function (obj, texture) {
 };
 
 StyleParser.evalCachedPointSizeProperty = function (val, sprite_info, texture_info, context) {
+    if (val == null) {
+        return;
+    }
+
     // no percentage-based calculation, one cache for all sprites
     if (!val.has_pct && !val.has_ratio) {
         return StyleParser.evalCachedProperty(val, context);
@@ -420,7 +424,10 @@ StyleParser.colorForString = function(string) {
 // (caching the result for future use)
 // { value: original, static: [r,g,b,a], zoom: { z: [r,g,b,a] }, dynamic: function(){...} }
 StyleParser.evalCachedColorProperty = function(val, context = {}) {
-    if (val.dynamic) {
+    if (val == null) {
+        return;
+    }
+    else if (val.dynamic) {
         let v = tryEval(val.dynamic, context);
 
         if (typeof v === 'string') {

--- a/src/styles/text/text_canvas.js
+++ b/src/styles/text/text_canvas.js
@@ -147,7 +147,7 @@ export default class TextCanvas {
         const ctx = this.context;
         const vertical_buffer = this.vertical_text_buffer * dpr;
         const horizontal_buffer = dpr * (stroke_width + this.horizontal_text_buffer);
-        const background_size = background_color ? (this.background_size + background_stroke_width) * dpr : 0;
+        const background_size = (background_color || background_stroke_width) ? (this.background_size + background_stroke_width) * dpr : 0;
         const leading = 2 * dpr; // make configurable and/or use Canvas TextMetrics when available
         const line_height = this.px_size + leading; // px_size already in device pixels
 
@@ -188,20 +188,22 @@ export default class TextCanvas {
         const { dpr, collision_size, texture_size, line_height, horizontal_buffer, vertical_buffer } = size;
 
         // draw optional background box
-        // TODO: allow background stroke without fill?
-        if (text_settings.background_color) {
+        if (text_settings.background_color || text_settings.background_stroke_color) {
             const background_stroke_color = text_settings.background_stroke_color;
             const background_stroke_width = text_settings.background_stroke_width * dpr;
 
             this.context.save();
-            this.context.fillStyle = text_settings.background_color;
-            this.context.fillRect(
-                // shift to "foreground" stroke texture for curved labels (separate stroke and fill textures)
-                x + horizontal_buffer + (label_type === 'curved' ? texture_size[0] : 0) + background_stroke_width,
-                y + vertical_buffer + background_stroke_width,
-                dpr * collision_size[0] - background_stroke_width * 2,
-                dpr * collision_size[1] - background_stroke_width * 2
-            );
+
+            if (text_settings.background_color) {
+                this.context.fillStyle = text_settings.background_color;
+                this.context.fillRect(
+                    // shift to "foreground" stroke texture for curved labels (separate stroke and fill textures)
+                    x + horizontal_buffer + (label_type === 'curved' ? texture_size[0] : 0) + background_stroke_width,
+                    y + vertical_buffer + background_stroke_width,
+                    dpr * collision_size[0] - background_stroke_width * 2,
+                    dpr * collision_size[1] - background_stroke_width * 2
+                );
+            }
 
             // optional stroke around background box
             if (background_stroke_color && background_stroke_width) {

--- a/src/styles/text/text_canvas.js
+++ b/src/styles/text/text_canvas.js
@@ -131,7 +131,7 @@ export default class TextCanvas {
 
     // Computes width and height of text based on current font style
     // Includes word wrapping, returns size info for whole text block and individual lines
-    textSize(style, text, { transform, text_wrap, max_lines, stroke_width = 0, background_color, background_stroke_width = 0, underline_width = 0, supersample }) {
+    textSize(style, text, { transform, text_wrap, max_lines, stroke_width = 0, background_color, background_stroke_width = 0, background_width, underline_width = 0, supersample }) {
         // Check cache first
         TextCanvas.cache.text[style] = TextCanvas.cache.text[style] || {};
         if (TextCanvas.cache.text[style][text]) {
@@ -147,7 +147,10 @@ export default class TextCanvas {
         const ctx = this.context;
         const vertical_buffer = this.vertical_text_buffer * dpr;
         const horizontal_buffer = (stroke_width + this.horizontal_text_buffer) * dpr;
-        const background_size = (background_color || background_stroke_width) ? (this.background_size + background_stroke_width) * dpr : 0;
+
+        background_width = background_width != null ? background_width : this.background_size; // apply default background width
+        const background_size = (background_color || background_stroke_width) ? (background_width + background_stroke_width) * dpr : 0;
+
         const leading = (2 + underline_width + (underline_width ? (stroke_width + 1) : 0)) * dpr; // adjust for underline and text stroke
         const line_height = this.px_size + leading; // px_size already in device pixels
 

--- a/src/styles/text/text_canvas.js
+++ b/src/styles/text/text_canvas.js
@@ -241,7 +241,7 @@ export default class TextCanvas {
 
     // Draw single line of text at specified location, adjusting for buffer and baseline
     drawTextLine(line, [x, y], size, text_settings, type) {
-        const { stroke, stroke_width, underline_color, transform, align = 'center' } = text_settings;
+        const { stroke, stroke_width, transform, align = 'center' } = text_settings;
         const { horizontal_buffer, vertical_buffer, texture_size, background_size, line_height, dpr } = size;
         const underline_width = (text_settings.underline_width || 0) * dpr;
         const text = this.applyTextTransform(line.text, transform);
@@ -266,9 +266,9 @@ export default class TextCanvas {
         const shift = (stroke && stroke_width > 0 && type === 'curved') ? texture_size[0] : 0;
 
         // optional text underline
-        if (underline_color && underline_width) {
+        if (underline_width) {
             this.context.save();
-            this.context.strokeStyle = underline_color;
+            this.context.strokeStyle = this.context.fillStyle;
             this.context.lineWidth = underline_width;
 
             // adjust the underline to account for the text stroke

--- a/src/styles/text/text_canvas.js
+++ b/src/styles/text/text_canvas.js
@@ -175,106 +175,100 @@ export default class TextCanvas {
         // Returns lines (w/per-line info for drawing) and text's overall bounding box + canvas size
         TextCanvas.cache.text[style][text] = {
             lines,
-            size: { collision_size, texture_size, logical_size, line_height, background_size }
+            size: {
+                collision_size, texture_size, logical_size,
+                horizontal_buffer, vertical_buffer, dpr, line_height, background_size
+            }
         };
         return TextCanvas.cache.text[style][text];
     }
 
     // Draw multiple lines of text
-    drawTextMultiLine (lines, [x, y], size, { stroke, stroke_width = 0, background, transform, align, supersample }, type) {
-        // draw optional background box
-        if (background) {
-            const dpr = Utils.device_pixel_ratio * supersample;
-            const horizontal_buffer = dpr * (this.horizontal_text_buffer + stroke_width);
-            const vertical_buffer = dpr * this.vertical_text_buffer;
+    drawTextMultiLine (lines, [x, y], size, text_settings, label_type) {
+        const { dpr, collision_size, texture_size, line_height, horizontal_buffer, vertical_buffer } = size;
 
+        // draw optional background box
+        if (text_settings.background) {
             this.context.save();
-            this.context.fillStyle = background;
+            this.context.fillStyle = text_settings.background;
             this.context.fillRect(
-                x + horizontal_buffer + (type === 'curved' ? size.texture_size[0] : 0),
+                // shift to "foreground" stroke texture for curved labels (separate stroke and fill textures)
+                x + horizontal_buffer + (label_type === 'curved' ? texture_size[0] : 0),
                 y + vertical_buffer,
-                dpr * size.collision_size[0],
-                dpr * size.collision_size[1]
+                dpr * collision_size[0],
+                dpr * collision_size[1]
             );
             this.context.restore();
         }
 
         // draw text
-        let height = y;
+        let ty = y;
         for (let line_num=0; line_num < lines.length; line_num++) {
             let line = lines[line_num];
-            this.drawTextLine(line, [x, height], size, { stroke, stroke_width, transform, align, supersample }, type);
-            height += size.line_height;
+            this.drawTextLine(line, [x, ty], size, text_settings, label_type);
+            ty += line_height;
         }
 
-        // Draw bounding boxes for debugging
-        if (debugSettings.draw_label_collision_boxes) {
-            const dpr = Utils.device_pixel_ratio * supersample;
-            const horizontal_buffer = dpr * (this.horizontal_text_buffer + stroke_width);
-            const vertical_buffer = dpr * this.vertical_text_buffer;
-            const collision_size = size.collision_size;
-            const lineWidth = 2;
+        this.drawTextDebug([x, y], size, label_type);
+    }
 
+    // Draw single line of text at specified location, adjusting for buffer and baseline
+    drawTextLine(line, [x, y], size, text_settings, type) {
+        const { stroke, stroke_width, transform, align = 'center' } = text_settings;
+        const { horizontal_buffer, vertical_buffer, texture_size, background_size, line_height } = size;
+        const text = this.applyTextTransform(line.text, transform);
+
+        // Text alignment
+        let tx;
+        if (align === 'left') {
+            tx = x + horizontal_buffer + background_size;
+        }
+        else if (align === 'center') {
+            tx = x + texture_size[0] / 2 - line.width / 2;
+        }
+        else if (align === 'right') {
+            tx = x + texture_size[0] - line.width - horizontal_buffer - background_size;
+        }
+
+        // In the absence of better Canvas TextMetrics (not supported by browsers yet),
+        // 0.75 buffer produces a better approximate vertical centering of text
+        const ty = y + vertical_buffer * 0.75 + line_height + background_size;
+
+        // Draw stroke and fill separately for curved text. Offset stroke in texture atlas by shift.
+        if (stroke && stroke_width > 0) {
+            let shift = (type === 'curved') ? texture_size[0] : 0;
+            this.context.strokeText(text, tx + shift, ty);
+        }
+        this.context.fillText(text, tx, ty);
+    }
+
+    // Draw optional text debug boxes
+    drawTextDebug ([x, y], size, label_type) {
+        const { dpr, horizontal_buffer, vertical_buffer, texture_size, collision_size } = size;
+        const line_width = 2;
+
+        if (debugSettings.draw_label_collision_boxes) {
             this.context.save();
             this.context.strokeStyle = 'blue';
-            this.context.lineWidth = lineWidth;
+            this.context.lineWidth = line_width;
             this.context.strokeRect(x + horizontal_buffer, y + vertical_buffer, dpr * collision_size[0], dpr * collision_size[1]);
-            if (type === 'curved'){
-                this.context.strokeRect(x + size.texture_size[0] + horizontal_buffer, y + vertical_buffer, dpr * collision_size[0], dpr * collision_size[1]);
+            if (label_type === 'curved'){
+                this.context.strokeRect(x + texture_size[0] + horizontal_buffer, y + vertical_buffer, dpr * collision_size[0], dpr * collision_size[1]);
             }
             this.context.restore();
         }
 
         if (debugSettings.draw_label_texture_boxes) {
-            const texture_size = size.texture_size;
-            const lineWidth = 2;
-
             this.context.save();
             this.context.strokeStyle = 'green';
-            this.context.lineWidth = lineWidth;
+            this.context.lineWidth = line_width;
             // stroke is applied internally, so the outer border is the edge of the texture
-            this.context.strokeRect(x + lineWidth, y + lineWidth, texture_size[0] - 2 * lineWidth, texture_size[1] - 2 * lineWidth);
-            if (type === 'curved') {
-                this.context.strokeRect(x + lineWidth + texture_size[0], y + lineWidth, texture_size[0] - 2 * lineWidth, texture_size[1] - 2 * lineWidth);
+            this.context.strokeRect(x + line_width, y + line_width, texture_size[0] - 2 * line_width, texture_size[1] - 2 * line_width);
+            if (label_type === 'curved') {
+                this.context.strokeRect(x + line_width + texture_size[0], y + line_width, texture_size[0] - 2 * line_width, texture_size[1] - 2 * line_width);
             }
             this.context.restore();
         }
-    }
-
-    // Draw single line of text at specified location, adjusting for buffer and baseline
-    drawTextLine (line, [x, y], size, { stroke, stroke_width = 0, transform, align, supersample }, type) {
-        let dpr = Utils.device_pixel_ratio * supersample;
-        align = align || 'center';
-
-        let vertical_buffer = this.vertical_text_buffer * dpr;
-        let texture_size = size.texture_size;
-        let line_height = size.line_height;
-        let horizontal_buffer = dpr * (stroke_width + this.horizontal_text_buffer);
-
-        let str = this.applyTextTransform(line.text, transform);
-
-        // Text alignment
-        let tx;
-        if (align === 'left') {
-            tx = x + horizontal_buffer + size.background_size;
-        }
-        else if (align === 'center') {
-            tx = x + texture_size[0]/2 - line.width/2;
-        }
-        else if (align === 'right') {
-            tx = x + texture_size[0] - line.width - horizontal_buffer - size.background_size;
-        }
-
-        // In the absence of better Canvas TextMetrics (not supported by browsers yet),
-        // 0.75 buffer produces a better approximate vertical centering of text
-        let ty = y + vertical_buffer * 0.75 + line_height + size.background_size;
-
-        // Draw stroke and fill separately for curved text. Offset stroke in texture atlas by shift.
-        if (stroke && stroke_width > 0) {
-            let shift = (type === 'curved') ? texture_size[0] : 0;
-            this.context.strokeText(str, tx + shift, ty);
-        }
-        this.context.fillText(str, tx, ty);
     }
 
     rasterize (texts, textures, tile_id, texture_prefix, gl) {

--- a/src/styles/text/text_canvas.js
+++ b/src/styles/text/text_canvas.js
@@ -131,7 +131,7 @@ export default class TextCanvas {
 
     // Computes width and height of text based on current font style
     // Includes word wrapping, returns size info for whole text block and individual lines
-    textSize(style, text, { transform, text_wrap, max_lines, stroke_width = 0, background_color, background_stroke_width, supersample}) {
+    textSize(style, text, { transform, text_wrap, max_lines, stroke_width = 0, background_color, background_stroke_width = 0, supersample}) {
         // Check cache first
         TextCanvas.cache.text[style] = TextCanvas.cache.text[style] || {};
         if (TextCanvas.cache.text[style][text]) {
@@ -190,7 +190,7 @@ export default class TextCanvas {
         // draw optional background box
         if (text_settings.background_color || text_settings.background_stroke_color) {
             const background_stroke_color = text_settings.background_stroke_color;
-            const background_stroke_width = text_settings.background_stroke_width * dpr;
+            const background_stroke_width = (text_settings.background_stroke_width || 0) * dpr;
 
             this.context.save();
 

--- a/src/styles/text/text_canvas.js
+++ b/src/styles/text/text_canvas.js
@@ -131,7 +131,7 @@ export default class TextCanvas {
 
     // Computes width and height of text based on current font style
     // Includes word wrapping, returns size info for whole text block and individual lines
-    textSize (style, text, {transform, text_wrap, max_lines, stroke_width = 0, background, supersample}) {
+    textSize(style, text, { transform, text_wrap, max_lines, stroke_width = 0, background_color, background_stroke_width, supersample}) {
         // Check cache first
         TextCanvas.cache.text[style] = TextCanvas.cache.text[style] || {};
         if (TextCanvas.cache.text[style][text]) {
@@ -147,7 +147,7 @@ export default class TextCanvas {
         const ctx = this.context;
         const vertical_buffer = this.vertical_text_buffer * dpr;
         const horizontal_buffer = dpr * (stroke_width + this.horizontal_text_buffer);
-        const background_size = background ? this.background_size * dpr : 0;
+        const background_size = background_color ? (this.background_size + background_stroke_width) * dpr : 0;
         const leading = 2 * dpr; // make configurable and/or use Canvas TextMetrics when available
         const line_height = this.px_size + leading; // px_size already in device pixels
 
@@ -188,16 +188,35 @@ export default class TextCanvas {
         const { dpr, collision_size, texture_size, line_height, horizontal_buffer, vertical_buffer } = size;
 
         // draw optional background box
-        if (text_settings.background) {
+        // TODO: allow background stroke without fill?
+        if (text_settings.background_color) {
+            const background_stroke_color = text_settings.background_stroke_color;
+            const background_stroke_width = text_settings.background_stroke_width * dpr;
+
             this.context.save();
-            this.context.fillStyle = text_settings.background;
+            this.context.fillStyle = text_settings.background_color;
             this.context.fillRect(
                 // shift to "foreground" stroke texture for curved labels (separate stroke and fill textures)
-                x + horizontal_buffer + (label_type === 'curved' ? texture_size[0] : 0),
-                y + vertical_buffer,
-                dpr * collision_size[0],
-                dpr * collision_size[1]
+                x + horizontal_buffer + (label_type === 'curved' ? texture_size[0] : 0) + background_stroke_width,
+                y + vertical_buffer + background_stroke_width,
+                dpr * collision_size[0] - background_stroke_width * 2,
+                dpr * collision_size[1] - background_stroke_width * 2
             );
+
+            // optional stroke around background box
+            if (background_stroke_color && background_stroke_width) {
+                this.context.strokeStyle = background_stroke_color;
+                this.context.lineWidth = background_stroke_width;
+                this.context.strokeRect(
+                    // shift to "foreground" stroke texture for curved labels (separate stroke and fill textures)
+                    x + horizontal_buffer + (label_type === 'curved' ? texture_size[0] : 0) + background_stroke_width * 0.5,
+                    y + vertical_buffer + background_stroke_width * 0.5,
+                    dpr * collision_size[0] - background_stroke_width,
+                    dpr * collision_size[1] - background_stroke_width
+                );
+
+            }
+
             this.context.restore();
         }
 

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -278,6 +278,7 @@ export const TextLabels = {
 
         // Colors
         draw.font.fill = StyleParser.createPropertyCache(draw.font.fill);
+        draw.font.background = StyleParser.createPropertyCache(draw.font.background);
         draw.font.alpha = StyleParser.createPropertyCache(draw.font.alpha);
         if (draw.font.stroke) {
             draw.font.stroke.color = StyleParser.createPropertyCache(draw.font.stroke.color);

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -277,7 +277,7 @@ export const TextLabels = {
         }
 
         // Colors
-        draw.font.fill = StyleParser.createPropertyCache(draw.font.fill);
+        draw.font.fill = StyleParser.createPropertyCache(draw.font.fill || TextSettings.defaults.fill);
         draw.font.alpha = StyleParser.createPropertyCache(draw.font.alpha);
         if (draw.font.stroke) {
             draw.font.stroke.color = StyleParser.createPropertyCache(draw.font.stroke.color);

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -36,7 +36,7 @@ export const TextLabels = {
         }
 
         // Compute text style and layout settings for this feature label
-        let text_settings = TextSettings.compute(feature, draw, context);
+        let text_settings = TextSettings.compute(draw, context);
         let text_settings_key = TextSettings.key(text_settings);
 
         // first label in tile, or with this style?

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -279,10 +279,17 @@ export const TextLabels = {
         // Colors
         draw.font.fill = StyleParser.createPropertyCache(draw.font.fill || TextSettings.defaults.fill);
         draw.font.alpha = StyleParser.createPropertyCache(draw.font.alpha);
+
         if (draw.font.stroke) {
             draw.font.stroke.color = StyleParser.createPropertyCache(draw.font.stroke.color);
             draw.font.stroke.alpha = StyleParser.createPropertyCache(draw.font.stroke.alpha);
         }
+
+        if (draw.font.underline) {
+            draw.font.underline.color = StyleParser.createPropertyCache(draw.font.underline.color);
+            draw.font.underline.alpha = StyleParser.createPropertyCache(draw.font.underline.alpha);
+        }
+
         if (draw.font.background) {
             draw.font.background.color = StyleParser.createPropertyCache(draw.font.background.color);
             draw.font.background.alpha = StyleParser.createPropertyCache(draw.font.background.alpha);
@@ -294,9 +301,15 @@ export const TextLabels = {
 
         // Convert font and text stroke sizes
         draw.font.px_size = StyleParser.createPropertyCache(draw.font.size || TextSettings.defaults.size, TextCanvas.fontPixelSize, TextCanvas.fontPixelSize);
+
         if (draw.font.stroke && draw.font.stroke.width != null) {
             draw.font.stroke.width = StyleParser.createPropertyCache(draw.font.stroke.width, StyleParser.parsePositiveNumber);
         }
+
+        if (draw.font.underline && draw.font.underline.width != null) {
+            draw.font.underline.width = StyleParser.createPropertyCache(draw.font.underline.width, StyleParser.parsePositiveNumber);
+        }
+
         if (draw.font.background && draw.font.background.stroke && draw.font.background.stroke.width != null) {
             draw.font.background.stroke.width = StyleParser.createPropertyCache(draw.font.background.stroke.width, StyleParser.parsePositiveNumber);
         }

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -278,17 +278,27 @@ export const TextLabels = {
 
         // Colors
         draw.font.fill = StyleParser.createPropertyCache(draw.font.fill);
-        draw.font.background = StyleParser.createPropertyCache(draw.font.background);
         draw.font.alpha = StyleParser.createPropertyCache(draw.font.alpha);
         if (draw.font.stroke) {
             draw.font.stroke.color = StyleParser.createPropertyCache(draw.font.stroke.color);
             draw.font.stroke.alpha = StyleParser.createPropertyCache(draw.font.stroke.alpha);
+        }
+        if (draw.font.background) {
+            draw.font.background.color = StyleParser.createPropertyCache(draw.font.background.color);
+            draw.font.background.alpha = StyleParser.createPropertyCache(draw.font.background.alpha);
+            if (draw.font.background.stroke) {
+                draw.font.background.stroke.color = StyleParser.createPropertyCache(draw.font.background.stroke.color);
+                draw.font.background.stroke.alpha = StyleParser.createPropertyCache(draw.font.background.stroke.alpha);
+            }
         }
 
         // Convert font and text stroke sizes
         draw.font.px_size = StyleParser.createPropertyCache(draw.font.size || TextSettings.defaults.size, TextCanvas.fontPixelSize, TextCanvas.fontPixelSize);
         if (draw.font.stroke && draw.font.stroke.width != null) {
             draw.font.stroke.width = StyleParser.createPropertyCache(draw.font.stroke.width, StyleParser.parsePositiveNumber);
+        }
+        if (draw.font.background && draw.font.background.stroke && draw.font.background.stroke.width != null) {
+            draw.font.background.stroke.width = StyleParser.createPropertyCache(draw.font.background.stroke.width, StyleParser.parsePositiveNumber);
         }
 
         // Offset (2d array)

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -285,11 +285,6 @@ export const TextLabels = {
             draw.font.stroke.alpha = StyleParser.createPropertyCache(draw.font.stroke.alpha);
         }
 
-        if (draw.font.underline) {
-            draw.font.underline.color = StyleParser.createPropertyCache(draw.font.underline.color);
-            draw.font.underline.alpha = StyleParser.createPropertyCache(draw.font.underline.alpha);
-        }
-
         if (draw.font.background) {
             draw.font.background.color = StyleParser.createPropertyCache(draw.font.background.color);
             draw.font.background.alpha = StyleParser.createPropertyCache(draw.font.background.alpha);
@@ -305,10 +300,6 @@ export const TextLabels = {
 
         if (draw.font.stroke && draw.font.stroke.width != null) {
             draw.font.stroke.width = StyleParser.createPropertyCache(draw.font.stroke.width, StyleParser.parsePositiveNumber);
-        }
-
-        if (draw.font.underline && draw.font.underline.width != null) {
-            draw.font.underline.width = StyleParser.createPropertyCache(draw.font.underline.width, StyleParser.parsePositiveNumber);
         }
 
         if (draw.font.background && draw.font.background.stroke && draw.font.background.stroke.width != null) {

--- a/src/styles/text/text_labels.js
+++ b/src/styles/text/text_labels.js
@@ -293,6 +293,7 @@ export const TextLabels = {
         if (draw.font.background) {
             draw.font.background.color = StyleParser.createPropertyCache(draw.font.background.color);
             draw.font.background.alpha = StyleParser.createPropertyCache(draw.font.background.alpha);
+            draw.font.background.width = StyleParser.createPropertyCache(draw.font.background.width, StyleParser.parsePositiveNumber);
             if (draw.font.background.stroke) {
                 draw.font.background.stroke.color = StyleParser.createPropertyCache(draw.font.background.stroke.color);
                 draw.font.background.stroke.alpha = StyleParser.createPropertyCache(draw.font.background.stroke.alpha);

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -16,6 +16,7 @@ const TextSettings = {
             settings.fill,
             settings.stroke,
             settings.stroke_width,
+            settings.background,
             settings.transform,
             settings.text_wrap,
             settings.max_lines,
@@ -38,7 +39,8 @@ const TextSettings = {
     },
 
     compute (feature, draw, context) {
-        let style = {};
+        const style = {};
+        const geomType = Geo.geometryType(feature.geometry.type);
 
         draw.font = draw.font || this.defaults;
 
@@ -47,14 +49,23 @@ const TextSettings = {
 
         // Use fill if specified, or default
         style.fill = draw.font.fill && StyleParser.evalCachedColorProperty(draw.font.fill, context);
+        if (geomType === 'point') { // background color box for point labels only
+            style.background = draw.font.background && StyleParser.evalCachedColorProperty(draw.font.background, context);
+        }
 
         // optional alpha override
         const alpha = StyleParser.evalCachedProperty(draw.font.alpha, context);
         if (alpha != null) {
             style.fill = [...(style.fill ? style.fill : this.defaults.fill_array)]; // copy to avoid modifying underlying object
             style.fill[3] = alpha;
+
+            if (style.background) {
+                style.background = [...style.background]; // copy to avoid modifying underlying object
+                style.background[3] = alpha;
+            }
         }
         style.fill = (style.fill && Utils.toCSSColor(style.fill)) || this.defaults.fill; // convert to CSS for Canvas
+        style.background = (style.background && Utils.toCSSColor(style.background));
 
         // Font properties are modeled after CSS names:
         // - family: Helvetica, Futura, etc.
@@ -101,7 +112,7 @@ const TextSettings = {
         // Not a font properties, but affect atlas of unique text textures
         let text_wrap = draw.text_wrap; // use explicitly set value
 
-        if (text_wrap == null && Geo.geometryType(feature.geometry.type) !== 'line') {
+        if (text_wrap == null && geomType !== 'line') {
             // point labels (for point and polygon features) have word wrap on w/default max length,
             // line labels default off
             text_wrap = true;

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -32,8 +32,7 @@ const TextSettings = {
         size: '12px',
         px_size: 12,
         family: 'Helvetica',
-        fill: 'white',
-        fill_array: [1, 1, 1, 1],
+        fill: [1, 1, 1, 1],
         text_wrap: 15,
         max_lines: 5,
         align: 'center'
@@ -48,53 +47,28 @@ const TextSettings = {
         style.can_articulate = draw.can_articulate;
 
         // Text fill
-        style.fill = StyleParser.evalCachedColorProperty(draw.font.fill, context);
-        const alpha = StyleParser.evalCachedProperty(draw.font.alpha, context); // optional alpha override
-        if (alpha != null) {
-            style.fill = [...(style.fill ? style.fill : this.defaults.fill_array)]; // copy to avoid modifying underlying object
-            style.fill[3] = alpha;
-        }
-        style.fill = (style.fill && Utils.toCSSColor(style.fill)) || this.defaults.fill; // convert to CSS for Canvas
+        style.fill = StyleParser.evalCachedColorPropertyWithAlpha(draw.font.fill, draw.font.alpha, context);
+        style.fill = Utils.toCSSColor(style.fill); // convert to CSS for Canvas
 
         // Text stroke
         if (draw.font.stroke && draw.font.stroke.color) {
-            style.stroke = StyleParser.evalCachedColorProperty(draw.font.stroke.color, context);
-            if (style.stroke) {
-                // optional alpha override
-                const stroke_alpha = StyleParser.evalCachedProperty(draw.font.stroke.alpha, context);
-                if (stroke_alpha != null) {
-                    style.stroke = [...style.stroke]; // copy to avoid modifying underlying object
-                    style.stroke[3] = stroke_alpha;
-                }
-                style.stroke = Utils.toCSSColor(style.stroke); // convert to CSS for Canvas
-            }
+            style.stroke = StyleParser.evalCachedColorPropertyWithAlpha(draw.font.stroke.color, draw.font.stroke.alpha, context);
+            style.stroke = Utils.toCSSColor(style.stroke); // convert to CSS for Canvas
             style.stroke_width = StyleParser.evalCachedProperty(draw.font.stroke.width, context);
         }
 
         // Background box
         if (draw.font.background && !style.can_articulate) { // supported for point labels only
             // Background fill
-            style.background_color = StyleParser.evalCachedColorProperty(draw.font.background.color, context);
-            if (style.background_color) {
-                const background_alpha = StyleParser.evalCachedProperty(draw.font.background.alpha, context);
-                if (background_alpha) {
-                    style.background_color = [...style.background_color];
-                    style.background_color[3] = background_alpha;
-                }
-                style.background_color = Utils.toCSSColor(style.background_color); // convert to CSS for Canvas
-            }
+            style.background_color = StyleParser.evalCachedColorPropertyWithAlpha(draw.font.background.color, draw.font.background.alpha, context);
+            style.background_color = Utils.toCSSColor(style.background_color); // convert to CSS for Canvas
 
             // Background stroke
             style.background_stroke_color =
                 draw.font.background.stroke &&
                 draw.font.background.stroke.color &&
-                StyleParser.evalCachedColorProperty(draw.font.background.stroke.color, context);
+            StyleParser.evalCachedColorPropertyWithAlpha(draw.font.background.stroke.color, draw.font.background.stroke.alpha, context);
             if (style.background_stroke_color) {
-                const background_stroke_alpha = StyleParser.evalCachedProperty(draw.font.background.stroke.alpha, context);
-                if (background_stroke_alpha) {
-                    style.background_stroke_color = [...style.background_stroke_color];
-                    style.background_stroke_color[3] = background_stroke_alpha;
-                }
                 style.background_stroke_color = Utils.toCSSColor(style.background_stroke_color); // convert to CSS for Canvas
 
                 // default background stroke to 1px when stroke color but no stroke width specified

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -40,7 +40,6 @@ const TextSettings = {
 
     compute (feature, draw, context) {
         const style = {};
-        const geomType = Geo.geometryType(feature.geometry.type);
 
         draw.font = draw.font || this.defaults;
 
@@ -49,7 +48,7 @@ const TextSettings = {
 
         // Use fill if specified, or default
         style.fill = draw.font.fill && StyleParser.evalCachedColorProperty(draw.font.fill, context);
-        if (geomType === 'point') { // background color box for point labels only
+        if (!style.can_articulate) { // background color box for point labels only
             style.background = draw.font.background && StyleParser.evalCachedColorProperty(draw.font.background, context);
         }
 
@@ -112,7 +111,7 @@ const TextSettings = {
         // Not a font properties, but affect atlas of unique text textures
         let text_wrap = draw.text_wrap; // use explicitly set value
 
-        if (text_wrap == null && geomType !== 'line') {
+        if (text_wrap == null && !style.can_articulate) {
             // point labels (for point and polygon features) have word wrap on w/default max length,
             // line labels default off
             text_wrap = true;

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -1,5 +1,4 @@
 import Utils from '../../utils/utils';
-import Geo from '../../utils/geo';
 import StyleParser from '../style_parser';
 
 export default TextSettings;
@@ -38,7 +37,7 @@ const TextSettings = {
         align: 'center'
     },
 
-    compute (feature, draw, context) {
+    compute (draw, context) {
         const style = {};
 
         draw.font = draw.font || this.defaults;

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -15,6 +15,8 @@ const TextSettings = {
             settings.fill,
             settings.stroke,
             settings.stroke_width,
+            settings.underline_color,
+            settings.underline_width,
             settings.background_color,
             settings.background_stroke_color,
             settings.background_stroke_width,
@@ -55,6 +57,17 @@ const TextSettings = {
             style.stroke = StyleParser.evalCachedColorPropertyWithAlpha(draw.font.stroke.color, draw.font.stroke.alpha, context);
             style.stroke = Utils.toCSSColor(style.stroke); // convert to CSS for Canvas
             style.stroke_width = StyleParser.evalCachedProperty(draw.font.stroke.width, context);
+        }
+
+        // Text underline
+        if (draw.font.underline && draw.font.underline.color && !style.can_articulate) {
+            style.underline_color = Utils.toCSSColor(
+                StyleParser.evalCachedColorPropertyWithAlpha(draw.font.underline.color, draw.font.underline.alpha, context));
+            if (style.underline_color) {
+                // default underline to 1px when color but no width specified
+                style.underline_width = draw.font.underline.width != null ?
+                    StyleParser.evalCachedProperty(draw.font.underline.width, context) : 1;
+            }
         }
 
         // Background box

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -15,7 +15,9 @@ const TextSettings = {
             settings.fill,
             settings.stroke,
             settings.stroke_width,
-            settings.background,
+            settings.background_color,
+            settings.background_stroke_color,
+            settings.background_stroke_width,
             settings.transform,
             settings.text_wrap,
             settings.max_lines,
@@ -45,25 +47,61 @@ const TextSettings = {
         // LineString labels can articulate while point labels cannot. Needed for future texture coordinate calculations.
         style.can_articulate = draw.can_articulate;
 
-        // Use fill if specified, or default
+        // Text fill
         style.fill = draw.font.fill && StyleParser.evalCachedColorProperty(draw.font.fill, context);
-        if (!style.can_articulate) { // background color box for point labels only
-            style.background = draw.font.background && StyleParser.evalCachedColorProperty(draw.font.background, context);
-        }
-
-        // optional alpha override
-        const alpha = StyleParser.evalCachedProperty(draw.font.alpha, context);
+        const alpha = StyleParser.evalCachedProperty(draw.font.alpha, context); // optional alpha override
         if (alpha != null) {
             style.fill = [...(style.fill ? style.fill : this.defaults.fill_array)]; // copy to avoid modifying underlying object
             style.fill[3] = alpha;
-
-            if (style.background) {
-                style.background = [...style.background]; // copy to avoid modifying underlying object
-                style.background[3] = alpha;
-            }
         }
         style.fill = (style.fill && Utils.toCSSColor(style.fill)) || this.defaults.fill; // convert to CSS for Canvas
-        style.background = (style.background && Utils.toCSSColor(style.background));
+
+        // Text stroke
+        if (draw.font.stroke && draw.font.stroke.color) {
+            style.stroke = StyleParser.evalCachedColorProperty(draw.font.stroke.color, context);
+            if (style.stroke) {
+                // optional alpha override
+                const stroke_alpha = StyleParser.evalCachedProperty(draw.font.stroke.alpha, context);
+                if (stroke_alpha != null) {
+                    style.stroke = [...style.stroke]; // copy to avoid modifying underlying object
+                    style.stroke[3] = stroke_alpha;
+                }
+                style.stroke = Utils.toCSSColor(style.stroke); // convert to CSS for Canvas
+            }
+            style.stroke_width = StyleParser.evalCachedProperty(draw.font.stroke.width, context);
+        }
+
+        // Background box
+        if (draw.font.background && !style.can_articulate) { // supported for point labels only
+            // Background fill
+            style.background_color = draw.font.background.color && StyleParser.evalCachedColorProperty(draw.font.background.color, context);
+            if (style.background_color) {
+                const background_alpha = draw.font.background.alpha && StyleParser.evalCachedProperty(draw.font.background.alpha, context);
+                if (background_alpha) {
+                    style.background_color = [...style.background_color];
+                    style.background_color[3] = background_alpha;
+                }
+                style.background_color = Utils.toCSSColor(style.background_color); // convert to CSS for Canvas
+            }
+
+            // Background stroke
+            style.background_stroke_color =
+                draw.font.background.stroke &&
+                draw.font.background.stroke.color &&
+                StyleParser.evalCachedColorProperty(draw.font.background.stroke.color, context);
+            if (style.background_stroke_color) {
+                const background_stroke_alpha = draw.font.background.stroke.alpha && StyleParser.evalCachedProperty(draw.font.background.stroke.alpha, context);
+                if (background_stroke_alpha) {
+                    style.background_stroke_color = [...style.background_stroke_color];
+                    style.background_stroke_color[3] = background_stroke_alpha;
+                }
+                style.background_stroke_color = Utils.toCSSColor(style.background_stroke_color); // convert to CSS for Canvas
+
+                // default background stroke to 1px when stroke color but no stroke width specified
+                style.background_stroke_width = draw.font.background.stroke.width != null ?
+                    StyleParser.evalCachedProperty(draw.font.background.stroke.width, context) : 1;
+            }
+        }
 
         // Font properties are modeled after CSS names:
         // - family: Helvetica, Futura, etc.
@@ -88,21 +126,6 @@ const TextSettings = {
         // calculated pixel size
         style.supersample = draw.supersample_text ? 1.5 : 1; // optionally render text at 150% to improve clarity
         style.px_size = StyleParser.evalCachedProperty(draw.font.px_size, context) * style.supersample;
-
-        // Use stroke if specified
-        if (draw.font.stroke && draw.font.stroke.color) {
-            style.stroke = StyleParser.evalCachedColorProperty(draw.font.stroke.color, context);
-            if (style.stroke) {
-                // optional alpha override
-                const stroke_alpha = StyleParser.evalCachedProperty(draw.font.stroke.alpha, context);
-                if (stroke_alpha != null) {
-                    style.stroke = [...style.stroke]; // copy to avoid modifying underlying object
-                    style.stroke[3] = stroke_alpha;
-                }
-                style.stroke = Utils.toCSSColor(style.stroke); // convert to CSS for Canvas
-            }
-            style.stroke_width = StyleParser.evalCachedProperty(draw.font.stroke.width, context);
-        }
 
         style.font_css = this.fontCSS(style);
 

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -18,6 +18,7 @@ const TextSettings = {
             settings.underline_color,
             settings.underline_width,
             settings.background_color,
+            settings.background_width,
             settings.background_stroke_color,
             settings.background_stroke_width,
             settings.transform,
@@ -75,6 +76,9 @@ const TextSettings = {
             // Background fill
             style.background_color = StyleParser.evalCachedColorPropertyWithAlpha(draw.font.background.color, draw.font.background.alpha, context);
             style.background_color = Utils.toCSSColor(style.background_color); // convert to CSS for Canvas
+            if (style.background_color) {
+                style.background_width = StyleParser.evalCachedProperty(draw.font.background.width, context);
+            }
 
             // Background stroke
             style.background_stroke_color =

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -48,7 +48,7 @@ const TextSettings = {
         style.can_articulate = draw.can_articulate;
 
         // Text fill
-        style.fill = draw.font.fill && StyleParser.evalCachedColorProperty(draw.font.fill, context);
+        style.fill = StyleParser.evalCachedColorProperty(draw.font.fill, context);
         const alpha = StyleParser.evalCachedProperty(draw.font.alpha, context); // optional alpha override
         if (alpha != null) {
             style.fill = [...(style.fill ? style.fill : this.defaults.fill_array)]; // copy to avoid modifying underlying object
@@ -74,9 +74,9 @@ const TextSettings = {
         // Background box
         if (draw.font.background && !style.can_articulate) { // supported for point labels only
             // Background fill
-            style.background_color = draw.font.background.color && StyleParser.evalCachedColorProperty(draw.font.background.color, context);
+            style.background_color = StyleParser.evalCachedColorProperty(draw.font.background.color, context);
             if (style.background_color) {
-                const background_alpha = draw.font.background.alpha && StyleParser.evalCachedProperty(draw.font.background.alpha, context);
+                const background_alpha = StyleParser.evalCachedProperty(draw.font.background.alpha, context);
                 if (background_alpha) {
                     style.background_color = [...style.background_color];
                     style.background_color[3] = background_alpha;
@@ -90,7 +90,7 @@ const TextSettings = {
                 draw.font.background.stroke.color &&
                 StyleParser.evalCachedColorProperty(draw.font.background.stroke.color, context);
             if (style.background_stroke_color) {
-                const background_stroke_alpha = draw.font.background.stroke.alpha && StyleParser.evalCachedProperty(draw.font.background.stroke.alpha, context);
+                const background_stroke_alpha = StyleParser.evalCachedProperty(draw.font.background.stroke.alpha, context);
                 if (background_stroke_alpha) {
                     style.background_stroke_color = [...style.background_stroke_color];
                     style.background_stroke_color[3] = background_stroke_alpha;

--- a/src/styles/text/text_settings.js
+++ b/src/styles/text/text_settings.js
@@ -15,7 +15,6 @@ const TextSettings = {
             settings.fill,
             settings.stroke,
             settings.stroke_width,
-            settings.underline_color,
             settings.underline_width,
             settings.background_color,
             settings.background_width,
@@ -46,6 +45,8 @@ const TextSettings = {
 
         draw.font = draw.font || this.defaults;
 
+        style.supersample = draw.supersample_text ? 1.5 : 1; // optionally render text at 150% to improve clarity
+
         // LineString labels can articulate while point labels cannot. Needed for future texture coordinate calculations.
         style.can_articulate = draw.can_articulate;
 
@@ -61,14 +62,8 @@ const TextSettings = {
         }
 
         // Text underline
-        if (draw.font.underline && draw.font.underline.color && !style.can_articulate) {
-            style.underline_color = Utils.toCSSColor(
-                StyleParser.evalCachedColorPropertyWithAlpha(draw.font.underline.color, draw.font.underline.alpha, context));
-            if (style.underline_color) {
-                // default underline to 1px when color but no width specified
-                style.underline_width = draw.font.underline.width != null ?
-                    StyleParser.evalCachedProperty(draw.font.underline.width, context) : 1;
-            }
+        if (draw.font.underline === true && !style.can_articulate) {
+            style.underline_width = 1.5 * style.supersample;
         }
 
         // Background box
@@ -115,7 +110,6 @@ const TextSettings = {
         style.transform = draw.font.transform;
 
         // calculated pixel size
-        style.supersample = draw.supersample_text ? 1.5 : 1; // optionally render text at 150% to improve clarity
         style.px_size = StyleParser.evalCachedProperty(draw.font.px_size, context) * style.supersample;
 
         style.font_css = this.fontCSS(style);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -234,9 +234,11 @@ Utils.interpolate = function(x, points, transform) {
 };
 
 Utils.toCSSColor = function (color) {
-    if (color[3] === 1) { // full opacity
-        return `rgb(${color.slice(0, 3).map(c => Math.round(c * 255)).join(', ')})`;
+    if (color != null) {
+        if (color[3] === 1) { // full opacity
+            return `rgb(${color.slice(0, 3).map(c => Math.round(c * 255)).join(', ')})`;
+        }
+        // RGB is between [0, 255] opacity is between [0, 1]
+        return `rgba(${color.map((c, i) => (i < 3 && Math.round(c * 255)) || c).join(', ')})`;
     }
-    // RGB is between [0, 255] opacity is between [0, 1]
-    return `rgba(${color.map((c, i) => (i < 3 && Math.round(c * 255)) || c).join(', ')})`;
 };


### PR DESCRIPTION
See #724. Adds support for an optional box behind text labels, which adds the following parameters, in a new `font.background` block:

- Text box **fill color**
  - `font.background.color`
  - Optionally vary alpha independently: `font.background.alpha`
- Text box **stroke color**
  - `font.background.stroke.color`
  - Optionally vary alpha independently: `font.background.stroke.alpha`
- Text box **stroke width**:
  - `font.background.stroke.width`
  - Values in pixels, as with `font.stroke.width`
    - e.g. `font.background.stroke.width: 2px` (explicit) or `font.background.stroke.width: 2` (implicit)
  - Defaults to `1px` when `font.background.stroke.color` is not null
- Text background fill and stroke are both incorporated into the label's collision box.

**Examples**

Fill only:

```
draw:
  text:
    ...
    font:
      ...
      background:
        color: red
```

![tangram-1593906832593](https://user-images.githubusercontent.com/16733/86522707-1a77fc00-be30-11ea-9f14-5f9f3be51a1a.png)

Fill and stroke:

```
draw:
  text:
    ...
    font:
      ...
      background:
        color: red
        stroke:
          color: black
          width: 2px
```

![tangram-1593906900223](https://user-images.githubusercontent.com/16733/86522727-57dc8980-be30-11ea-81c2-592e03e345d2.png)

Stroke only:

```
draw:
  text:
    ...
    font:
      ...
      background:
        stroke:
          color: black
```

![tangram-1593907009480](https://user-images.githubusercontent.com/16733/86522742-88bcbe80-be30-11ea-87e4-1cffe55a11e0.png)

All parameters can accept JS functions (alpha and stroke width shown here):

```
draw:
  text:
    ...
    font:
      ...
      background:
        color: red
        alpha: function() { return Math.min(Math.max(feature.kind_tile_rank - 4, 0), 20) / 8 + .35 }
        stroke:
          color: black
          width: function() { return Math.min(Math.max(feature.kind_tile_rank - 4, 1), 8) }
```

![tangram-1593907059790](https://user-images.githubusercontent.com/16733/86522756-ba358a00-be30-11ea-9c13-6a0e6f365963.png)

**Open Questions**

- For terminology, I was unsure of the following choices:
  - I used `font.background.color` instead of `font.background.fill`. Generally, `color` is more common than `fill` in Tangram, and the latter always felt like a bit of an outlier. That said, there's an argument for using it here for consistency with `font.fill`.
  - I used `font.background.stroke`, with `font.background.stroke.{color|width}`, which does follow `font.stroke.{color|width}`. An alternative would be `outline`, to match shape outlines for `lines` and `points`.
- I included support for `alpha` overrides, to match recently added functionality for all other color properties. Seems like potential overkill, but it's consistent.
- There's no limit on `font.background.stroke.width`. There's some implementation-specific limit, but for instance `stroke: 64px` does work:
![tangram-1593919222805](https://user-images.githubusercontent.com/16733/86524799-0a224a00-be4d-11ea-8f33-f7b1d0bdeb47.png)
