### PR TITLE
proxy tiles don't depend on scroll direction

### DIFF
--- a/src/tile/tile_manager.js
+++ b/src/tile/tile_manager.js
@@ -203,17 +203,12 @@ export default class TileManager {
 
         let proxy = false;
         this.forEachTile(tile => {
-            if (this.view.zoom_direction === 1) {
-                if (tile.visible && !tile.labeled) {
-                    const parent = this.pyramid.getAncestor(tile);
-                    if (parent) {
-                        parent.setProxyFor(tile);
-                        proxy = true;
-                    }
-                }
-            }
-            else if (this.view.zoom_direction === -1) {
-                if (tile.visible && !tile.labeled) {
+            if (tile.visible && !tile.labeled) {
+                const parent = this.pyramid.getAncestor(tile);
+                if (parent) {
+                    parent.setProxyFor(tile);
+                    proxy = true;
+                } else {
                     const descendants = this.pyramid.getDescendants(tile);
                     for (let i=0; i < descendants.length; i++) {
                         descendants[i].setProxyFor(tile);


### PR DESCRIPTION
The visibility of over/underzoomed "proxy tiles" when the current view tiles aren't done loading was determined by the instantaneous view state: +1 when zooming in, -1 when zooming out. This assumed that ZOOM-1 tiles are loaded when zooming in, and ZOOM+1 tiles are loaded when zooming out. This assumption works fine when slowly paging through zooms in one direction, letting each layer load at a time, but breaks down if the direction of the scroll is reversed within a zoom level that isn't done loading.

Comparison video of before/after, that flies 4 zoom levels in in 300ms, and 2 levels out in another 300ms:

[Video Link (mp4)](https://bdon.s3.amazonaws.com/tileload.mp4)

This doesn't solve all visibility issues related to flickering tiles I've noticed - may demand a larger rethinking of how TilePyramid and tile visibility/proxy tile states work