### PR TITLE
If no explicit attribution in leafletLayer, use attribution in YAML sources

### DIFF
--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -166,6 +166,12 @@ function extendLeaflet(options) {
                         blocking: false
                     }).then(() => {
 
+                    if (!this.options.attribution) {
+                        for (const [key, value] of Object.entries(this.scene.config.sources)) {
+                            if (value.attribution) map.attributionControl.addAttribution(value.attribution)
+                        }
+                    }
+
                     this._updating_tangram = true;
 
                     this.updateSize();

--- a/src/leaflet_layer.js
+++ b/src/leaflet_layer.js
@@ -167,8 +167,10 @@ function extendLeaflet(options) {
                     }).then(() => {
 
                     if (!this.options.attribution) {
-                        for (const [key, value] of Object.entries(this.scene.config.sources)) {
-                            if (value.attribution) map.attributionControl.addAttribution(value.attribution)
+                        for (const [, value] of Object.entries(this.scene.config.sources)) {
+                            if (value.attribution) {
+                                map.attributionControl.addAttribution(value.attribution);
+                            }
                         }
                     }
 


### PR DESCRIPTION
This is more similar to the behavior of Leaflet raster tiles where each individual tile layer can have an attribution. Because a TangramLayer can use multiple tile sources, this lets the attribution for each source be specified in YAML, and then these are added together in the case that no explicit 'attribution' prop is passed to LeafletLayer.