### PR TITLE
Resolve texture imports using final merged scene

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,14 +64,14 @@ module.exports = function (config) {
                     include: ['**/*.glsl'] // inline shader files
                 }),
 
+                babel({
+                    exclude: ['node_modules/**', '*.json']
+                }),
+
                 // These are needed for jszip node-environment compatibility,
                 // previously provided by browserify
                 globals(),
-                builtins(),
-
-                babel({
-                  exclude: ['node_modules/**', '*.json']
-                })
+                builtins()
             ]
         },
 

--- a/src/scene/globals.js
+++ b/src/scene/globals.js
@@ -1,0 +1,89 @@
+import log from '../utils/log';
+
+// Property name references a global property?
+export function isGlobalReference (val) {
+    if (val && val.slice(0, 7) === 'global.') {
+        return true;
+    }
+    return false;
+}
+
+// Flatten nested global properties for simpler string look-ups
+export function flattenGlobalProperties (obj, prefix = null, globals = {}) {
+    prefix = prefix ? (prefix + '.') : 'global.';
+
+    for (const p in obj) {
+        const key = prefix + p;
+        const val = obj[p];
+        globals[key] = val;
+
+        if (typeof val === 'object' && !Array.isArray(val)) {
+            flattenGlobalProperties(val, key, globals);
+        }
+    }
+    return globals;
+}
+
+// Find and apply new global properties (and re-apply old ones)
+export function applyGlobalProperties (globals, obj, target, key) {
+    let prop;
+
+    // Check for previously applied global substitution
+    if (target != null && typeof target === 'object' && target._global_prop && target._global_prop[key]) {
+        prop = target._global_prop[key];
+    }
+    // Check string for new global substitution
+    else if (typeof obj === 'string' && obj.slice(0, 7) === 'global.') {
+        prop = obj;
+    }
+
+    // Found global property to substitute
+    if (prop) {
+        // Mark property as global substitution
+        if (target._global_prop == null) {
+            Object.defineProperty(target, '_global_prop', { value: {} });
+        }
+        target._global_prop[key] = prop;
+
+        // Get current global value
+        let val = globals[prop];
+        let stack;
+        while (typeof val === 'string' && val.slice(0, 7) === 'global.') {
+            // handle globals that refer to other globals, detecting any cyclical references
+            stack = stack || [prop];
+            if (stack.indexOf(val) > -1) {
+                log({ level: 'warn', once: true }, 'Global properties: cyclical reference detected', stack);
+                val = null;
+                break;
+            }
+            stack.push(val);
+            val = globals[val];
+        }
+
+        // Create getter/setter
+        Object.defineProperty(target, key, {
+            enumerable: true,
+            get: function () {
+                return val; // return substituted value
+            },
+            set: function (v) {
+                // clear the global substitution and remove the getter/setter
+                delete target._global_prop[key];
+                delete target[key];
+                target[key] = v; // save the new value
+            }
+        });
+    }
+    // Loop through object keys or array indices
+    else if (Array.isArray(obj)) {
+        for (let p = 0; p < obj.length; p++) {
+            applyGlobalProperties(globals, obj[p], obj, p);
+        }
+    }
+    else if (typeof obj === 'object') {
+        for (const p in obj) {
+            applyGlobalProperties(globals, obj[p], obj, p);
+        }
+    }
+    return obj;
+}

--- a/src/scene/globals.js
+++ b/src/scene/globals.js
@@ -10,10 +10,7 @@ const GLOBAL_REGISTRY = '__global_prop';
 
 // Property name references a global property?
 export function isGlobalReference (val) {
-    if (val && val.slice(0, GLOBAL_PREFIX_LENGTH) === GLOBAL_PREFIX) {
-        return true;
-    }
-    return false;
+    return val?.slice(0, GLOBAL_PREFIX_LENGTH) === GLOBAL_PREFIX;
 }
 
 // Has object property been substitued with a value from a global reference?

--- a/src/scene/globals.js
+++ b/src/scene/globals.js
@@ -1,16 +1,33 @@
 import log from '../utils/log';
+import { getPropertyPathTarget } from '../utils/props';
+
+// prefix used to identify global property references
+const GLOBAL_PREFIX = 'global.';
+const GLOBAL_PREFIX_LENGTH = GLOBAL_PREFIX.length;
+
+// name of 'hidden' (non-enumerable) property used to track global property references on an object
+const GLOBAL_REGISTRY = '__global_prop';
 
 // Property name references a global property?
 export function isGlobalReference (val) {
-    if (val && val.slice(0, 7) === 'global.') {
+    if (val && val.slice(0, GLOBAL_PREFIX_LENGTH) === GLOBAL_PREFIX) {
         return true;
     }
     return false;
 }
 
+// Has object property been substitued with a value from a global reference?
+// Property provided as a single-depth string name, or nested path array (`a.b.c` => ['a', 'b', 'c'])
+export function isGlobalSubstitution (object, prop_or_path) {
+    const path = Array.isArray(prop_or_path) ? prop_or_path : [prop_or_path];
+    const target = getPropertyPathTarget(object, path);
+    const prop = path[path.length - 1];
+    return target?.[GLOBAL_REGISTRY]?.[prop] !== undefined;
+}
+
 // Flatten nested global properties for simpler string look-ups
 export function flattenGlobalProperties (obj, prefix = null, globals = {}) {
-    prefix = prefix ? (prefix + '.') : 'global.';
+    prefix = prefix ? (prefix + '.') : GLOBAL_PREFIX;
 
     for (const p in obj) {
         const key = prefix + p;
@@ -29,26 +46,26 @@ export function applyGlobalProperties (globals, obj, target, key) {
     let prop;
 
     // Check for previously applied global substitution
-    if (target != null && typeof target === 'object' && target._global_prop && target._global_prop[key]) {
-        prop = target._global_prop[key];
+    if (target?.[GLOBAL_REGISTRY]?.[key]) {
+        prop = target[GLOBAL_REGISTRY][key];
     }
     // Check string for new global substitution
-    else if (typeof obj === 'string' && obj.slice(0, 7) === 'global.') {
+    else if (typeof obj === 'string' && obj.slice(0, GLOBAL_PREFIX_LENGTH) === GLOBAL_PREFIX) {
         prop = obj;
     }
 
     // Found global property to substitute
     if (prop) {
         // Mark property as global substitution
-        if (target._global_prop == null) {
-            Object.defineProperty(target, '_global_prop', { value: {} });
+        if (target[GLOBAL_REGISTRY] == null) {
+            Object.defineProperty(target, GLOBAL_REGISTRY, { value: {} });
         }
-        target._global_prop[key] = prop;
+        target[GLOBAL_REGISTRY][key] = prop;
 
         // Get current global value
         let val = globals[prop];
         let stack;
-        while (typeof val === 'string' && val.slice(0, 7) === 'global.') {
+        while (typeof val === 'string' && val.slice(0, GLOBAL_PREFIX_LENGTH) === GLOBAL_PREFIX) {
             // handle globals that refer to other globals, detecting any cyclical references
             stack = stack || [prop];
             if (stack.indexOf(val) > -1) {
@@ -68,7 +85,7 @@ export function applyGlobalProperties (globals, obj, target, key) {
             },
             set: function (v) {
                 // clear the global substitution and remove the getter/setter
-                delete target._global_prop[key];
+                delete target[GLOBAL_REGISTRY][key];
                 delete target[key];
                 target[key] = v; // save the new value
             }

--- a/src/scene/scene_bundle.js
+++ b/src/scene/scene_bundle.js
@@ -1,5 +1,6 @@
 import Utils from '../utils/utils';
 import * as URLs from '../utils/urls';
+import { isGlobalReference } from './globals';
 
 import JSZip from 'jszip';
 import yaml from 'js-yaml';
@@ -52,7 +53,7 @@ export class SceneBundle {
     }
 
     urlFor(url) {
-        if (isGlobal(url)) {
+        if (isGlobalReference(url)) {
             return url;
         }
 
@@ -104,7 +105,7 @@ export class ZipSceneBundle extends SceneBundle {
     }
 
     urlFor(url) {
-        if (isGlobal(url)) {
+        if (isGlobalReference(url)) {
             return url;
         }
 
@@ -194,14 +195,6 @@ export function createSceneBundle(url, path, parent, type = null) {
         return new ZipSceneBundle(url, path, parent);
     }
     return new SceneBundle(url, path, parent);
-}
-
-// References a global property?
-export function isGlobal (val) {
-    if (val && val.slice(0, 7) === 'global.') {
-        return true;
-    }
-    return false;
 }
 
 function parseResource (body) {

--- a/src/scene/scene_loader.js
+++ b/src/scene/scene_loader.js
@@ -281,7 +281,6 @@ const SceneLoader = {
             if (typeof curValue === 'string' && config.textures[curValue] == null) {
                 if (isGlobalSubstitution(config, path)) {
                     // global substituions are resolved against the base scene path, not the import they came from
-                    // const url = curValue;
                     const url = base_bundle.urlFor(curValue);
                     config.textures[curValue] = { url };
                 }

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -1,0 +1,32 @@
+// Get a value for a nested property with path provided as an array (`a.b.c` => ['a', 'b', 'c'])
+export function getPropertyPath (object, path) {
+    const prop = path[path.length - 1];
+    return getPropertyPathTarget(object, path)?.[prop];
+}
+
+// Set a value for a nested property with path provided as an array (`a.b.c` => ['a', 'b', 'c'])
+export function setPropertyPath (object, path, value) {
+    const prop = path[path.length - 1];
+    const target = getPropertyPathTarget(object, path);
+    if (target) {
+        target[prop] = value;
+    }
+}
+
+// Get the immediate parent object for a property path name provided as an array
+// e.g. for a single-depth path, this is just `object`, for path ['a', 'b'], this is `object[a]`
+export function getPropertyPathTarget (object, path) {
+    if (path.length === 0) {
+        return;
+    }
+
+    let target = object;
+    for (let i = 0; i < path.length - 1; i++) {
+        const prop = path[i];
+        target = target[prop];
+        if (target == null) {
+            return;
+        }
+    }
+    return target;
+}


### PR DESCRIPTION
Resolve named textures using final merged scene. This fixes cases where named textures defined via global properties in imported scenes would be interpreted as URLs, if the texture name was not yet defined in the imported scene, but which will be defined in the final merged scene (e.g. the texture name is defined by an ancestor/importing scene, but not the descendant/imported scene where it is used).

See https://github.com/tangrams/tangram/issues/748 for issue, and https://github.com/tangrams/tangram-es/pull/2201 for Tangram ES fix.
